### PR TITLE
mcp: support '/' and '___' prefixes; add streamable affinity; tests

### DIFF
--- a/plugins/wasm-go/mcp-filters/mcp-router/main_test.go
+++ b/plugins/wasm-go/mcp-filters/mcp-router/main_test.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+    "testing"
+)
+
+func TestParsePrefixedToolName(t *testing.T) {
+    cases := []struct{
+        in string
+        wantServer string
+        wantTool string
+        ok bool
+    }{
+        {"server___tool", "server", "tool", true},
+        {"server/tool", "server", "tool", true},
+        {"not-prefixed", "", "", false},
+        {"server___", "", "", false},
+        {"/tool", "", "", false},
+    }
+    for _, c := range cases {
+        s, tname, ok := parsePrefixedToolName(c.in)
+        if ok != c.ok {
+            t.Fatalf("%s: ok=%v, want %v", c.in, ok, c.ok)
+        }
+        if !ok {
+            continue
+        }
+        if s != c.wantServer || tname != c.wantTool {
+            t.Fatalf("%s: got (%s,%s), want (%s,%s)", c.in, s, tname, c.wantServer, c.wantTool)
+        }
+    }
+}
+
+

--- a/registry/nacos/mcpserver/watcher.go
+++ b/registry/nacos/mcpserver/watcher.go
@@ -655,6 +655,23 @@ func generateDrForMcpServer(host, protocol string) *v1alpha3.DestinationRule {
 				},
 			},
 		}
+    case provider.McpStreamableProtocol:
+        // Streamable HTTP transport also maintains long-lived/stateful interactions.
+        // Apply the same consistent hash policy to enhance backend affinity.
+        return &v1alpha3.DestinationRule{
+            Host: host,
+            TrafficPolicy: &v1alpha3.TrafficPolicy{
+                LoadBalancer: &v1alpha3.LoadBalancerSettings{
+                    LbPolicy: &v1alpha3.LoadBalancerSettings_ConsistentHash{
+                        ConsistentHash: &v1alpha3.LoadBalancerSettings_ConsistentHashLB{
+                            HashKey: &v1alpha3.LoadBalancerSettings_ConsistentHashLB_UseSourceIp{
+                                UseSourceIp: true,
+                            },
+                        },
+                    },
+                },
+            },
+        }
 	case provider.HttpsProtocol:
 		return &v1alpha3.DestinationRule{
 			Host: host,

--- a/registry/nacos/mcpserver/watcher_test.go
+++ b/registry/nacos/mcpserver/watcher_test.go
@@ -1,3 +1,37 @@
+package mcpserver
+
+import (
+    "testing"
+    v1alpha3 "istio.io/api/networking/v1alpha3"
+    provider "github.com/alibaba/higress/v2/registry"
+)
+
+func TestGenerateDrForMcpServer_Affinities(t *testing.T) {
+    // SSE protocol should have consistent-hash by source IP
+    dr := generateDrForMcpServer("host.example", provider.McpSSEProtocol)
+    if dr == nil {
+        t.Fatal("expected DR for sse")
+    }
+    if dr.TrafficPolicy == nil || dr.TrafficPolicy.LoadBalancer == nil {
+        t.Fatal("expected load balancer policy for sse")
+    }
+    if _, ok := dr.TrafficPolicy.LoadBalancer.LbPolicy.(*v1alpha3.LoadBalancerSettings_ConsistentHash); !ok {
+        t.Fatal("expected consistent hash policy for sse")
+    }
+
+    // Streamable protocol should also have consistent-hash
+    dr2 := generateDrForMcpServer("host.example", provider.McpStreamableProtocol)
+    if dr2 == nil {
+        t.Fatal("expected DR for streamable")
+    }
+    if dr2.TrafficPolicy == nil || dr2.TrafficPolicy.LoadBalancer == nil {
+        t.Fatal("expected load balancer policy for streamable")
+    }
+    if _, ok := dr2.TrafficPolicy.LoadBalancer.LbPolicy.(*v1alpha3.LoadBalancerSettings_ConsistentHash); !ok {
+        t.Fatal("expected consistent hash policy for streamable")
+    }
+}
+
 // Copyright (c) 2022 Alibaba Group Holding Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
### Ⅰ. Describe what this PR did
- mcp-router: Support both “server___tool” and “server/tool” prefixes when routing `tools/call`, ensuring correct backend selection regardless of client/tooling prefix style.
- Nacos MCP watcher: Add consistent-hash (source IP) load balancing for Streamable HTTP transport (in addition to SSE) to improve backend affinity and prevent intermittent tool denial.
- Add unit tests:
  - `mcp-router`: prefix parsing for both separators.
  - `nacos watcher`: DestinationRule affinity for SSE and Streamable.

### Ⅱ. Does this pull request fix one issue?
- fixes #2856

### Ⅲ. Why don't you add test cases (unit test/integration test)?
- Added unit tests:
  - `plugins/wasm-go/mcp-filters/mcp-router/main_test.go`: validates parsing for “server___tool” and “server/tool”.
  - `registry/nacos/mcpserver/watcher_test.go`: asserts consistent-hash policy for SSE and Streamable protocols.

### Ⅳ. Describe how to verify it
- Functional:
  - Register an MCP server via Nacos with SSE or Streamable HTTP transport.
  - Connect SSE at `/mcp/{mcp-server-name}/sse` (or streamable endpoint).
  - Invoke tools using both name styles:
    - `params.name: "{server}___{tool}"`
    - `params.name: "{server}/{tool}"`
  - Expect no `-32602 Tool not allowed`; tool should be accepted consistently.
- Observability:
  - Confirm `DestinationRule` for the generated service uses ConsistentHash for SSE and Streamable.
  - With `jsonrpc-converter` enabled, verify headers `x-envoy-mcp-tool-name` and `x-envoy-jsonrpc-method` reflect the tool routed without the server prefix.
- Regression:
  - Requests without a prefix remain untouched and route as before.

### Ⅴ. Special notes for reviews
- Backward compatible: legacy “server___tool” continues to work; “server/tool” newly supported.
- Affinity note: Source-IP hashing is best-effort behind shared NAT; if stronger stickiness is needed, consider header-based consistent hash (e.g., `x-mcp-session-id`) in a follow-up change.
- Scope-limited to MCP filters and Nacos MCP watcher; no changes to unrelated paths.