### PR TITLE
feat: Enhance SSL passthrough support

### DIFF
--- a/pkg/ingress/config/ingress_config.go
+++ b/pkg/ingress/config/ingress_config.go
@@ -440,6 +440,7 @@ func (m *IngressConfig) convertGateways(configs []common.WrapperConfig) []config
 	if err != nil {
 		IngressLog.Errorf("Get higress https configmap err %v", err)
 	}
+	m.prepareDuplicateTLSHosts(&convertOptions, configs, httpsCredentialConfig)
 	for idx := range configs {
 		cfg := configs[idx]
 		clusterId := common.GetClusterId(cfg.Config.Annotations)
@@ -506,7 +507,11 @@ func (m *IngressConfig) convertVirtualService(configs []common.WrapperConfig) []
 		}
 	}
 
-	m.prepareDuplicateTLSHosts(&convertOptions, configs)
+	httpsCredentialConfig, err := m.httpsConfigMgr.GetConfigFromConfigmap()
+	if err != nil {
+		IngressLog.Errorf("Get higress https configmap err %v", err)
+	}
+	m.prepareDuplicateTLSHosts(&convertOptions, configs, httpsCredentialConfig)
 
 	// convert http route
 	for idx := range configs {
@@ -635,19 +640,62 @@ func virtualServiceNameAndClusterID(cleanHost string, wrapperVS *common.WrapperV
 	return common.CreateConvertedName(constants.IstioIngressGatewayName, cfg.Namespace, cfg.Name, cleanHost), common.GetClusterId(cfg.Annotations)
 }
 
-func (m *IngressConfig) prepareDuplicateTLSHosts(convertOptions *common.ConvertOptions, configs []common.WrapperConfig) {
-	httpsCredentialConfig, err := m.httpsConfigMgr.GetConfigFromConfigmap()
-	if err != nil {
-		IngressLog.Errorf("Get higress https configmap err %v", err)
+func (m *IngressConfig) prepareDuplicateTLSHosts(convertOptions *common.ConvertOptions, configs []common.WrapperConfig, httpsCredentialConfig *cert.Config) {
+	if convertOptions.SSLPassthroughTLSHosts == nil {
+		convertOptions.SSLPassthroughTLSHosts = map[string]*config.Config{}
 	}
+
+	rootPathOwners := map[string]*config.Config{}
+	for idx := range configs {
+		cfg := configs[idx]
+		if cfg.AnnotationsConfig.IsCanary() {
+			continue
+		}
+
+		for _, host := range ingressRootPathHosts(cfg.Config.Spec) {
+			_, exist := rootPathOwners[host]
+			if !exist {
+				rootPathOwners[host] = cfg.Config
+				if cfg.AnnotationsConfig.IsSSLPassthrough() {
+					convertOptions.SSLPassthroughTLSHosts[host] = cfg.Config
+				}
+			}
+		}
+	}
+
 	tlsHostOwners := map[string]*config.Config{}
 	for idx := range configs {
 		cfg := configs[idx]
 		if cfg.AnnotationsConfig.IsCanary() {
 			continue
 		}
+
+		if cfg.AnnotationsConfig.IsSSLPassthrough() {
+			hosts := ingressRuleHosts(cfg.Config.Spec)
+			for _, host := range hosts {
+				if !common.IsSSLPassthroughTLSHostOwner(convertOptions, cfg.Config, host) {
+					common.AddDuplicateTLSHost(convertOptions, cfg.Config, host)
+					continue
+				}
+				owner, exist := tlsHostOwners[host]
+				if exist && !common.SameConfig(owner, cfg.Config) {
+					common.AddDuplicateTLSHost(convertOptions, cfg.Config, host)
+					continue
+				}
+				if !exist {
+					tlsHostOwners[host] = cfg.Config
+				}
+			}
+			continue
+		}
+
 		hosts := ingressTLSHosts(cfg, httpsCredentialConfig)
 		for _, host := range hosts {
+			if _, exist := convertOptions.SSLPassthroughTLSHosts[host]; exist {
+				common.AddDuplicateTLSHost(convertOptions, cfg.Config, host)
+				continue
+			}
+
 			owner, exist := tlsHostOwners[host]
 			if exist && !common.SameConfig(owner, cfg.Config) {
 				common.AddDuplicateTLSHost(convertOptions, cfg.Config, host)
@@ -660,6 +708,17 @@ func (m *IngressConfig) prepareDuplicateTLSHosts(convertOptions *common.ConvertO
 	}
 }
 
+func ingressRootPathHosts(spec config.Spec) []string {
+	switch ingressSpec := spec.(type) {
+	case networkingv1.IngressSpec:
+		return ingressV1RootPathHosts(ingressSpec.Rules)
+	case networkingv1beta1.IngressSpec:
+		return ingressV1Beta1RootPathHosts(ingressSpec.Rules)
+	default:
+		return nil
+	}
+}
+
 func ingressTLSHosts(wrapper common.WrapperConfig, httpsCredentialConfig *cert.Config) []string {
 	if wrapper.AnnotationsConfig.IsSSLPassthrough() {
 		return ingressRuleHosts(wrapper.Config.Spec)
@@ -667,8 +726,14 @@ func ingressTLSHosts(wrapper common.WrapperConfig, httpsCredentialConfig *cert.C
 
 	switch spec := wrapper.Config.Spec.(type) {
 	case networkingv1.IngressSpec:
+		if len(spec.TLS) == 0 {
+			return nil
+		}
 		return ingressV1HTTPSHosts(spec, httpsCredentialConfig)
 	case networkingv1beta1.IngressSpec:
+		if len(spec.TLS) == 0 {
+			return nil
+		}
 		return ingressV1Beta1HTTPSHosts(spec, httpsCredentialConfig)
 	default:
 		return nil
@@ -707,6 +772,10 @@ func ingressV1Beta1HTTPSHosts(spec networkingv1beta1.IngressSpec, httpsCredentia
 }
 
 func ingressV1SSLPassthroughHosts(rules []networkingv1.IngressRule) []string {
+	return ingressV1RootPathHosts(rules)
+}
+
+func ingressV1RootPathHosts(rules []networkingv1.IngressRule) []string {
 	out := make([]string, 0, len(rules))
 	for _, rule := range rules {
 		if rule.HTTP == nil || !hasV1RootHTTPIngressPath(rule.HTTP.Paths) {
@@ -718,6 +787,10 @@ func ingressV1SSLPassthroughHosts(rules []networkingv1.IngressRule) []string {
 }
 
 func ingressV1Beta1SSLPassthroughHosts(rules []networkingv1beta1.IngressRule) []string {
+	return ingressV1Beta1RootPathHosts(rules)
+}
+
+func ingressV1Beta1RootPathHosts(rules []networkingv1beta1.IngressRule) []string {
 	out := make([]string, 0, len(rules))
 	for _, rule := range rules {
 		if rule.HTTP == nil || !hasV1Beta1RootHTTPIngressPath(rule.HTTP.Paths) {

--- a/pkg/ingress/config/ingress_config.go
+++ b/pkg/ingress/config/ingress_config.go
@@ -674,62 +674,6 @@ func ingressRootPathHosts(spec config.Spec) []string {
 	}
 }
 
-func ingressTLSHosts(wrapper common.WrapperConfig, httpsCredentialConfig *cert.Config) []string {
-	if wrapper.AnnotationsConfig.IsSSLPassthrough() {
-		return ingressRuleHosts(wrapper.Config.Spec)
-	}
-
-	switch spec := wrapper.Config.Spec.(type) {
-	case networkingv1.IngressSpec:
-		if len(spec.TLS) == 0 {
-			return nil
-		}
-		return ingressV1HTTPSHosts(spec, httpsCredentialConfig)
-	case networkingv1beta1.IngressSpec:
-		if len(spec.TLS) == 0 {
-			return nil
-		}
-		return ingressV1Beta1HTTPSHosts(spec, httpsCredentialConfig)
-	default:
-		return nil
-	}
-}
-
-func ingressRuleHosts(spec config.Spec) []string {
-	switch ingressSpec := spec.(type) {
-	case networkingv1.IngressSpec:
-		return ingressV1SSLPassthroughHosts(ingressSpec.Rules)
-	case networkingv1beta1.IngressSpec:
-		return ingressV1Beta1SSLPassthroughHosts(ingressSpec.Rules)
-	default:
-		return nil
-	}
-}
-
-func ingressV1HTTPSHosts(spec networkingv1.IngressSpec, httpsCredentialConfig *cert.Config) []string {
-	var out []string
-	for _, rule := range spec.Rules {
-		if ingressV1TLSSecretName(rule.Host, spec.TLS) != "" || matchHTTPSConfigHost(rule.Host, httpsCredentialConfig) {
-			out = append(out, rule.Host)
-		}
-	}
-	return out
-}
-
-func ingressV1Beta1HTTPSHosts(spec networkingv1beta1.IngressSpec, httpsCredentialConfig *cert.Config) []string {
-	var out []string
-	for _, rule := range spec.Rules {
-		if ingressV1Beta1TLSSecretName(rule.Host, spec.TLS) != "" || matchHTTPSConfigHost(rule.Host, httpsCredentialConfig) {
-			out = append(out, rule.Host)
-		}
-	}
-	return out
-}
-
-func ingressV1SSLPassthroughHosts(rules []networkingv1.IngressRule) []string {
-	return ingressV1RootPathHosts(rules)
-}
-
 func ingressV1RootPathHosts(rules []networkingv1.IngressRule) []string {
 	out := make([]string, 0, len(rules))
 	for _, rule := range rules {
@@ -739,10 +683,6 @@ func ingressV1RootPathHosts(rules []networkingv1.IngressRule) []string {
 		out = append(out, rule.Host)
 	}
 	return out
-}
-
-func ingressV1Beta1SSLPassthroughHosts(rules []networkingv1beta1.IngressRule) []string {
-	return ingressV1Beta1RootPathHosts(rules)
 }
 
 func ingressV1Beta1RootPathHosts(rules []networkingv1beta1.IngressRule) []string {
@@ -772,32 +712,6 @@ func hasV1Beta1RootHTTPIngressPath(paths []networkingv1beta1.HTTPIngressPath) bo
 		}
 	}
 	return false
-}
-
-func ingressV1TLSSecretName(host string, tls []networkingv1.IngressTLS) string {
-	for _, item := range tls {
-		for _, tlsHost := range item.Hosts {
-			if tlsHost == host {
-				return item.SecretName
-			}
-		}
-	}
-	return ""
-}
-
-func ingressV1Beta1TLSSecretName(host string, tls []networkingv1beta1.IngressTLS) string {
-	for _, item := range tls {
-		for _, tlsHost := range item.Hosts {
-			if tlsHost == host {
-				return item.SecretName
-			}
-		}
-	}
-	return ""
-}
-
-func matchHTTPSConfigHost(host string, httpsCredentialConfig *cert.Config) bool {
-	return httpsCredentialConfig != nil && httpsCredentialConfig.MatchSecretNameByDomain(host) != ""
 }
 
 func (m *IngressConfig) convertEnvoyFilter(convertOptions *common.ConvertOptions) {

--- a/pkg/ingress/config/ingress_config.go
+++ b/pkg/ingress/config/ingress_config.go
@@ -46,6 +46,8 @@ import (
 	"istio.io/istio/pkg/log"
 	"istio.io/istio/pkg/util/sets"
 	v1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	networkingv1beta1 "k8s.io/api/networking/v1beta1"
 	listersv1 "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
 
@@ -504,6 +506,8 @@ func (m *IngressConfig) convertVirtualService(configs []common.WrapperConfig) []
 		}
 	}
 
+	m.prepareDuplicateTLSHosts(&convertOptions, configs)
+
 	// convert http route
 	for idx := range configs {
 		cfg := configs[idx]
@@ -570,13 +574,8 @@ func (m *IngressConfig) convertVirtualService(configs []common.WrapperConfig) []
 	m.ingressRouteCache = convertOptions.IngressRouteCache.Extract()
 	m.mutex.Unlock()
 
-	// Convert http route to virtual service
-	out := make([]config.Config, 0, len(convertOptions.HTTPRoutes))
-	for host, routes := range convertOptions.HTTPRoutes {
-		if len(routes) == 0 {
-			continue
-		}
-
+	out := make([]config.Config, 0, len(convertOptions.VirtualServices))
+	for host, wrapperVS := range convertOptions.VirtualServices {
 		cleanHost := common.CleanHost(host)
 		// namespace/name, name format: (istio cluster id)-host
 		gateways := []string{
@@ -585,13 +584,10 @@ func (m *IngressConfig) convertVirtualService(configs []common.WrapperConfig) []
 			common.CreateConvertedName(constants.IstioIngressGatewayName, cleanHost),
 		}
 
-		wrapperVS, exist := convertOptions.VirtualServices[host]
-		if !exist {
-			IngressLog.Warnf("virtual service for host %s does not exist.", host)
-		}
 		vs := wrapperVS.VirtualService
 		vs.Gateways = gateways
 
+		routes := convertOptions.HTTPRoutes[host]
 		// Sort, exact -> prefix -> regex
 		common.SortHTTPRoutes(routes)
 
@@ -599,14 +595,18 @@ func (m *IngressConfig) convertVirtualService(configs []common.WrapperConfig) []
 			vs.Http = append(vs.Http, route.HTTPRoute)
 		}
 
-		firstRoute := routes[0]
+		if len(vs.Http) == 0 && len(vs.Tls) == 0 {
+			continue
+		}
+
+		vsName, clusterId := virtualServiceNameAndClusterID(cleanHost, wrapperVS, routes)
 		out = append(out, config.Config{
 			Meta: config.Meta{
 				GroupVersionKind: gvk.VirtualService,
-				Name:             common.CreateConvertedName(constants.IstioIngressGatewayName, firstRoute.WrapperConfig.Config.Namespace, firstRoute.WrapperConfig.Config.Name, cleanHost),
+				Name:             vsName,
 				Namespace:        m.namespace,
 				Annotations: map[string]string{
-					common.ClusterIdAnnotation: firstRoute.ClusterId.String(),
+					common.ClusterIdAnnotation: clusterId.String(),
 				},
 			},
 			Spec: vs,
@@ -623,6 +623,153 @@ func (m *IngressConfig) convertVirtualService(configs []common.WrapperConfig) []
 	// We generate some specific envoy filter here to avoid duplicated computation.
 	m.convertEnvoyFilter(&convertOptions)
 	return out
+}
+
+func virtualServiceNameAndClusterID(cleanHost string, wrapperVS *common.WrapperVirtualService, routes []*common.WrapperHTTPRoute) (string, cluster.ID) {
+	if len(routes) > 0 {
+		firstRoute := routes[0]
+		return common.CreateConvertedName(constants.IstioIngressGatewayName, firstRoute.WrapperConfig.Config.Namespace, firstRoute.WrapperConfig.Config.Name, cleanHost), firstRoute.ClusterId
+	}
+
+	cfg := wrapperVS.WrapperConfig.Config
+	return common.CreateConvertedName(constants.IstioIngressGatewayName, cfg.Namespace, cfg.Name, cleanHost), common.GetClusterId(cfg.Annotations)
+}
+
+func (m *IngressConfig) prepareDuplicateTLSHosts(convertOptions *common.ConvertOptions, configs []common.WrapperConfig) {
+	httpsCredentialConfig, err := m.httpsConfigMgr.GetConfigFromConfigmap()
+	if err != nil {
+		IngressLog.Errorf("Get higress https configmap err %v", err)
+	}
+	tlsHostOwners := map[string]*config.Config{}
+	for idx := range configs {
+		cfg := configs[idx]
+		if cfg.AnnotationsConfig.IsCanary() {
+			continue
+		}
+		hosts := ingressTLSHosts(cfg, httpsCredentialConfig)
+		for _, host := range hosts {
+			owner, exist := tlsHostOwners[host]
+			if exist && !common.SameConfig(owner, cfg.Config) {
+				common.AddDuplicateTLSHost(convertOptions, cfg.Config, host)
+				continue
+			}
+			if !exist {
+				tlsHostOwners[host] = cfg.Config
+			}
+		}
+	}
+}
+
+func ingressTLSHosts(wrapper common.WrapperConfig, httpsCredentialConfig *cert.Config) []string {
+	if wrapper.AnnotationsConfig.IsSSLPassthrough() {
+		return ingressRuleHosts(wrapper.Config.Spec)
+	}
+
+	switch spec := wrapper.Config.Spec.(type) {
+	case networkingv1.IngressSpec:
+		return ingressV1HTTPSHosts(spec, httpsCredentialConfig)
+	case networkingv1beta1.IngressSpec:
+		return ingressV1Beta1HTTPSHosts(spec, httpsCredentialConfig)
+	default:
+		return nil
+	}
+}
+
+func ingressRuleHosts(spec config.Spec) []string {
+	switch ingressSpec := spec.(type) {
+	case networkingv1.IngressSpec:
+		return ingressV1SSLPassthroughHosts(ingressSpec.Rules)
+	case networkingv1beta1.IngressSpec:
+		return ingressV1Beta1SSLPassthroughHosts(ingressSpec.Rules)
+	default:
+		return nil
+	}
+}
+
+func ingressV1HTTPSHosts(spec networkingv1.IngressSpec, httpsCredentialConfig *cert.Config) []string {
+	var out []string
+	for _, rule := range spec.Rules {
+		if ingressV1TLSSecretName(rule.Host, spec.TLS) != "" || matchHTTPSConfigHost(rule.Host, httpsCredentialConfig) {
+			out = append(out, rule.Host)
+		}
+	}
+	return out
+}
+
+func ingressV1Beta1HTTPSHosts(spec networkingv1beta1.IngressSpec, httpsCredentialConfig *cert.Config) []string {
+	var out []string
+	for _, rule := range spec.Rules {
+		if ingressV1Beta1TLSSecretName(rule.Host, spec.TLS) != "" || matchHTTPSConfigHost(rule.Host, httpsCredentialConfig) {
+			out = append(out, rule.Host)
+		}
+	}
+	return out
+}
+
+func ingressV1SSLPassthroughHosts(rules []networkingv1.IngressRule) []string {
+	out := make([]string, 0, len(rules))
+	for _, rule := range rules {
+		if rule.HTTP == nil || !hasV1RootHTTPIngressPath(rule.HTTP.Paths) {
+			continue
+		}
+		out = append(out, rule.Host)
+	}
+	return out
+}
+
+func ingressV1Beta1SSLPassthroughHosts(rules []networkingv1beta1.IngressRule) []string {
+	out := make([]string, 0, len(rules))
+	for _, rule := range rules {
+		if rule.HTTP == nil || !hasV1Beta1RootHTTPIngressPath(rule.HTTP.Paths) {
+			continue
+		}
+		out = append(out, rule.Host)
+	}
+	return out
+}
+
+func hasV1RootHTTPIngressPath(paths []networkingv1.HTTPIngressPath) bool {
+	for _, path := range paths {
+		if path.Path == "" || path.Path == "/" {
+			return true
+		}
+	}
+	return false
+}
+
+func hasV1Beta1RootHTTPIngressPath(paths []networkingv1beta1.HTTPIngressPath) bool {
+	for _, path := range paths {
+		if path.Path == "" || path.Path == "/" {
+			return true
+		}
+	}
+	return false
+}
+
+func ingressV1TLSSecretName(host string, tls []networkingv1.IngressTLS) string {
+	for _, item := range tls {
+		for _, tlsHost := range item.Hosts {
+			if tlsHost == host {
+				return item.SecretName
+			}
+		}
+	}
+	return ""
+}
+
+func ingressV1Beta1TLSSecretName(host string, tls []networkingv1beta1.IngressTLS) string {
+	for _, item := range tls {
+		for _, tlsHost := range item.Hosts {
+			if tlsHost == host {
+				return item.SecretName
+			}
+		}
+	}
+	return ""
+}
+
+func matchHTTPSConfigHost(host string, httpsCredentialConfig *cert.Config) bool {
+	return httpsCredentialConfig != nil && httpsCredentialConfig.MatchSecretNameByDomain(host) != ""
 }
 
 func (m *IngressConfig) convertEnvoyFilter(convertOptions *common.ConvertOptions) {

--- a/pkg/ingress/config/ingress_config.go
+++ b/pkg/ingress/config/ingress_config.go
@@ -440,7 +440,7 @@ func (m *IngressConfig) convertGateways(configs []common.WrapperConfig) []config
 	if err != nil {
 		IngressLog.Errorf("Get higress https configmap err %v", err)
 	}
-	m.prepareDuplicateTLSHosts(&convertOptions, configs, httpsCredentialConfig)
+	m.prepareTLSHostOwnership(&convertOptions, configs, httpsCredentialConfig)
 	for idx := range configs {
 		cfg := configs[idx]
 		clusterId := common.GetClusterId(cfg.Config.Annotations)
@@ -511,7 +511,7 @@ func (m *IngressConfig) convertVirtualService(configs []common.WrapperConfig) []
 	if err != nil {
 		IngressLog.Errorf("Get higress https configmap err %v", err)
 	}
-	m.prepareDuplicateTLSHosts(&convertOptions, configs, httpsCredentialConfig)
+	m.prepareTLSHostOwnership(&convertOptions, configs, httpsCredentialConfig)
 
 	// convert http route
 	for idx := range configs {
@@ -640,12 +640,14 @@ func virtualServiceNameAndClusterID(cleanHost string, wrapperVS *common.WrapperV
 	return common.CreateConvertedName(constants.IstioIngressGatewayName, cfg.Namespace, cfg.Name, cleanHost), common.GetClusterId(cfg.Annotations)
 }
 
-func (m *IngressConfig) prepareDuplicateTLSHosts(convertOptions *common.ConvertOptions, configs []common.WrapperConfig, httpsCredentialConfig *cert.Config) {
-	if convertOptions.SSLPassthroughTLSHosts == nil {
-		convertOptions.SSLPassthroughTLSHosts = map[string]*config.Config{}
+func (m *IngressConfig) prepareTLSHostOwnership(convertOptions *common.ConvertOptions, configs []common.WrapperConfig, httpsCredentialConfig *cert.Config) {
+	if convertOptions.PassthroughTLSHostOwners == nil {
+		convertOptions.PassthroughTLSHostOwners = map[string]*config.Config{}
 	}
 
-	rootPathOwners := map[string]*config.Config{}
+	// A host can be taken over by SSL passthrough only when the first root path
+	// seen for that host belongs to an SSL passthrough ingress.
+	firstRootPathHosts := map[string]struct{}{}
 	for idx := range configs {
 		cfg := configs[idx]
 		if cfg.AnnotationsConfig.IsCanary() {
@@ -653,17 +655,19 @@ func (m *IngressConfig) prepareDuplicateTLSHosts(convertOptions *common.ConvertO
 		}
 
 		for _, host := range ingressRootPathHosts(cfg.Config.Spec) {
-			_, exist := rootPathOwners[host]
-			if !exist {
-				rootPathOwners[host] = cfg.Config
-				if cfg.AnnotationsConfig.IsSSLPassthrough() {
-					convertOptions.SSLPassthroughTLSHosts[host] = cfg.Config
-				}
+			if _, exist := firstRootPathHosts[host]; exist {
+				continue
+			}
+			firstRootPathHosts[host] = struct{}{}
+			if cfg.AnnotationsConfig.IsSSLPassthrough() {
+				convertOptions.PassthroughTLSHostOwners[host] = cfg.Config
 			}
 		}
 	}
 
-	tlsHostOwners := map[string]*config.Config{}
+	// Suppress only the TLS generation for conflicting ingresses. HTTP routes
+	// remain eligible for normal route merging.
+	tlsServerOwners := map[string]*config.Config{}
 	for idx := range configs {
 		cfg := configs[idx]
 		if cfg.AnnotationsConfig.IsCanary() {
@@ -673,17 +677,17 @@ func (m *IngressConfig) prepareDuplicateTLSHosts(convertOptions *common.ConvertO
 		if cfg.AnnotationsConfig.IsSSLPassthrough() {
 			hosts := ingressRuleHosts(cfg.Config.Spec)
 			for _, host := range hosts {
-				if !common.IsSSLPassthroughTLSHostOwner(convertOptions, cfg.Config, host) {
-					common.AddDuplicateTLSHost(convertOptions, cfg.Config, host)
+				if !common.IsPassthroughTLSHostOwner(convertOptions, cfg.Config, host) {
+					common.AddSuppressedTLSHost(convertOptions, cfg.Config, host)
 					continue
 				}
-				owner, exist := tlsHostOwners[host]
+				owner, exist := tlsServerOwners[host]
 				if exist && !common.SameConfig(owner, cfg.Config) {
-					common.AddDuplicateTLSHost(convertOptions, cfg.Config, host)
+					common.AddSuppressedTLSHost(convertOptions, cfg.Config, host)
 					continue
 				}
 				if !exist {
-					tlsHostOwners[host] = cfg.Config
+					tlsServerOwners[host] = cfg.Config
 				}
 			}
 			continue
@@ -691,18 +695,18 @@ func (m *IngressConfig) prepareDuplicateTLSHosts(convertOptions *common.ConvertO
 
 		hosts := ingressTLSHosts(cfg, httpsCredentialConfig)
 		for _, host := range hosts {
-			if _, exist := convertOptions.SSLPassthroughTLSHosts[host]; exist {
-				common.AddDuplicateTLSHost(convertOptions, cfg.Config, host)
+			if _, exist := convertOptions.PassthroughTLSHostOwners[host]; exist {
+				common.AddSuppressedTLSHost(convertOptions, cfg.Config, host)
 				continue
 			}
 
-			owner, exist := tlsHostOwners[host]
+			owner, exist := tlsServerOwners[host]
 			if exist && !common.SameConfig(owner, cfg.Config) {
-				common.AddDuplicateTLSHost(convertOptions, cfg.Config, host)
+				common.AddSuppressedTLSHost(convertOptions, cfg.Config, host)
 				continue
 			}
 			if !exist {
-				tlsHostOwners[host] = cfg.Config
+				tlsServerOwners[host] = cfg.Config
 			}
 		}
 	}

--- a/pkg/ingress/config/ingress_config.go
+++ b/pkg/ingress/config/ingress_config.go
@@ -440,7 +440,7 @@ func (m *IngressConfig) convertGateways(configs []common.WrapperConfig) []config
 	if err != nil {
 		IngressLog.Errorf("Get higress https configmap err %v", err)
 	}
-	m.prepareTLSHostOwnership(&convertOptions, configs, httpsCredentialConfig)
+	m.preparePassthroughTLSHostOwners(&convertOptions, configs)
 	for idx := range configs {
 		cfg := configs[idx]
 		clusterId := common.GetClusterId(cfg.Config.Annotations)
@@ -507,11 +507,7 @@ func (m *IngressConfig) convertVirtualService(configs []common.WrapperConfig) []
 		}
 	}
 
-	httpsCredentialConfig, err := m.httpsConfigMgr.GetConfigFromConfigmap()
-	if err != nil {
-		IngressLog.Errorf("Get higress https configmap err %v", err)
-	}
-	m.prepareTLSHostOwnership(&convertOptions, configs, httpsCredentialConfig)
+	m.preparePassthroughTLSHostOwners(&convertOptions, configs)
 
 	// convert http route
 	for idx := range configs {
@@ -640,13 +636,14 @@ func virtualServiceNameAndClusterID(cleanHost string, wrapperVS *common.WrapperV
 	return common.CreateConvertedName(constants.IstioIngressGatewayName, cfg.Namespace, cfg.Name, cleanHost), common.GetClusterId(cfg.Annotations)
 }
 
-func (m *IngressConfig) prepareTLSHostOwnership(convertOptions *common.ConvertOptions, configs []common.WrapperConfig, httpsCredentialConfig *cert.Config) {
+func (m *IngressConfig) preparePassthroughTLSHostOwners(convertOptions *common.ConvertOptions, configs []common.WrapperConfig) {
 	if convertOptions.PassthroughTLSHostOwners == nil {
 		convertOptions.PassthroughTLSHostOwners = map[string]*config.Config{}
 	}
 
-	// A host can be taken over by SSL passthrough only when the first root path
-	// seen for that host belongs to an SSL passthrough ingress.
+	// A host can be taken over by SSL passthrough only when the first root path seen for that host
+	// belongs to an SSL passthrough ingress. Later conversion stages derive all skip decisions from
+	// this single owner map.
 	firstRootPathHosts := map[string]struct{}{}
 	for idx := range configs {
 		cfg := configs[idx]
@@ -661,52 +658,6 @@ func (m *IngressConfig) prepareTLSHostOwnership(convertOptions *common.ConvertOp
 			firstRootPathHosts[host] = struct{}{}
 			if cfg.AnnotationsConfig.IsSSLPassthrough() {
 				convertOptions.PassthroughTLSHostOwners[host] = cfg.Config
-			}
-		}
-	}
-
-	// Suppress only the TLS generation for conflicting ingresses. HTTP routes
-	// remain eligible for normal route merging.
-	tlsServerOwners := map[string]*config.Config{}
-	for idx := range configs {
-		cfg := configs[idx]
-		if cfg.AnnotationsConfig.IsCanary() {
-			continue
-		}
-
-		if cfg.AnnotationsConfig.IsSSLPassthrough() {
-			hosts := ingressRuleHosts(cfg.Config.Spec)
-			for _, host := range hosts {
-				if !common.IsPassthroughTLSHostOwner(convertOptions, cfg.Config, host) {
-					common.AddSuppressedTLSHost(convertOptions, cfg.Config, host)
-					continue
-				}
-				owner, exist := tlsServerOwners[host]
-				if exist && !common.SameConfig(owner, cfg.Config) {
-					common.AddSuppressedTLSHost(convertOptions, cfg.Config, host)
-					continue
-				}
-				if !exist {
-					tlsServerOwners[host] = cfg.Config
-				}
-			}
-			continue
-		}
-
-		hosts := ingressTLSHosts(cfg, httpsCredentialConfig)
-		for _, host := range hosts {
-			if _, exist := convertOptions.PassthroughTLSHostOwners[host]; exist {
-				common.AddSuppressedTLSHost(convertOptions, cfg.Config, host)
-				continue
-			}
-
-			owner, exist := tlsServerOwners[host]
-			if exist && !common.SameConfig(owner, cfg.Config) {
-				common.AddSuppressedTLSHost(convertOptions, cfg.Config, host)
-				continue
-			}
-			if !exist {
-				tlsServerOwners[host] = cfg.Config
 			}
 		}
 	}

--- a/pkg/ingress/config/ingress_config.go
+++ b/pkg/ingress/config/ingress_config.go
@@ -641,25 +641,44 @@ func (m *IngressConfig) preparePassthroughTLSHostOwners(convertOptions *common.C
 		convertOptions.PassthroughTLSHostOwners = map[string]*config.Config{}
 	}
 
-	// A host can be taken over by SSL passthrough only when the first root path seen for that host
-	// belongs to an SSL passthrough ingress. Later conversion stages derive all skip decisions from
-	// this single owner map.
-	firstRootPathHosts := map[string]struct{}{}
+	// ingress-nginx enables SSL passthrough at host level when any ingress for the host has the
+	// annotation, then uses the first root path as the passthrough backend.
+	passthroughHosts := map[string]struct{}{}
+	firstRootPathHostOwners := map[string]*config.Config{}
 	for idx := range configs {
 		cfg := configs[idx]
 		if cfg.AnnotationsConfig.IsCanary() {
 			continue
 		}
 
-		for _, host := range ingressRootPathHosts(cfg.Config.Spec) {
-			if _, exist := firstRootPathHosts[host]; exist {
-				continue
-			}
-			firstRootPathHosts[host] = struct{}{}
-			if cfg.AnnotationsConfig.IsSSLPassthrough() {
-				convertOptions.PassthroughTLSHostOwners[host] = cfg.Config
+		if cfg.AnnotationsConfig.IsSSLPassthrough() {
+			for _, host := range ingressRuleHosts(cfg.Config.Spec) {
+				passthroughHosts[host] = struct{}{}
 			}
 		}
+		for _, host := range ingressRootPathHosts(cfg.Config.Spec) {
+			if _, exist := firstRootPathHostOwners[host]; exist {
+				continue
+			}
+			firstRootPathHostOwners[host] = cfg.Config
+		}
+	}
+
+	for host := range passthroughHosts {
+		if owner := firstRootPathHostOwners[host]; owner != nil {
+			convertOptions.PassthroughTLSHostOwners[host] = owner
+		}
+	}
+}
+
+func ingressRuleHosts(spec config.Spec) []string {
+	switch ingressSpec := spec.(type) {
+	case networkingv1.IngressSpec:
+		return ingressV1RuleHosts(ingressSpec.Rules)
+	case networkingv1beta1.IngressSpec:
+		return ingressV1Beta1RuleHosts(ingressSpec.Rules)
+	default:
+		return nil
 	}
 }
 
@@ -672,6 +691,22 @@ func ingressRootPathHosts(spec config.Spec) []string {
 	default:
 		return nil
 	}
+}
+
+func ingressV1RuleHosts(rules []networkingv1.IngressRule) []string {
+	out := make([]string, 0, len(rules))
+	for _, rule := range rules {
+		out = append(out, rule.Host)
+	}
+	return out
+}
+
+func ingressV1Beta1RuleHosts(rules []networkingv1beta1.IngressRule) []string {
+	out := make([]string, 0, len(rules))
+	for _, rule := range rules {
+		out = append(out, rule.Host)
+	}
+	return out
 }
 
 func ingressV1RootPathHosts(rules []networkingv1.IngressRule) []string {

--- a/pkg/ingress/config/ingress_config_test.go
+++ b/pkg/ingress/config/ingress_config_test.go
@@ -23,6 +23,7 @@ import (
 	networking "istio.io/api/networking/v1alpha3"
 	"istio.io/istio/pkg/cluster"
 	"istio.io/istio/pkg/config"
+	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/schema/gvk"
 	"istio.io/istio/pkg/config/xds"
 	ingress "k8s.io/api/networking/v1"
@@ -106,6 +107,94 @@ func TestNormalizeWeightedCluster(t *testing.T) {
 				t.Fatalf("Weight sum should be 100, but actual is %d", validate(route))
 			}
 		})
+	}
+}
+
+func TestVirtualServiceNameAndClusterID(t *testing.T) {
+	cleanHost := common.CleanHost("example.com")
+	wrapperVS := &common.WrapperVirtualService{
+		WrapperConfig: &common.WrapperConfig{
+			Config: &config.Config{
+				Meta: config.Meta{
+					Namespace: "tls-ns",
+					Name:      "tls-ingress",
+					Annotations: map[string]string{
+						common.ClusterIdAnnotation: "tls-cluster",
+					},
+				},
+			},
+		},
+	}
+	routes := []*common.WrapperHTTPRoute{
+		{
+			WrapperConfig: &common.WrapperConfig{
+				Config: &config.Config{
+					Meta: config.Meta{
+						Namespace: "http-ns",
+						Name:      "http-ingress",
+					},
+				},
+			},
+			ClusterId: "http-cluster",
+		},
+	}
+
+	name, clusterID := virtualServiceNameAndClusterID(cleanHost, wrapperVS, routes)
+	if name != common.CreateConvertedName(constants.IstioIngressGatewayName, "http-ns", "http-ingress", cleanHost) {
+		t.Fatalf("http-backed virtual service name mismatch: %s", name)
+	}
+	if clusterID != "http-cluster" {
+		t.Fatalf("http-backed cluster id mismatch: %s", clusterID)
+	}
+
+	name, clusterID = virtualServiceNameAndClusterID(cleanHost, wrapperVS, nil)
+	if name != common.CreateConvertedName(constants.IstioIngressGatewayName, "tls-ns", "tls-ingress", cleanHost) {
+		t.Fatalf("tls-only virtual service name mismatch: %s", name)
+	}
+	if clusterID != "tls-cluster" {
+		t.Fatalf("tls-only cluster id mismatch: %s", clusterID)
+	}
+}
+
+func TestIngressTLSHostsForSSLPassthroughRequiresRootBackend(t *testing.T) {
+	wrapper := common.WrapperConfig{
+		Config: &config.Config{
+			Spec: ingress.IngressSpec{
+				Rules: []ingress.IngressRule{
+					{
+						Host: "non-root.example.com",
+						IngressRuleValue: ingress.IngressRuleValue{
+							HTTP: &ingress.HTTPIngressRuleValue{
+								Paths: []ingress.HTTPIngressPath{
+									{Path: "/api"},
+								},
+							},
+						},
+					},
+					{
+						Host: "root.example.com",
+						IngressRuleValue: ingress.IngressRuleValue{
+							HTTP: &ingress.HTTPIngressRuleValue{
+								Paths: []ingress.HTTPIngressPath{
+									{Path: "/"},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		AnnotationsConfig: &annotations.Ingress{
+			SSLPassthrough: &annotations.SSLPassthroughConfig{Enabled: true},
+		},
+	}
+
+	hosts := ingressTLSHosts(wrapper, nil)
+	if len(hosts) != 1 {
+		t.Fatalf("ssl passthrough host count mismatch, want 1, got %d", len(hosts))
+	}
+	if hosts[0] != "root.example.com" {
+		t.Fatalf("ssl passthrough host mismatch, got %s", hosts[0])
 	}
 }
 

--- a/pkg/ingress/config/ingress_config_test.go
+++ b/pkg/ingress/config/ingress_config_test.go
@@ -156,6 +156,65 @@ func TestVirtualServiceNameAndClusterID(t *testing.T) {
 	}
 }
 
+func TestPreparePassthroughTLSHostOwnersRequiresPassthroughHost(t *testing.T) {
+	m := &IngressConfig{}
+	configs := []common.WrapperConfig{
+		{
+			Config: &config.Config{
+				Meta: config.Meta{
+					Namespace: "default",
+					Name:      "plain-root",
+				},
+				Spec: ingress.IngressSpec{
+					Rules: []ingress.IngressRule{
+						{
+							Host: "example.com",
+							IngressRuleValue: ingress.IngressRuleValue{
+								HTTP: &ingress.HTTPIngressRuleValue{
+									Paths: []ingress.HTTPIngressPath{
+										{Path: "/"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			AnnotationsConfig: &annotations.Ingress{},
+		},
+		{
+			Config: &config.Config{
+				Meta: config.Meta{
+					Namespace: "default",
+					Name:      "plain-root-duplicate",
+				},
+				Spec: ingress.IngressSpec{
+					Rules: []ingress.IngressRule{
+						{
+							Host: "example.com",
+							IngressRuleValue: ingress.IngressRuleValue{
+								HTTP: &ingress.HTTPIngressRuleValue{
+									Paths: []ingress.HTTPIngressPath{
+										{Path: "/"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			AnnotationsConfig: &annotations.Ingress{},
+		},
+	}
+
+	options := &common.ConvertOptions{}
+	m.preparePassthroughTLSHostOwners(options, configs)
+
+	if len(options.PassthroughTLSHostOwners) != 0 {
+		t.Fatalf("unexpected ssl passthrough owners: %+v", options.PassthroughTLSHostOwners)
+	}
+}
+
 func TestPreparePassthroughTLSHostOwnersUsesFirstRootPathOwner(t *testing.T) {
 	m := &IngressConfig{}
 	configs := []common.WrapperConfig{
@@ -186,45 +245,7 @@ func TestPreparePassthroughTLSHostOwnersUsesFirstRootPathOwner(t *testing.T) {
 			Config: &config.Config{
 				Meta: config.Meta{
 					Namespace: "default",
-					Name:      "passthrough-root",
-				},
-				Spec: ingress.IngressSpec{
-					Rules: []ingress.IngressRule{
-						{
-							Host: "example.com",
-							IngressRuleValue: ingress.IngressRuleValue{
-								HTTP: &ingress.HTTPIngressRuleValue{
-									Paths: []ingress.HTTPIngressPath{
-										{Path: "/"},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-			AnnotationsConfig: &annotations.Ingress{
-				SSLPassthrough: &annotations.SSLPassthroughConfig{Enabled: true},
-			},
-		},
-	}
-
-	options := &common.ConvertOptions{}
-	m.preparePassthroughTLSHostOwners(options, configs)
-
-	if len(options.PassthroughTLSHostOwners) != 0 {
-		t.Fatalf("unexpected ssl passthrough owners: %+v", options.PassthroughTLSHostOwners)
-	}
-}
-
-func TestPreparePassthroughTLSHostOwnersAllowsFirstRootPathSSLPassthroughOwner(t *testing.T) {
-	m := &IngressConfig{}
-	configs := []common.WrapperConfig{
-		{
-			Config: &config.Config{
-				Meta: config.Meta{
-					Namespace: "default",
-					Name:      "non-root",
+					Name:      "passthrough-non-root",
 				},
 				Spec: ingress.IngressSpec{
 					Rules: []ingress.IngressRule{
@@ -241,29 +262,6 @@ func TestPreparePassthroughTLSHostOwnersAllowsFirstRootPathSSLPassthroughOwner(t
 					},
 				},
 			},
-			AnnotationsConfig: &annotations.Ingress{},
-		},
-		{
-			Config: &config.Config{
-				Meta: config.Meta{
-					Namespace: "default",
-					Name:      "passthrough-root",
-				},
-				Spec: ingress.IngressSpec{
-					Rules: []ingress.IngressRule{
-						{
-							Host: "example.com",
-							IngressRuleValue: ingress.IngressRuleValue{
-								HTTP: &ingress.HTTPIngressRuleValue{
-									Paths: []ingress.HTTPIngressPath{
-										{Path: "/"},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
 			AnnotationsConfig: &annotations.Ingress{
 				SSLPassthrough: &annotations.SSLPassthroughConfig{Enabled: true},
 			},
@@ -273,8 +271,11 @@ func TestPreparePassthroughTLSHostOwnersAllowsFirstRootPathSSLPassthroughOwner(t
 	options := &common.ConvertOptions{}
 	m.preparePassthroughTLSHostOwners(options, configs)
 
-	if !common.IsPassthroughTLSHostOwner(options, configs[1].Config, "example.com") {
-		t.Fatal("first root ssl passthrough ingress was not recorded as owner")
+	if !common.IsPassthroughTLSHostOwner(options, configs[0].Config, "example.com") {
+		t.Fatal("first root ingress was not recorded as passthrough owner")
+	}
+	if !common.HasPassthroughTLSHostOwner(options, configs[0].Config) {
+		t.Fatal("first root ingress was not found as passthrough owner")
 	}
 }
 
@@ -435,6 +436,76 @@ func TestConvertGatewaysHonorsFirstRootPathSSLPassthroughOwner(t *testing.T) {
 	}
 	if tlsServer.Tls.GetMode() != networking.ServerTLSSettings_PASSTHROUGH {
 		t.Fatalf("tls mode mismatch, want PASSTHROUGH, got %s", tlsServer.Tls.GetMode())
+	}
+}
+
+func TestConvertGatewaysUsesFirstRootOwnerWhenLaterIngressEnablesSSLPassthrough(t *testing.T) {
+	fake := kube.NewFakeClient()
+	options := common.Options{
+		Enable:           true,
+		ClusterId:        "ingress-v1",
+		RawClusterId:     "ingress-v1__",
+		GatewayHttpPort:  80,
+		GatewayHttpsPort: 443,
+	}
+	ingressController := controllerv1.NewController(fake, fake, options, nil)
+	m := NewIngressConfig(fake, nil, "wakanda", options)
+	m.remoteIngressControllers = map[cluster.ID]common.IngressController{
+		"ingress-v1": ingressController,
+	}
+
+	configs := []common.WrapperConfig{
+		ingressV1Wrapper("root", "example.com", "/", false),
+		ingressV1Wrapper("passthrough", "example.com", "/passthrough", true),
+	}
+
+	result := m.convertGateways(configs)
+	if len(result) != 1 {
+		t.Fatalf("gateway count mismatch, want 1, got %d", len(result))
+	}
+	gateway := result[0].Spec.(*networking.Gateway)
+	if len(gateway.Servers) != 2 {
+		t.Fatalf("server count mismatch, want 2, got %d", len(gateway.Servers))
+	}
+	tlsServer := gateway.Servers[1]
+	if tlsServer.Port.Protocol != "TLS" {
+		t.Fatalf("tls server protocol mismatch, want TLS, got %s", tlsServer.Port.Protocol)
+	}
+	if tlsServer.Tls.GetMode() != networking.ServerTLSSettings_PASSTHROUGH {
+		t.Fatalf("tls mode mismatch, want PASSTHROUGH, got %s", tlsServer.Tls.GetMode())
+	}
+}
+
+func TestConvertVirtualServiceUsesFirstRootOwnerWhenLaterIngressEnablesSSLPassthrough(t *testing.T) {
+	fake := kube.NewFakeClient()
+	options := common.Options{
+		Enable:           true,
+		ClusterId:        "ingress-v1",
+		RawClusterId:     "ingress-v1__",
+		GatewayHttpPort:  80,
+		GatewayHttpsPort: 443,
+	}
+	ingressController := controllerv1.NewController(fake, fake, options, nil)
+	m := NewIngressConfig(fake, nil, "wakanda", options)
+	m.remoteIngressControllers = map[cluster.ID]common.IngressController{
+		"ingress-v1": ingressController,
+	}
+
+	configs := []common.WrapperConfig{
+		ingressV1Wrapper("root", "example.com", "/", false),
+		ingressV1Wrapper("passthrough", "example.com", "/passthrough", true),
+	}
+
+	result := m.convertVirtualService(configs)
+	if len(result) != 1 {
+		t.Fatalf("virtual service count mismatch, want 1, got %d", len(result))
+	}
+	vs := result[0].Spec.(*networking.VirtualService)
+	if len(vs.Tls) != 1 {
+		t.Fatalf("tls route count mismatch, want 1, got %d", len(vs.Tls))
+	}
+	if got := vs.Tls[0].Route[0].Destination.Host; got != "root.default.svc.cluster.local" {
+		t.Fatalf("destination host mismatch, want root.default.svc.cluster.local, got %s", got)
 	}
 }
 
@@ -944,4 +1015,47 @@ func TestConstructBasicAuthEnvoyFilter(t *testing.T) {
 	}
 	target := proto.Clone(pb).(*httppb.HttpFilter)
 	t.Log(target)
+}
+
+func ingressV1Wrapper(name, host, path string, sslPassthrough bool) common.WrapperConfig {
+	wrapper := common.WrapperConfig{
+		Config: &config.Config{
+			Meta: config.Meta{
+				Namespace: "default",
+				Name:      name,
+				Annotations: map[string]string{
+					common.ClusterIdAnnotation: "ingress-v1",
+				},
+			},
+			Spec: ingress.IngressSpec{
+				Rules: []ingress.IngressRule{
+					{
+						Host: host,
+						IngressRuleValue: ingress.IngressRuleValue{
+							HTTP: &ingress.HTTPIngressRuleValue{
+								Paths: []ingress.HTTPIngressPath{
+									{
+										Path: path,
+										Backend: ingress.IngressBackend{
+											Service: &ingress.IngressServiceBackend{
+												Name: name,
+												Port: ingress.ServiceBackendPort{Number: 443},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		AnnotationsConfig: &annotations.Ingress{
+			Match: &annotations.MatchConfig{},
+		},
+	}
+	if sslPassthrough {
+		wrapper.AnnotationsConfig.SSLPassthrough = &annotations.SSLPassthroughConfig{Enabled: true}
+	}
+	return wrapper
 }

--- a/pkg/ingress/config/ingress_config_test.go
+++ b/pkg/ingress/config/ingress_config_test.go
@@ -29,6 +29,7 @@ import (
 	ingress "k8s.io/api/networking/v1"
 	ingressv1beta1 "k8s.io/api/networking/v1beta1"
 
+	"github.com/alibaba/higress/v2/pkg/cert"
 	"github.com/alibaba/higress/v2/pkg/ingress/kube/annotations"
 	"github.com/alibaba/higress/v2/pkg/ingress/kube/common"
 	controllerv1beta1 "github.com/alibaba/higress/v2/pkg/ingress/kube/ingress"
@@ -195,6 +196,301 @@ func TestIngressTLSHostsForSSLPassthroughRequiresRootBackend(t *testing.T) {
 	}
 	if hosts[0] != "root.example.com" {
 		t.Fatalf("ssl passthrough host mismatch, got %s", hosts[0])
+	}
+}
+
+func TestPrepareDuplicateTLSHostsUsesFirstRootPathOwnerForSSLPassthrough(t *testing.T) {
+	m := &IngressConfig{}
+	configs := []common.WrapperConfig{
+		{
+			Config: &config.Config{
+				Meta: config.Meta{
+					Namespace: "default",
+					Name:      "plain-root",
+				},
+				Spec: ingress.IngressSpec{
+					Rules: []ingress.IngressRule{
+						{
+							Host: "example.com",
+							IngressRuleValue: ingress.IngressRuleValue{
+								HTTP: &ingress.HTTPIngressRuleValue{
+									Paths: []ingress.HTTPIngressPath{
+										{Path: "/"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			AnnotationsConfig: &annotations.Ingress{},
+		},
+		{
+			Config: &config.Config{
+				Meta: config.Meta{
+					Namespace: "default",
+					Name:      "passthrough-root",
+				},
+				Spec: ingress.IngressSpec{
+					Rules: []ingress.IngressRule{
+						{
+							Host: "example.com",
+							IngressRuleValue: ingress.IngressRuleValue{
+								HTTP: &ingress.HTTPIngressRuleValue{
+									Paths: []ingress.HTTPIngressPath{
+										{Path: "/"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			AnnotationsConfig: &annotations.Ingress{
+				SSLPassthrough: &annotations.SSLPassthroughConfig{Enabled: true},
+			},
+		},
+	}
+
+	options := &common.ConvertOptions{}
+	m.prepareDuplicateTLSHosts(options, configs, nil)
+
+	if len(options.SSLPassthroughTLSHosts) != 0 {
+		t.Fatalf("unexpected ssl passthrough owners: %+v", options.SSLPassthroughTLSHosts)
+	}
+	if !common.IsDuplicateTLSHost(options, configs[1].Config, "example.com") {
+		t.Fatal("later ssl passthrough root ingress was not marked as duplicated")
+	}
+}
+
+func TestPrepareDuplicateTLSHostsAllowsFirstRootPathSSLPassthroughOwner(t *testing.T) {
+	m := &IngressConfig{}
+	configs := []common.WrapperConfig{
+		{
+			Config: &config.Config{
+				Meta: config.Meta{
+					Namespace: "default",
+					Name:      "non-root",
+				},
+				Spec: ingress.IngressSpec{
+					Rules: []ingress.IngressRule{
+						{
+							Host: "example.com",
+							IngressRuleValue: ingress.IngressRuleValue{
+								HTTP: &ingress.HTTPIngressRuleValue{
+									Paths: []ingress.HTTPIngressPath{
+										{Path: "/api"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			AnnotationsConfig: &annotations.Ingress{},
+		},
+		{
+			Config: &config.Config{
+				Meta: config.Meta{
+					Namespace: "default",
+					Name:      "passthrough-root",
+				},
+				Spec: ingress.IngressSpec{
+					Rules: []ingress.IngressRule{
+						{
+							Host: "example.com",
+							IngressRuleValue: ingress.IngressRuleValue{
+								HTTP: &ingress.HTTPIngressRuleValue{
+									Paths: []ingress.HTTPIngressPath{
+										{Path: "/"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			AnnotationsConfig: &annotations.Ingress{
+				SSLPassthrough: &annotations.SSLPassthroughConfig{Enabled: true},
+			},
+		},
+	}
+
+	options := &common.ConvertOptions{}
+	m.prepareDuplicateTLSHosts(options, configs, nil)
+
+	if !common.IsSSLPassthroughTLSHostOwner(options, configs[1].Config, "example.com") {
+		t.Fatal("first root ssl passthrough ingress was not recorded as owner")
+	}
+	if common.IsDuplicateTLSHost(options, configs[1].Config, "example.com") {
+		t.Fatal("first root ssl passthrough ingress was marked as duplicated")
+	}
+}
+
+func TestPrepareDuplicateTLSHostsIgnoresHTTPOnlyIngressForHTTPSFallback(t *testing.T) {
+	m := &IngressConfig{}
+	configs := []common.WrapperConfig{
+		{
+			Config: &config.Config{
+				Meta: config.Meta{
+					Namespace: "default",
+					Name:      "http-only",
+				},
+				Spec: ingress.IngressSpec{
+					Rules: []ingress.IngressRule{
+						{
+							Host: "example.com",
+							IngressRuleValue: ingress.IngressRuleValue{
+								HTTP: &ingress.HTTPIngressRuleValue{
+									Paths: []ingress.HTTPIngressPath{
+										{Path: "/api"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			AnnotationsConfig: &annotations.Ingress{},
+		},
+		{
+			Config: &config.Config{
+				Meta: config.Meta{
+					Namespace: "default",
+					Name:      "tls-ingress",
+				},
+				Spec: ingress.IngressSpec{
+					TLS: []ingress.IngressTLS{
+						{
+							Hosts:      []string{"example.com"},
+							SecretName: "example-com",
+						},
+					},
+					Rules: []ingress.IngressRule{
+						{
+							Host: "example.com",
+							IngressRuleValue: ingress.IngressRuleValue{
+								HTTP: &ingress.HTTPIngressRuleValue{
+									Paths: []ingress.HTTPIngressPath{
+										{Path: "/app"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			AnnotationsConfig: &annotations.Ingress{},
+		},
+	}
+
+	options := &common.ConvertOptions{}
+	m.prepareDuplicateTLSHosts(options, configs, &cert.Config{
+		CredentialConfig: []cert.CredentialEntry{
+			{
+				Domains:   []string{"example.com"},
+				TLSSecret: "default/fallback-cert",
+			},
+		},
+	})
+
+	if common.IsDuplicateTLSHost(options, configs[1].Config, "example.com") {
+		t.Fatal("tls ingress was marked as duplicated by an earlier http-only ingress")
+	}
+}
+
+func TestConvertGatewaysHonorsFirstRootPathSSLPassthroughOwner(t *testing.T) {
+	fake := kube.NewFakeClient()
+	options := common.Options{
+		Enable:           true,
+		ClusterId:        "ingress-v1",
+		RawClusterId:     "ingress-v1__",
+		GatewayHttpPort:  80,
+		GatewayHttpsPort: 443,
+	}
+	ingressController := controllerv1.NewController(fake, fake, options, nil)
+	m := NewIngressConfig(fake, nil, "wakanda", options)
+	m.remoteIngressControllers = map[cluster.ID]common.IngressController{
+		"ingress-v1": ingressController,
+	}
+
+	configs := []common.WrapperConfig{
+		{
+			Config: &config.Config{
+				Meta: config.Meta{
+					Namespace: "default",
+					Name:      "tls-non-root",
+					Annotations: map[string]string{
+						common.ClusterIdAnnotation: "ingress-v1",
+					},
+				},
+				Spec: ingress.IngressSpec{
+					TLS: []ingress.IngressTLS{
+						{
+							Hosts:      []string{"example.com"},
+							SecretName: "example-com",
+						},
+					},
+					Rules: []ingress.IngressRule{
+						{
+							Host: "example.com",
+							IngressRuleValue: ingress.IngressRuleValue{
+								HTTP: &ingress.HTTPIngressRuleValue{
+									Paths: []ingress.HTTPIngressPath{
+										{Path: "/api"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			AnnotationsConfig: &annotations.Ingress{},
+		},
+		{
+			Config: &config.Config{
+				Meta: config.Meta{
+					Namespace: "default",
+					Name:      "passthrough-root",
+					Annotations: map[string]string{
+						common.ClusterIdAnnotation: "ingress-v1",
+					},
+				},
+				Spec: ingress.IngressSpec{
+					Rules: []ingress.IngressRule{
+						{
+							Host: "example.com",
+							IngressRuleValue: ingress.IngressRuleValue{
+								HTTP: &ingress.HTTPIngressRuleValue{
+									Paths: []ingress.HTTPIngressPath{
+										{Path: "/"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			AnnotationsConfig: &annotations.Ingress{
+				SSLPassthrough: &annotations.SSLPassthroughConfig{Enabled: true},
+			},
+		},
+	}
+
+	result := m.convertGateways(configs)
+	if len(result) != 1 {
+		t.Fatalf("gateway count mismatch, want 1, got %d", len(result))
+	}
+	gateway := result[0].Spec.(*networking.Gateway)
+	if len(gateway.Servers) != 2 {
+		t.Fatalf("server count mismatch, want 2, got %d", len(gateway.Servers))
+	}
+	tlsServer := gateway.Servers[1]
+	if tlsServer.Port.Protocol != "TLS" {
+		t.Fatalf("tls server protocol mismatch, want TLS, got %s", tlsServer.Port.Protocol)
+	}
+	if tlsServer.Tls.GetMode() != networking.ServerTLSSettings_PASSTHROUGH {
+		t.Fatalf("tls mode mismatch, want PASSTHROUGH, got %s", tlsServer.Tls.GetMode())
 	}
 }
 

--- a/pkg/ingress/config/ingress_config_test.go
+++ b/pkg/ingress/config/ingress_config_test.go
@@ -156,48 +156,6 @@ func TestVirtualServiceNameAndClusterID(t *testing.T) {
 	}
 }
 
-func TestIngressTLSHostsForSSLPassthroughRequiresRootBackend(t *testing.T) {
-	wrapper := common.WrapperConfig{
-		Config: &config.Config{
-			Spec: ingress.IngressSpec{
-				Rules: []ingress.IngressRule{
-					{
-						Host: "non-root.example.com",
-						IngressRuleValue: ingress.IngressRuleValue{
-							HTTP: &ingress.HTTPIngressRuleValue{
-								Paths: []ingress.HTTPIngressPath{
-									{Path: "/api"},
-								},
-							},
-						},
-					},
-					{
-						Host: "root.example.com",
-						IngressRuleValue: ingress.IngressRuleValue{
-							HTTP: &ingress.HTTPIngressRuleValue{
-								Paths: []ingress.HTTPIngressPath{
-									{Path: "/"},
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-		AnnotationsConfig: &annotations.Ingress{
-			SSLPassthrough: &annotations.SSLPassthroughConfig{Enabled: true},
-		},
-	}
-
-	hosts := ingressTLSHosts(wrapper, nil)
-	if len(hosts) != 1 {
-		t.Fatalf("ssl passthrough host count mismatch, want 1, got %d", len(hosts))
-	}
-	if hosts[0] != "root.example.com" {
-		t.Fatalf("ssl passthrough host mismatch, got %s", hosts[0])
-	}
-}
-
 func TestPreparePassthroughTLSHostOwnersUsesFirstRootPathOwner(t *testing.T) {
 	m := &IngressConfig{}
 	configs := []common.WrapperConfig{

--- a/pkg/ingress/config/ingress_config_test.go
+++ b/pkg/ingress/config/ingress_config_test.go
@@ -199,7 +199,7 @@ func TestIngressTLSHostsForSSLPassthroughRequiresRootBackend(t *testing.T) {
 	}
 }
 
-func TestPrepareDuplicateTLSHostsUsesFirstRootPathOwnerForSSLPassthrough(t *testing.T) {
+func TestPrepareTLSHostOwnershipUsesFirstRootPathOwnerForSSLPassthrough(t *testing.T) {
 	m := &IngressConfig{}
 	configs := []common.WrapperConfig{
 		{
@@ -253,17 +253,17 @@ func TestPrepareDuplicateTLSHostsUsesFirstRootPathOwnerForSSLPassthrough(t *test
 	}
 
 	options := &common.ConvertOptions{}
-	m.prepareDuplicateTLSHosts(options, configs, nil)
+	m.prepareTLSHostOwnership(options, configs, nil)
 
-	if len(options.SSLPassthroughTLSHosts) != 0 {
-		t.Fatalf("unexpected ssl passthrough owners: %+v", options.SSLPassthroughTLSHosts)
+	if len(options.PassthroughTLSHostOwners) != 0 {
+		t.Fatalf("unexpected ssl passthrough owners: %+v", options.PassthroughTLSHostOwners)
 	}
-	if !common.IsDuplicateTLSHost(options, configs[1].Config, "example.com") {
-		t.Fatal("later ssl passthrough root ingress was not marked as duplicated")
+	if !common.IsSuppressedTLSHost(options, configs[1].Config, "example.com") {
+		t.Fatal("later ssl passthrough root ingress was not marked as suppressed")
 	}
 }
 
-func TestPrepareDuplicateTLSHostsAllowsFirstRootPathSSLPassthroughOwner(t *testing.T) {
+func TestPrepareTLSHostOwnershipAllowsFirstRootPathSSLPassthroughOwner(t *testing.T) {
 	m := &IngressConfig{}
 	configs := []common.WrapperConfig{
 		{
@@ -317,17 +317,17 @@ func TestPrepareDuplicateTLSHostsAllowsFirstRootPathSSLPassthroughOwner(t *testi
 	}
 
 	options := &common.ConvertOptions{}
-	m.prepareDuplicateTLSHosts(options, configs, nil)
+	m.prepareTLSHostOwnership(options, configs, nil)
 
-	if !common.IsSSLPassthroughTLSHostOwner(options, configs[1].Config, "example.com") {
+	if !common.IsPassthroughTLSHostOwner(options, configs[1].Config, "example.com") {
 		t.Fatal("first root ssl passthrough ingress was not recorded as owner")
 	}
-	if common.IsDuplicateTLSHost(options, configs[1].Config, "example.com") {
-		t.Fatal("first root ssl passthrough ingress was marked as duplicated")
+	if common.IsSuppressedTLSHost(options, configs[1].Config, "example.com") {
+		t.Fatal("first root ssl passthrough ingress was marked as suppressed")
 	}
 }
 
-func TestPrepareDuplicateTLSHostsIgnoresHTTPOnlyIngressForHTTPSFallback(t *testing.T) {
+func TestPrepareTLSHostOwnershipIgnoresHTTPOnlyIngressForHTTPSFallback(t *testing.T) {
 	m := &IngressConfig{}
 	configs := []common.WrapperConfig{
 		{
@@ -385,7 +385,7 @@ func TestPrepareDuplicateTLSHostsIgnoresHTTPOnlyIngressForHTTPSFallback(t *testi
 	}
 
 	options := &common.ConvertOptions{}
-	m.prepareDuplicateTLSHosts(options, configs, &cert.Config{
+	m.prepareTLSHostOwnership(options, configs, &cert.Config{
 		CredentialConfig: []cert.CredentialEntry{
 			{
 				Domains:   []string{"example.com"},
@@ -394,8 +394,8 @@ func TestPrepareDuplicateTLSHostsIgnoresHTTPOnlyIngressForHTTPSFallback(t *testi
 		},
 	})
 
-	if common.IsDuplicateTLSHost(options, configs[1].Config, "example.com") {
-		t.Fatal("tls ingress was marked as duplicated by an earlier http-only ingress")
+	if common.IsSuppressedTLSHost(options, configs[1].Config, "example.com") {
+		t.Fatal("tls ingress was marked as suppressed by an earlier http-only ingress")
 	}
 }
 

--- a/pkg/ingress/config/ingress_config_test.go
+++ b/pkg/ingress/config/ingress_config_test.go
@@ -29,7 +29,6 @@ import (
 	ingress "k8s.io/api/networking/v1"
 	ingressv1beta1 "k8s.io/api/networking/v1beta1"
 
-	"github.com/alibaba/higress/v2/pkg/cert"
 	"github.com/alibaba/higress/v2/pkg/ingress/kube/annotations"
 	"github.com/alibaba/higress/v2/pkg/ingress/kube/common"
 	controllerv1beta1 "github.com/alibaba/higress/v2/pkg/ingress/kube/ingress"
@@ -199,7 +198,7 @@ func TestIngressTLSHostsForSSLPassthroughRequiresRootBackend(t *testing.T) {
 	}
 }
 
-func TestPrepareTLSHostOwnershipUsesFirstRootPathOwnerForSSLPassthrough(t *testing.T) {
+func TestPreparePassthroughTLSHostOwnersUsesFirstRootPathOwner(t *testing.T) {
 	m := &IngressConfig{}
 	configs := []common.WrapperConfig{
 		{
@@ -253,17 +252,14 @@ func TestPrepareTLSHostOwnershipUsesFirstRootPathOwnerForSSLPassthrough(t *testi
 	}
 
 	options := &common.ConvertOptions{}
-	m.prepareTLSHostOwnership(options, configs, nil)
+	m.preparePassthroughTLSHostOwners(options, configs)
 
 	if len(options.PassthroughTLSHostOwners) != 0 {
 		t.Fatalf("unexpected ssl passthrough owners: %+v", options.PassthroughTLSHostOwners)
 	}
-	if !common.IsSuppressedTLSHost(options, configs[1].Config, "example.com") {
-		t.Fatal("later ssl passthrough root ingress was not marked as suppressed")
-	}
 }
 
-func TestPrepareTLSHostOwnershipAllowsFirstRootPathSSLPassthroughOwner(t *testing.T) {
+func TestPreparePassthroughTLSHostOwnersAllowsFirstRootPathSSLPassthroughOwner(t *testing.T) {
 	m := &IngressConfig{}
 	configs := []common.WrapperConfig{
 		{
@@ -317,17 +313,14 @@ func TestPrepareTLSHostOwnershipAllowsFirstRootPathSSLPassthroughOwner(t *testin
 	}
 
 	options := &common.ConvertOptions{}
-	m.prepareTLSHostOwnership(options, configs, nil)
+	m.preparePassthroughTLSHostOwners(options, configs)
 
 	if !common.IsPassthroughTLSHostOwner(options, configs[1].Config, "example.com") {
 		t.Fatal("first root ssl passthrough ingress was not recorded as owner")
 	}
-	if common.IsSuppressedTLSHost(options, configs[1].Config, "example.com") {
-		t.Fatal("first root ssl passthrough ingress was marked as suppressed")
-	}
 }
 
-func TestPrepareTLSHostOwnershipIgnoresHTTPOnlyIngressForHTTPSFallback(t *testing.T) {
+func TestPreparePassthroughTLSHostOwnersIgnoresHTTPOnlyIngressForHTTPSFallback(t *testing.T) {
 	m := &IngressConfig{}
 	configs := []common.WrapperConfig{
 		{
@@ -385,17 +378,10 @@ func TestPrepareTLSHostOwnershipIgnoresHTTPOnlyIngressForHTTPSFallback(t *testin
 	}
 
 	options := &common.ConvertOptions{}
-	m.prepareTLSHostOwnership(options, configs, &cert.Config{
-		CredentialConfig: []cert.CredentialEntry{
-			{
-				Domains:   []string{"example.com"},
-				TLSSecret: "default/fallback-cert",
-			},
-		},
-	})
+	m.preparePassthroughTLSHostOwners(options, configs)
 
-	if common.IsSuppressedTLSHost(options, configs[1].Config, "example.com") {
-		t.Fatal("tls ingress was marked as suppressed by an earlier http-only ingress")
+	if len(options.PassthroughTLSHostOwners) != 0 {
+		t.Fatalf("unexpected ssl passthrough owners: %+v", options.PassthroughTLSHostOwners)
 	}
 }
 

--- a/pkg/ingress/kube/annotations/annotations.go
+++ b/pkg/ingress/kube/annotations/annotations.go
@@ -57,6 +57,8 @@ type Ingress struct {
 
 	DownstreamTLS *DownstreamTLSConfig
 
+	SSLPassthrough *SSLPassthroughConfig
+
 	Canary *CanaryConfig
 
 	IPAccessControl *IPAccessControlConfig
@@ -115,6 +117,10 @@ func (i *Ingress) IsCanary() bool {
 	return i.Canary.Enabled
 }
 
+func (i *Ingress) IsSSLPassthrough() bool {
+	return i.SSLPassthrough != nil && i.SSLPassthrough.Enabled
+}
+
 // CanaryKind return byHeader, byWeight
 func (i *Ingress) CanaryKind() (bool, bool) {
 	if !i.IsCanary() {
@@ -157,6 +163,7 @@ func NewAnnotationHandlerManager() AnnotationHandler {
 			canary{},
 			cors{},
 			downstreamTLS{},
+			sslPassthrough{},
 			redirect{},
 			rewrite{},
 			upstreamTLS{},

--- a/pkg/ingress/kube/annotations/downstreamtls.go
+++ b/pkg/ingress/kube/annotations/downstreamtls.go
@@ -106,6 +106,9 @@ func (d downstreamTLS) ApplyGateway(gateway *networking.Gateway, config *Ingress
 	downstreamTLSConfig := config.DownstreamTLS
 	for _, server := range gateway.Servers {
 		if gatewaytool.IsTLSServer(server) {
+			if server.Tls != nil && server.Tls.Mode == networking.ServerTLSSettings_PASSTHROUGH {
+				continue
+			}
 			if downstreamTLSConfig.CASecretName.Name != "" {
 				serverCert := extraSecret(server.Tls.CredentialName)
 				if downstreamTLSConfig.CASecretName.Namespace != serverCert.Namespace ||

--- a/pkg/ingress/kube/annotations/downstreamtls_test.go
+++ b/pkg/ingress/kube/annotations/downstreamtls_test.go
@@ -269,6 +269,40 @@ func TestApplyGateway(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "skip passthrough server",
+			input: &networking.Gateway{
+				Servers: []*networking.Server{
+					{
+						Port: &networking.Port{
+							Protocol: "TLS",
+						},
+						Tls: &networking.ServerTLSSettings{
+							Mode: networking.ServerTLSSettings_PASSTHROUGH,
+						},
+					},
+				},
+			},
+			config: &Ingress{
+				DownstreamTLS: &DownstreamTLSConfig{
+					CipherSuites: []string{"ECDHE-RSA-AES256-GCM-SHA384"},
+					MinVersion:   "TLSv1.2",
+					MaxVersion:   "TLSv1.3",
+				},
+			},
+			expect: &networking.Gateway{
+				Servers: []*networking.Server{
+					{
+						Port: &networking.Port{
+							Protocol: "TLS",
+						},
+						Tls: &networking.ServerTLSSettings{
+							Mode: networking.ServerTLSSettings_PASSTHROUGH,
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/ingress/kube/annotations/ssl_passthrough.go
+++ b/pkg/ingress/kube/annotations/ssl_passthrough.go
@@ -1,0 +1,34 @@
+// Copyright (c) 2022 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package annotations
+
+const sslPassthroughAnnotation = "ssl-passthrough"
+
+var _ Parser = &sslPassthrough{}
+
+type SSLPassthroughConfig struct {
+	Enabled bool
+}
+
+type sslPassthrough struct{}
+
+func (s sslPassthrough) Parse(annotations Annotations, config *Ingress, _ *GlobalContext) error {
+	enabled, err := annotations.ParseBoolASAP(sslPassthroughAnnotation)
+	if err != nil {
+		return nil
+	}
+	config.SSLPassthrough = &SSLPassthroughConfig{Enabled: enabled}
+	return nil
+}

--- a/pkg/ingress/kube/annotations/ssl_passthrough_test.go
+++ b/pkg/ingress/kube/annotations/ssl_passthrough_test.go
@@ -1,0 +1,112 @@
+// Copyright (c) 2022 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package annotations
+
+import "testing"
+
+func TestSSLPassthroughParse(t *testing.T) {
+	testCases := []struct {
+		name    string
+		input   Annotations
+		enabled bool
+		exists  bool
+	}{
+		{
+			name:  "missing",
+			input: Annotations{},
+		},
+		{
+			name: "enabled by nginx annotation",
+			input: Annotations{
+				buildNginxAnnotationKey(sslPassthroughAnnotation): "true",
+			},
+			enabled: true,
+			exists:  true,
+		},
+		{
+			name: "enabled by higress annotation",
+			input: Annotations{
+				buildHigressAnnotationKey(sslPassthroughAnnotation): "true",
+			},
+			enabled: true,
+			exists:  true,
+		},
+		{
+			name: "disabled by nginx annotation",
+			input: Annotations{
+				buildNginxAnnotationKey(sslPassthroughAnnotation): "false",
+			},
+			exists: true,
+		},
+		{
+			name: "disabled by higress annotation",
+			input: Annotations{
+				buildHigressAnnotationKey(sslPassthroughAnnotation): "false",
+			},
+			exists: true,
+		},
+	}
+
+	parser := sslPassthrough{}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			config := &Ingress{}
+			if err := parser.Parse(tc.input, config, nil); err != nil {
+				t.Fatalf("Parse() error = %v", err)
+			}
+			if tc.exists && config.SSLPassthrough == nil {
+				t.Fatal("expected ssl passthrough config")
+			}
+			if !tc.exists && config.SSLPassthrough != nil {
+				t.Fatal("unexpected ssl passthrough config")
+			}
+			if tc.exists && config.SSLPassthrough.Enabled != tc.enabled {
+				t.Fatalf("enabled mismatch, want %v, got %v", tc.enabled, config.SSLPassthrough.Enabled)
+			}
+		})
+	}
+}
+
+func TestSSLPassthroughDoesNotSetUpstreamTLS(t *testing.T) {
+	parser := sslPassthrough{}
+	config := &Ingress{}
+	err := parser.Parse(Annotations{
+		buildNginxAnnotationKey(sslPassthroughAnnotation): "true",
+	}, config, nil)
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+	if config.UpstreamTLS != nil {
+		t.Fatal("unexpected upstream tls config")
+	}
+}
+
+func TestSSLPassthroughKeepsExplicitBackendProtocol(t *testing.T) {
+	manager := NewAnnotationHandlerManager()
+	config := &Ingress{}
+	err := manager.Parse(Annotations{
+		buildNginxAnnotationKey(sslPassthroughAnnotation): "true",
+		buildNginxAnnotationKey(backendProtocol):          "HTTPS",
+	}, config, nil)
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+	if config.UpstreamTLS == nil {
+		t.Fatal("expected upstream tls config")
+	}
+	if config.UpstreamTLS.BackendProtocol != "HTTPS" {
+		t.Fatalf("backend protocol mismatch, want HTTPS, got %s", config.UpstreamTLS.BackendProtocol)
+	}
+}

--- a/pkg/ingress/kube/common/controller.go
+++ b/pkg/ingress/kube/common/controller.go
@@ -15,6 +15,7 @@
 package common
 
 import (
+	"strconv"
 	"strings"
 	"time"
 
@@ -23,6 +24,7 @@ import (
 	"istio.io/istio/pkg/cluster"
 	"istio.io/istio/pkg/config"
 	gatewaytool "istio.io/istio/pkg/config/gateway"
+	"istio.io/istio/pkg/config/protocol"
 	listerv1 "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
 
@@ -78,6 +80,20 @@ func (w *WrapperGateway) IsHTTPS() bool {
 	return false
 }
 
+func CreateSSLPassthroughServer(host string, port uint32, clusterId cluster.ID) *networking.Server {
+	return &networking.Server{
+		Port: &networking.Port{
+			Number:   port,
+			Protocol: string(protocol.TLS),
+			Name:     CreateConvertedName("tls-"+strconv.FormatUint(uint64(port), 10)+"-ingress", clusterId.String()),
+		},
+		Hosts: []string{host},
+		Tls: &networking.ServerTLSSettings{
+			Mode: networking.ServerTLSSettings_PASSTHROUGH,
+		},
+	}
+}
+
 type WrapperHTTPRoute struct {
 	HTTPRoute        *networking.HTTPRoute
 	WrapperConfig    *WrapperConfig
@@ -109,6 +125,42 @@ type WrapperVirtualService struct {
 	WrapperConfig            *WrapperConfig
 	ConfiguredDefaultBackend bool
 	AppRoot                  string
+}
+
+func (w *WrapperVirtualService) HasTLSRouteForHost(host string) bool {
+	if w == nil || w.VirtualService == nil {
+		return false
+	}
+	for _, route := range w.VirtualService.Tls {
+		for _, match := range route.Match {
+			for _, sniHost := range match.SniHosts {
+				if sniHost == host {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+func NewWrapperVirtualService(host string, wrapper *WrapperConfig) *WrapperVirtualService {
+	return &WrapperVirtualService{
+		VirtualService: &networking.VirtualService{
+			Hosts: []string{host},
+		},
+		WrapperConfig: wrapper,
+	}
+}
+
+func CreateTLSRoute(host string, routeDestination []*networking.RouteDestination) *networking.TLSRoute {
+	return &networking.TLSRoute{
+		Match: []*networking.TLSMatchAttributes{
+			{
+				SniHosts: []string{host},
+			},
+		},
+		Route: routeDestination,
+	}
 }
 
 type WrapperTrafficPolicy struct {

--- a/pkg/ingress/kube/common/controller.go
+++ b/pkg/ingress/kube/common/controller.go
@@ -87,7 +87,7 @@ func CreateSSLPassthroughServer(host string, port uint32, clusterId cluster.ID) 
 			Protocol: string(protocol.TLS),
 			Name:     CreateConvertedName("tls-"+strconv.FormatUint(uint64(port), 10)+"-ingress", clusterId.String()),
 		},
-		Hosts: []string{host},
+		Hosts: []string{wildcardHost(host)},
 		Tls: &networking.ServerTLSSettings{
 			Mode: networking.ServerTLSSettings_PASSTHROUGH,
 		},
@@ -146,7 +146,7 @@ func (w *WrapperVirtualService) HasTLSRouteForHost(host string) bool {
 func NewWrapperVirtualService(host string, wrapper *WrapperConfig) *WrapperVirtualService {
 	return &WrapperVirtualService{
 		VirtualService: &networking.VirtualService{
-			Hosts: []string{host},
+			Hosts: []string{wildcardHost(host)},
 		},
 		WrapperConfig: wrapper,
 	}
@@ -156,11 +156,18 @@ func CreateTLSRoute(host string, routeDestination []*networking.RouteDestination
 	return &networking.TLSRoute{
 		Match: []*networking.TLSMatchAttributes{
 			{
-				SniHosts: []string{host},
+				SniHosts: []string{wildcardHost(host)},
 			},
 		},
 		Route: routeDestination,
 	}
+}
+
+func wildcardHost(host string) string {
+	if host == "" {
+		return "*"
+	}
+	return host
 }
 
 type WrapperTrafficPolicy struct {

--- a/pkg/ingress/kube/common/controller.go
+++ b/pkg/ingress/kube/common/controller.go
@@ -87,7 +87,7 @@ func CreateSSLPassthroughServer(host string, port uint32, clusterId cluster.ID) 
 			Protocol: string(protocol.TLS),
 			Name:     CreateConvertedName("tls-"+strconv.FormatUint(uint64(port), 10)+"-ingress", clusterId.String()),
 		},
-		Hosts: []string{wildcardHost(host)},
+		Hosts: []string{WildcardHost(host)},
 		Tls: &networking.ServerTLSSettings{
 			Mode: networking.ServerTLSSettings_PASSTHROUGH,
 		},
@@ -131,11 +131,11 @@ func (w *WrapperVirtualService) HasTLSRouteForHost(host string) bool {
 	if w == nil || w.VirtualService == nil {
 		return false
 	}
-	host = wildcardHost(host)
+	host = WildcardHost(host)
 	for _, route := range w.VirtualService.Tls {
 		for _, match := range route.Match {
 			for _, sniHost := range match.SniHosts {
-				if wildcardHost(sniHost) == host {
+				if WildcardHost(sniHost) == host {
 					return true
 				}
 			}
@@ -147,7 +147,7 @@ func (w *WrapperVirtualService) HasTLSRouteForHost(host string) bool {
 func NewWrapperVirtualService(host string, wrapper *WrapperConfig) *WrapperVirtualService {
 	return &WrapperVirtualService{
 		VirtualService: &networking.VirtualService{
-			Hosts: []string{wildcardHost(host)},
+			Hosts: []string{WildcardHost(host)},
 		},
 		WrapperConfig: wrapper,
 	}
@@ -157,14 +157,14 @@ func CreateTLSRoute(host string, routeDestination []*networking.RouteDestination
 	return &networking.TLSRoute{
 		Match: []*networking.TLSMatchAttributes{
 			{
-				SniHosts: []string{wildcardHost(host)},
+				SniHosts: []string{WildcardHost(host)},
 			},
 		},
 		Route: routeDestination,
 	}
 }
 
-func wildcardHost(host string) string {
+func WildcardHost(host string) string {
 	if host == "" {
 		return "*"
 	}

--- a/pkg/ingress/kube/common/controller.go
+++ b/pkg/ingress/kube/common/controller.go
@@ -131,10 +131,11 @@ func (w *WrapperVirtualService) HasTLSRouteForHost(host string) bool {
 	if w == nil || w.VirtualService == nil {
 		return false
 	}
+	host = wildcardHost(host)
 	for _, route := range w.VirtualService.Tls {
 		for _, match := range route.Match {
 			for _, sniHost := range match.SniHosts {
-				if sniHost == host {
+				if wildcardHost(sniHost) == host {
 					return true
 				}
 			}

--- a/pkg/ingress/kube/common/model.go
+++ b/pkg/ingress/kube/common/model.go
@@ -145,6 +145,47 @@ func (i *IngressDomainCache) Extract() model.IngressDomainCollection {
 	}
 }
 
+func AddDuplicateTLSHost(convertOptions *ConvertOptions, cfg *config.Config, host string) {
+	if convertOptions.DuplicateTLSHosts == nil {
+		convertOptions.DuplicateTLSHosts = map[TLSHostKey]struct{}{}
+	}
+	convertOptions.DuplicateTLSHosts[NewTLSHostKey(cfg, host)] = struct{}{}
+}
+
+func SameConfig(left *config.Config, right *config.Config) bool {
+	if left == nil || right == nil {
+		return left == right
+	}
+	return GetClusterId(left.Annotations) == GetClusterId(right.Annotations) &&
+		left.Namespace == right.Namespace &&
+		left.Name == right.Name
+}
+
+func IsDuplicateTLSHost(convertOptions *ConvertOptions, cfg *config.Config, host string) bool {
+	if convertOptions == nil || len(convertOptions.DuplicateTLSHosts) == 0 {
+		return false
+	}
+	_, exist := convertOptions.DuplicateTLSHosts[NewTLSHostKey(cfg, host)]
+	return exist
+}
+
+type TLSHostKey struct {
+	ClusterId cluster.ID
+	Namespace string
+	Name      string
+	Host      string
+}
+
+func NewTLSHostKey(cfg *config.Config, host string) TLSHostKey {
+	key := TLSHostKey{Host: host}
+	if cfg != nil {
+		key.ClusterId = GetClusterId(cfg.Annotations)
+		key.Namespace = cfg.Namespace
+		key.Name = cfg.Name
+	}
+	return key
+}
+
 type ConvertOptions struct {
 	HostWithRule2Ingress map[string]*config.Config
 
@@ -166,6 +207,8 @@ type ConvertOptions struct {
 	HTTPRoutes map[string][]*WrapperHTTPRoute
 
 	CanaryIngresses []*WrapperConfig
+
+	DuplicateTLSHosts map[TLSHostKey]struct{}
 
 	Service2TrafficPolicy map[ServiceKey]*WrapperTrafficPolicy
 

--- a/pkg/ingress/kube/common/model.go
+++ b/pkg/ingress/kube/common/model.go
@@ -145,11 +145,11 @@ func (i *IngressDomainCache) Extract() model.IngressDomainCollection {
 	}
 }
 
-func AddDuplicateTLSHost(convertOptions *ConvertOptions, cfg *config.Config, host string) {
-	if convertOptions.DuplicateTLSHosts == nil {
-		convertOptions.DuplicateTLSHosts = map[TLSHostKey]struct{}{}
+func AddSuppressedTLSHost(convertOptions *ConvertOptions, cfg *config.Config, host string) {
+	if convertOptions.SuppressedTLSHosts == nil {
+		convertOptions.SuppressedTLSHosts = map[TLSHostKey]struct{}{}
 	}
-	convertOptions.DuplicateTLSHosts[NewTLSHostKey(cfg, host)] = struct{}{}
+	convertOptions.SuppressedTLSHosts[NewTLSHostKey(cfg, host)] = struct{}{}
 }
 
 func SameConfig(left *config.Config, right *config.Config) bool {
@@ -161,26 +161,26 @@ func SameConfig(left *config.Config, right *config.Config) bool {
 		left.Name == right.Name
 }
 
-func IsDuplicateTLSHost(convertOptions *ConvertOptions, cfg *config.Config, host string) bool {
-	if convertOptions == nil || len(convertOptions.DuplicateTLSHosts) == 0 {
+func IsSuppressedTLSHost(convertOptions *ConvertOptions, cfg *config.Config, host string) bool {
+	if convertOptions == nil || len(convertOptions.SuppressedTLSHosts) == 0 {
 		return false
 	}
-	_, exist := convertOptions.DuplicateTLSHosts[NewTLSHostKey(cfg, host)]
+	_, exist := convertOptions.SuppressedTLSHosts[NewTLSHostKey(cfg, host)]
 	return exist
 }
 
-func IsSSLPassthroughTLSHostOwner(convertOptions *ConvertOptions, cfg *config.Config, host string) bool {
-	if convertOptions == nil || convertOptions.SSLPassthroughTLSHosts == nil {
+func IsPassthroughTLSHostOwner(convertOptions *ConvertOptions, cfg *config.Config, host string) bool {
+	if convertOptions == nil || convertOptions.PassthroughTLSHostOwners == nil {
 		return true
 	}
-	return SameConfig(convertOptions.SSLPassthroughTLSHosts[host], cfg)
+	return SameConfig(convertOptions.PassthroughTLSHostOwners[host], cfg)
 }
 
-func SSLPassthroughTLSHostOwner(convertOptions *ConvertOptions, host string) *config.Config {
-	if convertOptions == nil || len(convertOptions.SSLPassthroughTLSHosts) == 0 {
+func PassthroughTLSHostOwner(convertOptions *ConvertOptions, host string) *config.Config {
+	if convertOptions == nil || len(convertOptions.PassthroughTLSHostOwners) == 0 {
 		return nil
 	}
-	return convertOptions.SSLPassthroughTLSHosts[host]
+	return convertOptions.PassthroughTLSHostOwners[host]
 }
 
 type TLSHostKey struct {
@@ -222,9 +222,11 @@ type ConvertOptions struct {
 
 	CanaryIngresses []*WrapperConfig
 
-	DuplicateTLSHosts map[TLSHostKey]struct{}
+	// Ingress+host pairs whose TLS server or TLS passthrough route should be skipped.
+	SuppressedTLSHosts map[TLSHostKey]struct{}
 
-	SSLPassthroughTLSHosts map[string]*config.Config
+	// Host to the ingress that owns TLS passthrough for that host.
+	PassthroughTLSHostOwners map[string]*config.Config
 
 	Service2TrafficPolicy map[ServiceKey]*WrapperTrafficPolicy
 

--- a/pkg/ingress/kube/common/model.go
+++ b/pkg/ingress/kube/common/model.go
@@ -168,6 +168,18 @@ func PassthroughTLSHostOwner(convertOptions *ConvertOptions, host string) *confi
 	return convertOptions.PassthroughTLSHostOwners[host]
 }
 
+func HasPassthroughTLSHostOwner(convertOptions *ConvertOptions, cfg *config.Config) bool {
+	if convertOptions == nil || len(convertOptions.PassthroughTLSHostOwners) == 0 {
+		return false
+	}
+	for _, owner := range convertOptions.PassthroughTLSHostOwners {
+		if SameConfig(owner, cfg) {
+			return true
+		}
+	}
+	return false
+}
+
 type ConvertOptions struct {
 	HostWithRule2Ingress map[string]*config.Config
 
@@ -190,7 +202,7 @@ type ConvertOptions struct {
 
 	CanaryIngresses []*WrapperConfig
 
-	// Host to the ingress that owns TLS passthrough for that host.
+	// Host to the first root-path ingress owner for hosts that have TLS passthrough enabled.
 	PassthroughTLSHostOwners map[string]*config.Config
 
 	Service2TrafficPolicy map[ServiceKey]*WrapperTrafficPolicy

--- a/pkg/ingress/kube/common/model.go
+++ b/pkg/ingress/kube/common/model.go
@@ -145,13 +145,6 @@ func (i *IngressDomainCache) Extract() model.IngressDomainCollection {
 	}
 }
 
-func AddSuppressedTLSHost(convertOptions *ConvertOptions, cfg *config.Config, host string) {
-	if convertOptions.SuppressedTLSHosts == nil {
-		convertOptions.SuppressedTLSHosts = map[TLSHostKey]struct{}{}
-	}
-	convertOptions.SuppressedTLSHosts[NewTLSHostKey(cfg, host)] = struct{}{}
-}
-
 func SameConfig(left *config.Config, right *config.Config) bool {
 	if left == nil || right == nil {
 		return left == right
@@ -159,14 +152,6 @@ func SameConfig(left *config.Config, right *config.Config) bool {
 	return GetClusterId(left.Annotations) == GetClusterId(right.Annotations) &&
 		left.Namespace == right.Namespace &&
 		left.Name == right.Name
-}
-
-func IsSuppressedTLSHost(convertOptions *ConvertOptions, cfg *config.Config, host string) bool {
-	if convertOptions == nil || len(convertOptions.SuppressedTLSHosts) == 0 {
-		return false
-	}
-	_, exist := convertOptions.SuppressedTLSHosts[NewTLSHostKey(cfg, host)]
-	return exist
 }
 
 func IsPassthroughTLSHostOwner(convertOptions *ConvertOptions, cfg *config.Config, host string) bool {
@@ -181,23 +166,6 @@ func PassthroughTLSHostOwner(convertOptions *ConvertOptions, host string) *confi
 		return nil
 	}
 	return convertOptions.PassthroughTLSHostOwners[host]
-}
-
-type TLSHostKey struct {
-	ClusterId cluster.ID
-	Namespace string
-	Name      string
-	Host      string
-}
-
-func NewTLSHostKey(cfg *config.Config, host string) TLSHostKey {
-	key := TLSHostKey{Host: host}
-	if cfg != nil {
-		key.ClusterId = GetClusterId(cfg.Annotations)
-		key.Namespace = cfg.Namespace
-		key.Name = cfg.Name
-	}
-	return key
 }
 
 type ConvertOptions struct {
@@ -221,9 +189,6 @@ type ConvertOptions struct {
 	HTTPRoutes map[string][]*WrapperHTTPRoute
 
 	CanaryIngresses []*WrapperConfig
-
-	// Ingress+host pairs whose TLS server or TLS passthrough route should be skipped.
-	SuppressedTLSHosts map[TLSHostKey]struct{}
 
 	// Host to the ingress that owns TLS passthrough for that host.
 	PassthroughTLSHostOwners map[string]*config.Config

--- a/pkg/ingress/kube/common/model.go
+++ b/pkg/ingress/kube/common/model.go
@@ -169,6 +169,20 @@ func IsDuplicateTLSHost(convertOptions *ConvertOptions, cfg *config.Config, host
 	return exist
 }
 
+func IsSSLPassthroughTLSHostOwner(convertOptions *ConvertOptions, cfg *config.Config, host string) bool {
+	if convertOptions == nil || convertOptions.SSLPassthroughTLSHosts == nil {
+		return true
+	}
+	return SameConfig(convertOptions.SSLPassthroughTLSHosts[host], cfg)
+}
+
+func SSLPassthroughTLSHostOwner(convertOptions *ConvertOptions, host string) *config.Config {
+	if convertOptions == nil || len(convertOptions.SSLPassthroughTLSHosts) == 0 {
+		return nil
+	}
+	return convertOptions.SSLPassthroughTLSHosts[host]
+}
+
 type TLSHostKey struct {
 	ClusterId cluster.ID
 	Namespace string
@@ -209,6 +223,8 @@ type ConvertOptions struct {
 	CanaryIngresses []*WrapperConfig
 
 	DuplicateTLSHosts map[TLSHostKey]struct{}
+
+	SSLPassthroughTLSHosts map[string]*config.Config
 
 	Service2TrafficPolicy map[ServiceKey]*WrapperTrafficPolicy
 

--- a/pkg/ingress/kube/common/model_test.go
+++ b/pkg/ingress/kube/common/model_test.go
@@ -36,6 +36,30 @@ func TestWildcardHostForSSLPassthrough(t *testing.T) {
 	assert.True(t, vs.HasTLSRouteForHost(""))
 }
 
+func TestPassthroughTLSHostOwnerNilMapAllowsStandaloneConversion(t *testing.T) {
+	cfg := &config.Config{
+		Meta: config.Meta{
+			Namespace: "default",
+			Name:      "tls-passthrough",
+		},
+	}
+
+	// A nil owner map means the caller did not prepare ownership from the full ingress snapshot.
+	assert.True(t, IsPassthroughTLSHostOwner(&ConvertOptions{}, cfg, "example.com"))
+	assert.Nil(t, PassthroughTLSHostOwner(&ConvertOptions{}, "example.com"))
+
+	// A non-nil owner map means ownership has been prepared and missing hosts have no owner.
+	options := &ConvertOptions{
+		PassthroughTLSHostOwners: map[string]*config.Config{},
+	}
+	assert.False(t, IsPassthroughTLSHostOwner(options, cfg, "example.com"))
+	assert.Nil(t, PassthroughTLSHostOwner(options, "example.com"))
+
+	options.PassthroughTLSHostOwners["example.com"] = cfg
+	assert.True(t, IsPassthroughTLSHostOwner(options, cfg, "example.com"))
+	assert.Equal(t, cfg, PassthroughTLSHostOwner(options, "example.com"))
+}
+
 func TestIngressDomainCache(t *testing.T) {
 	cache := NewIngressDomainCache()
 	assert.NotNil(t, cache)

--- a/pkg/ingress/kube/common/model_test.go
+++ b/pkg/ingress/kube/common/model_test.go
@@ -18,9 +18,21 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	networking "istio.io/api/networking/v1alpha3"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pkg/config"
 )
+
+func TestWildcardHostForSSLPassthrough(t *testing.T) {
+	server := CreateSSLPassthroughServer("", 443, "")
+	assert.Equal(t, []string{"*"}, server.Hosts)
+
+	vs := NewWrapperVirtualService("", &WrapperConfig{})
+	assert.Equal(t, []string{"*"}, vs.VirtualService.Hosts)
+
+	route := CreateTLSRoute("", []*networking.RouteDestination{{Weight: 100}})
+	assert.Equal(t, []string{"*"}, route.Match[0].SniHosts)
+}
 
 func TestIngressDomainCache(t *testing.T) {
 	cache := NewIngressDomainCache()

--- a/pkg/ingress/kube/common/model_test.go
+++ b/pkg/ingress/kube/common/model_test.go
@@ -32,6 +32,8 @@ func TestWildcardHostForSSLPassthrough(t *testing.T) {
 
 	route := CreateTLSRoute("", []*networking.RouteDestination{{Weight: 100}})
 	assert.Equal(t, []string{"*"}, route.Match[0].SniHosts)
+	vs.VirtualService.Tls = append(vs.VirtualService.Tls, route)
+	assert.True(t, vs.HasTLSRouteForHost(""))
 }
 
 func TestIngressDomainCache(t *testing.T) {

--- a/pkg/ingress/kube/ingress/controller.go
+++ b/pkg/ingress/kube/ingress/controller.go
@@ -429,6 +429,19 @@ func (c *controller) ConvertGateway(convertOptions *common.ConvertOptions, wrapp
 			if _, ok := rootHTTPIngressPath(rule.HTTP.Paths); !ok {
 				continue
 			}
+			if !common.IsSSLPassthroughTLSHostOwner(convertOptions, cfg, rule.Host) {
+				if common.IsDuplicateTLSHost(convertOptions, cfg, rule.Host) {
+					domainBuilder.Protocol = common.HTTPS
+					domainBuilder.Event = common.DuplicatedTls
+					domainBuilder.PreIngress = common.SSLPassthroughTLSHostOwner(convertOptions, rule.Host)
+					if domainBuilder.PreIngress == nil && preDomainBuilder != nil {
+						domainBuilder.PreIngress = preDomainBuilder.Ingress
+					}
+					convertOptions.IngressDomainCache.Invalid = append(convertOptions.IngressDomainCache.Invalid,
+						domainBuilder.Build())
+				}
+				continue
+			}
 
 			domainBuilder.Protocol = common.HTTPS
 			if wrapperGateway.IsHTTPS() {
@@ -495,6 +508,18 @@ func (c *controller) ConvertGateway(convertOptions *common.ConvertOptions, wrapp
 		domainBuilder.Protocol = common.HTTPS
 
 		domainBuilder.SecretName = path.Join(c.options.ClusterId.String(), cfg.Namespace, secretName)
+
+		if common.IsDuplicateTLSHost(convertOptions, cfg, rule.Host) {
+			domainBuilder.Event = common.DuplicatedTls
+			if sslPassthroughOwner := convertOptions.SSLPassthroughTLSHosts[rule.Host]; sslPassthroughOwner != nil {
+				domainBuilder.PreIngress = sslPassthroughOwner
+			} else if preDomainBuilder != nil {
+				domainBuilder.PreIngress = preDomainBuilder.Ingress
+			}
+			convertOptions.IngressDomainCache.Invalid = append(convertOptions.IngressDomainCache.Invalid,
+				domainBuilder.Build())
+			continue
+		}
 
 		// There is a matching secret and the gateway has already a tls secret.
 		// We should report the duplicated tls secret event.

--- a/pkg/ingress/kube/ingress/controller.go
+++ b/pkg/ingress/kube/ingress/controller.go
@@ -422,6 +422,32 @@ func (c *controller) ConvertGateway(convertOptions *common.ConvertOptions, wrapp
 			}
 		}
 
+		if wrapper.AnnotationsConfig.IsSSLPassthrough() {
+			if rule.HTTP == nil || len(rule.HTTP.Paths) == 0 {
+				continue
+			}
+			if _, ok := rootHTTPIngressPath(rule.HTTP.Paths); !ok {
+				continue
+			}
+
+			domainBuilder.Protocol = common.HTTPS
+			if wrapperGateway.IsHTTPS() {
+				if common.SameConfig(preDomainBuilder.Ingress, cfg) {
+					continue
+				}
+				domainBuilder.Event = common.DuplicatedTls
+				domainBuilder.PreIngress = preDomainBuilder.Ingress
+				common.AddDuplicateTLSHost(convertOptions, cfg, rule.Host)
+				convertOptions.IngressDomainCache.Invalid = append(convertOptions.IngressDomainCache.Invalid,
+					domainBuilder.Build())
+				continue
+			}
+			wrapperGateway.Gateway.Servers = append(wrapperGateway.Gateway.Servers,
+				common.CreateSSLPassthroughServer(rule.Host, c.options.GatewayHttpsPort, c.options.ClusterId))
+			convertOptions.IngressDomainCache.Valid[rule.Host] = domainBuilder
+			continue
+		}
+
 		// There are no tls settings, so just skip.
 		if len(ingressV1Beta.TLS) == 0 {
 			continue
@@ -475,6 +501,7 @@ func (c *controller) ConvertGateway(convertOptions *common.ConvertOptions, wrapp
 		if wrapperGateway.IsHTTPS() {
 			domainBuilder.Event = common.DuplicatedTls
 			domainBuilder.PreIngress = preDomainBuilder.Ingress
+			common.AddDuplicateTLSHost(convertOptions, cfg, rule.Host)
 			convertOptions.IngressDomainCache.Invalid = append(convertOptions.IngressDomainCache.Invalid,
 				domainBuilder.Build())
 			continue
@@ -514,6 +541,21 @@ func (c *controller) ConvertHTTPRoute(convertOptions *common.ConvertOptions, wra
 		convertOptions.CanaryIngresses = append(convertOptions.CanaryIngresses, wrapper)
 		return nil
 	}
+
+	if convertOptions.Route2Ingress == nil {
+		convertOptions.Route2Ingress = map[string]*common.WrapperConfigWithRuleKey{}
+	}
+	if convertOptions.IngressRouteCache == nil {
+		convertOptions.IngressRouteCache = common.NewIngressRouteCache()
+	}
+	if convertOptions.VirtualServices == nil {
+		convertOptions.VirtualServices = map[string]*common.WrapperVirtualService{}
+	}
+	if convertOptions.HTTPRoutes == nil {
+		convertOptions.HTTPRoutes = map[string][]*common.WrapperHTTPRoute{}
+	}
+
+	sslPassthrough := wrapper.AnnotationsConfig.IsSSLPassthrough()
 
 	cfg := wrapper.Config
 	ingressV1, ok := cfg.Spec.(ingress.IngressSpec)
@@ -579,7 +621,11 @@ func (c *controller) ConvertHTTPRoute(convertOptions *common.ConvertOptions, wra
 					pathType = common.PrefixRegex
 				}
 			} else {
-				switch *httpPath.PathType {
+				ingressPathType := defaultPathType
+				if httpPath.PathType != nil {
+					ingressPathType = *httpPath.PathType
+				}
+				switch ingressPathType {
 				case ingress.PathTypeExact:
 					pathType = common.Exact
 				case ingress.PathTypePrefix:
@@ -661,7 +707,74 @@ func (c *controller) ConvertHTTPRoute(convertOptions *common.ConvertOptions, wra
 		common.SortHTTPRoutes(routes)
 	}
 
+	if sslPassthrough {
+		return c.ConvertTLSRoute(convertOptions, wrapper)
+	}
+
 	return nil
+}
+
+func (c *controller) ConvertTLSRoute(convertOptions *common.ConvertOptions, wrapper *common.WrapperConfig) error {
+	if convertOptions.VirtualServices == nil {
+		convertOptions.VirtualServices = map[string]*common.WrapperVirtualService{}
+	}
+
+	cfg := wrapper.Config
+	ingressV1Beta, ok := cfg.Spec.(ingress.IngressSpec)
+	if !ok {
+		common.IncrementInvalidIngress(c.options.ClusterId, common.Unknown)
+		return fmt.Errorf("convert type is invalid in cluster %s", c.options.ClusterId)
+	}
+	if len(ingressV1Beta.Rules) == 0 {
+		common.IncrementInvalidIngress(c.options.ClusterId, common.EmptyRule)
+		return fmt.Errorf("invalid ingress rule %s:%s in cluster %s, `rules` must be specified", cfg.Namespace, cfg.Name, c.options.ClusterId)
+	}
+
+	for _, rule := range ingressV1Beta.Rules {
+		if common.IsDuplicateTLSHost(convertOptions, cfg, rule.Host) {
+			IngressLog.Warnf("ignore duplicated ssl passthrough ingress rule %s:%s for host %q in cluster %s", cfg.Namespace, cfg.Name, rule.Host, c.options.ClusterId)
+			continue
+		}
+
+		if rule.HTTP == nil || len(rule.HTTP.Paths) == 0 {
+			IngressLog.Warnf("invalid ssl passthrough ingress rule %s:%s for host %q in cluster %s, no paths defined", cfg.Namespace, cfg.Name, rule.Host, c.options.ClusterId)
+			continue
+		}
+
+		httpPath, ok := rootHTTPIngressPath(rule.HTTP.Paths)
+		if !ok {
+			IngressLog.Warnf("ignore ssl passthrough ingress rule %s:%s for host %q in cluster %s, root path is not defined", cfg.Namespace, cfg.Name, rule.Host, c.options.ClusterId)
+			continue
+		}
+
+		wrapperVS, exist := convertOptions.VirtualServices[rule.Host]
+		if !exist {
+			wrapperVS = common.NewWrapperVirtualService(rule.Host, wrapper)
+			convertOptions.VirtualServices[rule.Host] = wrapperVS
+		} else if wrapperVS.HasTLSRouteForHost(rule.Host) {
+			continue
+		}
+
+		routeDestination, event := c.backendToTLSRouteDestination(&httpPath.Backend, cfg.Namespace, wrapper.AnnotationsConfig.Destination)
+		if event != common.Normal {
+			common.IncrementInvalidIngress(c.options.ClusterId, event)
+			continue
+		}
+
+		wrapperVS.VirtualService.Tls = append(wrapperVS.VirtualService.Tls,
+			common.CreateTLSRoute(rule.Host, routeDestination))
+	}
+
+	return nil
+}
+
+func rootHTTPIngressPath(paths []ingress.HTTPIngressPath) (*ingress.HTTPIngressPath, bool) {
+	for idx := range paths {
+		if paths[idx].Path == "" || paths[idx].Path == "/" {
+			return &paths[idx], true
+		}
+	}
+	return nil, false
 }
 
 func (c *controller) ApplyDefaultBackend(convertOptions *common.ConvertOptions, wrapper *common.WrapperConfig) error {
@@ -790,7 +903,11 @@ func (c *controller) ApplyCanaryIngress(convertOptions *common.ConvertOptions, w
 					pathType = common.PrefixRegex
 				}
 			} else {
-				switch *httpPath.PathType {
+				ingressPathType := defaultPathType
+				if httpPath.PathType != nil {
+					ingressPathType = *httpPath.PathType
+				}
+				switch ingressPathType {
 				case ingress.PathTypeExact:
 					pathType = common.Exact
 				case ingress.PathTypePrefix:
@@ -1090,6 +1207,53 @@ func (c *controller) backendToRouteDestination(backend *ingress.IngressBackend, 
 			Weight: 100,
 		},
 	}, common.Normal
+}
+
+func (c *controller) backendToTLSRouteDestination(backend *ingress.IngressBackend, namespace string,
+	config *annotations.DestinationConfig,
+) ([]*networking.RouteDestination, common.Event) {
+	if backend == nil {
+		return nil, common.InvalidBackendService
+	}
+
+	if backend.ServiceName == "" {
+		if config != nil {
+			return httpRouteDestinationToRouteDestination(config.McpDestination), common.Normal
+		}
+		return nil, common.InvalidBackendService
+	}
+
+	port := &networking.PortSelector{}
+	if backend.ServicePort.Type == intstr.Int {
+		port.Number = uint32(backend.ServicePort.IntVal)
+	} else {
+		resolvedPort, err := resolveNamedPort(backend, namespace, c.serviceLister)
+		if err != nil {
+			return nil, common.PortNameResolveError
+		}
+		port.Number = uint32(resolvedPort)
+	}
+
+	return []*networking.RouteDestination{
+		{
+			Destination: &networking.Destination{
+				Host: util.CreateServiceFQDN(namespace, backend.ServiceName),
+				Port: port,
+			},
+			Weight: 100,
+		},
+	}, common.Normal
+}
+
+func httpRouteDestinationToRouteDestination(destinations []*networking.HTTPRouteDestination) []*networking.RouteDestination {
+	out := make([]*networking.RouteDestination, 0, len(destinations))
+	for _, destination := range destinations {
+		out = append(out, &networking.RouteDestination{
+			Destination: destination.Destination,
+			Weight:      destination.Weight,
+		})
+	}
+	return out
 }
 
 func resolveNamedPort(backend *ingress.IngressBackend, namespace string, serviceLister listerv1.ServiceLister) (int32, error) {

--- a/pkg/ingress/kube/ingress/controller.go
+++ b/pkg/ingress/kube/ingress/controller.go
@@ -409,7 +409,7 @@ func (c *controller) ConvertGateway(convertOptions *common.ConvertOptions, wrapp
 					Protocol: string(protocol.HTTP),
 					Name:     common.CreateConvertedName("http-80-ingress", c.options.ClusterId.String()),
 				},
-				Hosts: []string{rule.Host},
+				Hosts: []string{common.WildcardHost(rule.Host)},
 			})
 
 			// Add new gateway, builder
@@ -538,7 +538,7 @@ func (c *controller) ConvertGateway(convertOptions *common.ConvertOptions, wrapp
 				Protocol: string(protocol.HTTPS),
 				Name:     common.CreateConvertedName("https-443-ingress", c.options.ClusterId.String()),
 			},
-			Hosts: []string{rule.Host},
+			Hosts: []string{common.WildcardHost(rule.Host)},
 			Tls: &networking.ServerTLSSettings{
 				Mode:           networking.ServerTLSSettings_SIMPLE,
 				CredentialName: credentials.ToKubernetesIngressResource(c.options.RawClusterId, secretNamespace, secretName),

--- a/pkg/ingress/kube/ingress/controller.go
+++ b/pkg/ingress/kube/ingress/controller.go
@@ -429,14 +429,19 @@ func (c *controller) ConvertGateway(convertOptions *common.ConvertOptions, wrapp
 			if _, ok := rootHTTPIngressPath(rule.HTTP.Paths); !ok {
 				continue
 			}
+			if passthroughOwner := common.PassthroughTLSHostOwner(convertOptions, rule.Host); passthroughOwner != nil && !common.SameConfig(passthroughOwner, cfg) {
+				domainBuilder.Protocol = common.HTTPS
+				domainBuilder.Event = common.DuplicatedTls
+				domainBuilder.PreIngress = passthroughOwner
+				convertOptions.IngressDomainCache.Invalid = append(convertOptions.IngressDomainCache.Invalid,
+					domainBuilder.Build())
+				continue
+			}
 			if !common.IsPassthroughTLSHostOwner(convertOptions, cfg, rule.Host) {
-				if common.IsSuppressedTLSHost(convertOptions, cfg, rule.Host) {
+				if preDomainBuilder != nil {
 					domainBuilder.Protocol = common.HTTPS
 					domainBuilder.Event = common.DuplicatedTls
-					domainBuilder.PreIngress = common.PassthroughTLSHostOwner(convertOptions, rule.Host)
-					if domainBuilder.PreIngress == nil && preDomainBuilder != nil {
-						domainBuilder.PreIngress = preDomainBuilder.Ingress
-					}
+					domainBuilder.PreIngress = preDomainBuilder.Ingress
 					convertOptions.IngressDomainCache.Invalid = append(convertOptions.IngressDomainCache.Invalid,
 						domainBuilder.Build())
 				}
@@ -450,7 +455,6 @@ func (c *controller) ConvertGateway(convertOptions *common.ConvertOptions, wrapp
 				}
 				domainBuilder.Event = common.DuplicatedTls
 				domainBuilder.PreIngress = preDomainBuilder.Ingress
-				common.AddSuppressedTLSHost(convertOptions, cfg, rule.Host)
 				convertOptions.IngressDomainCache.Invalid = append(convertOptions.IngressDomainCache.Invalid,
 					domainBuilder.Build())
 				continue
@@ -509,13 +513,9 @@ func (c *controller) ConvertGateway(convertOptions *common.ConvertOptions, wrapp
 
 		domainBuilder.SecretName = path.Join(c.options.ClusterId.String(), cfg.Namespace, secretName)
 
-		if common.IsSuppressedTLSHost(convertOptions, cfg, rule.Host) {
+		if passthroughOwner := common.PassthroughTLSHostOwner(convertOptions, rule.Host); passthroughOwner != nil && !common.SameConfig(passthroughOwner, cfg) {
 			domainBuilder.Event = common.DuplicatedTls
-			if sslPassthroughOwner := convertOptions.PassthroughTLSHostOwners[rule.Host]; sslPassthroughOwner != nil {
-				domainBuilder.PreIngress = sslPassthroughOwner
-			} else if preDomainBuilder != nil {
-				domainBuilder.PreIngress = preDomainBuilder.Ingress
-			}
+			domainBuilder.PreIngress = passthroughOwner
 			convertOptions.IngressDomainCache.Invalid = append(convertOptions.IngressDomainCache.Invalid,
 				domainBuilder.Build())
 			continue
@@ -526,7 +526,6 @@ func (c *controller) ConvertGateway(convertOptions *common.ConvertOptions, wrapp
 		if wrapperGateway.IsHTTPS() {
 			domainBuilder.Event = common.DuplicatedTls
 			domainBuilder.PreIngress = preDomainBuilder.Ingress
-			common.AddSuppressedTLSHost(convertOptions, cfg, rule.Host)
 			convertOptions.IngressDomainCache.Invalid = append(convertOptions.IngressDomainCache.Invalid,
 				domainBuilder.Build())
 			continue
@@ -758,7 +757,7 @@ func (c *controller) ConvertTLSRoute(convertOptions *common.ConvertOptions, wrap
 	}
 
 	for _, rule := range ingressV1Beta.Rules {
-		if common.IsSuppressedTLSHost(convertOptions, cfg, rule.Host) {
+		if !common.IsPassthroughTLSHostOwner(convertOptions, cfg, rule.Host) {
 			IngressLog.Warnf("ignore duplicated ssl passthrough ingress rule %s:%s for host %q in cluster %s", cfg.Namespace, cfg.Name, rule.Host, c.options.ClusterId)
 			continue
 		}

--- a/pkg/ingress/kube/ingress/controller.go
+++ b/pkg/ingress/kube/ingress/controller.go
@@ -613,12 +613,7 @@ func (c *controller) ConvertHTTPRoute(convertOptions *common.ConvertOptions, wra
 
 		wrapperVS, exist := convertOptions.VirtualServices[rule.Host]
 		if !exist {
-			wrapperVS = &common.WrapperVirtualService{
-				VirtualService: &networking.VirtualService{
-					Hosts: []string{rule.Host},
-				},
-				WrapperConfig: wrapper,
-			}
+			wrapperVS = common.NewWrapperVirtualService(rule.Host, wrapper)
 			convertOptions.VirtualServices[rule.Host] = wrapperVS
 		}
 
@@ -829,12 +824,7 @@ func (c *controller) ApplyDefaultBackend(convertOptions *common.ConvertOptions, 
 		wirecardVS, exist := convertOptions.VirtualServices[host]
 		if !exist || !wirecardVS.ConfiguredDefaultBackend {
 			if !exist {
-				wirecardVS = &common.WrapperVirtualService{
-					VirtualService: &networking.VirtualService{
-						Hosts: []string{host},
-					},
-					WrapperConfig: wrapper,
-				}
+				wirecardVS = common.NewWrapperVirtualService(host, wrapper)
 			}
 
 			specDefaultBackend := c.createDefaultRoute(wrapper, ingressV1Beta1.Backend, "*")

--- a/pkg/ingress/kube/ingress/controller.go
+++ b/pkg/ingress/kube/ingress/controller.go
@@ -429,11 +429,11 @@ func (c *controller) ConvertGateway(convertOptions *common.ConvertOptions, wrapp
 			if _, ok := rootHTTPIngressPath(rule.HTTP.Paths); !ok {
 				continue
 			}
-			if !common.IsSSLPassthroughTLSHostOwner(convertOptions, cfg, rule.Host) {
-				if common.IsDuplicateTLSHost(convertOptions, cfg, rule.Host) {
+			if !common.IsPassthroughTLSHostOwner(convertOptions, cfg, rule.Host) {
+				if common.IsSuppressedTLSHost(convertOptions, cfg, rule.Host) {
 					domainBuilder.Protocol = common.HTTPS
 					domainBuilder.Event = common.DuplicatedTls
-					domainBuilder.PreIngress = common.SSLPassthroughTLSHostOwner(convertOptions, rule.Host)
+					domainBuilder.PreIngress = common.PassthroughTLSHostOwner(convertOptions, rule.Host)
 					if domainBuilder.PreIngress == nil && preDomainBuilder != nil {
 						domainBuilder.PreIngress = preDomainBuilder.Ingress
 					}
@@ -450,7 +450,7 @@ func (c *controller) ConvertGateway(convertOptions *common.ConvertOptions, wrapp
 				}
 				domainBuilder.Event = common.DuplicatedTls
 				domainBuilder.PreIngress = preDomainBuilder.Ingress
-				common.AddDuplicateTLSHost(convertOptions, cfg, rule.Host)
+				common.AddSuppressedTLSHost(convertOptions, cfg, rule.Host)
 				convertOptions.IngressDomainCache.Invalid = append(convertOptions.IngressDomainCache.Invalid,
 					domainBuilder.Build())
 				continue
@@ -509,9 +509,9 @@ func (c *controller) ConvertGateway(convertOptions *common.ConvertOptions, wrapp
 
 		domainBuilder.SecretName = path.Join(c.options.ClusterId.String(), cfg.Namespace, secretName)
 
-		if common.IsDuplicateTLSHost(convertOptions, cfg, rule.Host) {
+		if common.IsSuppressedTLSHost(convertOptions, cfg, rule.Host) {
 			domainBuilder.Event = common.DuplicatedTls
-			if sslPassthroughOwner := convertOptions.SSLPassthroughTLSHosts[rule.Host]; sslPassthroughOwner != nil {
+			if sslPassthroughOwner := convertOptions.PassthroughTLSHostOwners[rule.Host]; sslPassthroughOwner != nil {
 				domainBuilder.PreIngress = sslPassthroughOwner
 			} else if preDomainBuilder != nil {
 				domainBuilder.PreIngress = preDomainBuilder.Ingress
@@ -526,7 +526,7 @@ func (c *controller) ConvertGateway(convertOptions *common.ConvertOptions, wrapp
 		if wrapperGateway.IsHTTPS() {
 			domainBuilder.Event = common.DuplicatedTls
 			domainBuilder.PreIngress = preDomainBuilder.Ingress
-			common.AddDuplicateTLSHost(convertOptions, cfg, rule.Host)
+			common.AddSuppressedTLSHost(convertOptions, cfg, rule.Host)
 			convertOptions.IngressDomainCache.Invalid = append(convertOptions.IngressDomainCache.Invalid,
 				domainBuilder.Build())
 			continue
@@ -758,7 +758,7 @@ func (c *controller) ConvertTLSRoute(convertOptions *common.ConvertOptions, wrap
 	}
 
 	for _, rule := range ingressV1Beta.Rules {
-		if common.IsDuplicateTLSHost(convertOptions, cfg, rule.Host) {
+		if common.IsSuppressedTLSHost(convertOptions, cfg, rule.Host) {
 			IngressLog.Warnf("ignore duplicated ssl passthrough ingress rule %s:%s for host %q in cluster %s", cfg.Namespace, cfg.Name, rule.Host, c.options.ClusterId)
 			continue
 		}

--- a/pkg/ingress/kube/ingress/controller.go
+++ b/pkg/ingress/kube/ingress/controller.go
@@ -422,29 +422,13 @@ func (c *controller) ConvertGateway(convertOptions *common.ConvertOptions, wrapp
 			}
 		}
 
-		if wrapper.AnnotationsConfig.IsSSLPassthrough() {
+		passthroughOwner := common.PassthroughTLSHostOwner(convertOptions, rule.Host)
+		standaloneSSLPassthrough := convertOptions.PassthroughTLSHostOwners == nil && wrapper.AnnotationsConfig.IsSSLPassthrough()
+		if common.SameConfig(passthroughOwner, cfg) || standaloneSSLPassthrough {
 			if rule.HTTP == nil || len(rule.HTTP.Paths) == 0 {
 				continue
 			}
 			if _, ok := rootHTTPIngressPath(rule.HTTP.Paths); !ok {
-				continue
-			}
-			if passthroughOwner := common.PassthroughTLSHostOwner(convertOptions, rule.Host); passthroughOwner != nil && !common.SameConfig(passthroughOwner, cfg) {
-				domainBuilder.Protocol = common.HTTPS
-				domainBuilder.Event = common.DuplicatedTls
-				domainBuilder.PreIngress = passthroughOwner
-				convertOptions.IngressDomainCache.Invalid = append(convertOptions.IngressDomainCache.Invalid,
-					domainBuilder.Build())
-				continue
-			}
-			if !common.IsPassthroughTLSHostOwner(convertOptions, cfg, rule.Host) {
-				if preDomainBuilder != nil {
-					domainBuilder.Protocol = common.HTTPS
-					domainBuilder.Event = common.DuplicatedTls
-					domainBuilder.PreIngress = preDomainBuilder.Ingress
-					convertOptions.IngressDomainCache.Invalid = append(convertOptions.IngressDomainCache.Invalid,
-						domainBuilder.Build())
-				}
 				continue
 			}
 
@@ -462,6 +446,18 @@ func (c *controller) ConvertGateway(convertOptions *common.ConvertOptions, wrapp
 			wrapperGateway.Gateway.Servers = append(wrapperGateway.Gateway.Servers,
 				common.CreateSSLPassthroughServer(rule.Host, c.options.GatewayHttpsPort, c.options.ClusterId))
 			convertOptions.IngressDomainCache.Valid[rule.Host] = domainBuilder
+			continue
+		}
+		if wrapper.AnnotationsConfig.IsSSLPassthrough() {
+			if rule.HTTP != nil {
+				if _, ok := rootHTTPIngressPath(rule.HTTP.Paths); ok && passthroughOwner != nil {
+					domainBuilder.Protocol = common.HTTPS
+					domainBuilder.Event = common.DuplicatedTls
+					domainBuilder.PreIngress = passthroughOwner
+					convertOptions.IngressDomainCache.Invalid = append(convertOptions.IngressDomainCache.Invalid,
+						domainBuilder.Build())
+				}
+			}
 			continue
 		}
 
@@ -513,7 +509,7 @@ func (c *controller) ConvertGateway(convertOptions *common.ConvertOptions, wrapp
 
 		domainBuilder.SecretName = path.Join(c.options.ClusterId.String(), cfg.Namespace, secretName)
 
-		if passthroughOwner := common.PassthroughTLSHostOwner(convertOptions, rule.Host); passthroughOwner != nil && !common.SameConfig(passthroughOwner, cfg) {
+		if passthroughOwner != nil {
 			domainBuilder.Event = common.DuplicatedTls
 			domainBuilder.PreIngress = passthroughOwner
 			convertOptions.IngressDomainCache.Invalid = append(convertOptions.IngressDomainCache.Invalid,
@@ -578,8 +574,6 @@ func (c *controller) ConvertHTTPRoute(convertOptions *common.ConvertOptions, wra
 	if convertOptions.HTTPRoutes == nil {
 		convertOptions.HTTPRoutes = map[string][]*common.WrapperHTTPRoute{}
 	}
-
-	sslPassthrough := wrapper.AnnotationsConfig.IsSSLPassthrough()
 
 	cfg := wrapper.Config
 	ingressV1, ok := cfg.Spec.(ingress.IngressSpec)
@@ -726,7 +720,8 @@ func (c *controller) ConvertHTTPRoute(convertOptions *common.ConvertOptions, wra
 		common.SortHTTPRoutes(routes)
 	}
 
-	if sslPassthrough {
+	if common.HasPassthroughTLSHostOwner(convertOptions, cfg) ||
+		(convertOptions.PassthroughTLSHostOwners == nil && wrapper.AnnotationsConfig.IsSSLPassthrough()) {
 		return c.ConvertTLSRoute(convertOptions, wrapper)
 	}
 

--- a/pkg/ingress/kube/ingress/controller.go
+++ b/pkg/ingress/kube/ingress/controller.go
@@ -735,6 +735,13 @@ func (c *controller) ConvertHTTPRoute(convertOptions *common.ConvertOptions, wra
 }
 
 func (c *controller) ConvertTLSRoute(convertOptions *common.ConvertOptions, wrapper *common.WrapperConfig) error {
+	if convertOptions == nil {
+		return fmt.Errorf("convertOptions is nil")
+	}
+	if wrapper == nil {
+		return fmt.Errorf("wrapperConfig is nil")
+	}
+
 	if convertOptions.VirtualServices == nil {
 		convertOptions.VirtualServices = map[string]*common.WrapperVirtualService{}
 	}

--- a/pkg/ingress/kube/ingress/controller.go
+++ b/pkg/ingress/kube/ingress/controller.go
@@ -1242,7 +1242,7 @@ func (c *controller) backendToTLSRouteDestination(backend *ingress.IngressBacken
 	}
 
 	if backend.ServiceName == "" {
-		if config != nil {
+		if config != nil && len(config.McpDestination) > 0 {
 			return httpRouteDestinationToRouteDestination(config.McpDestination), common.Normal
 		}
 		return nil, common.InvalidBackendService

--- a/pkg/ingress/kube/ingress/controller_test.go
+++ b/pkg/ingress/kube/ingress/controller_test.go
@@ -475,6 +475,81 @@ func TestBackendToTLSRouteDestinationRejectsEmptyMCPDestination(t *testing.T) {
 	}
 }
 
+func TestSSLPassthroughUsesFirstRootOwnerWhenLaterIngressEnablesPassthrough(t *testing.T) {
+	c := controller{
+		options: common.Options{
+			GatewayHttpPort:  80,
+			GatewayHttpsPort: 443,
+		},
+	}
+	root := &common.WrapperConfig{
+		Config: &config.Config{
+			Meta: config.Meta{
+				Namespace: "default",
+				Name:      "root",
+			},
+			Spec: ingress.IngressSpec{
+				Rules: []ingress.IngressRule{
+					ingressV1Beta1Rule("example.com", ingressV1Beta1Path("/", "root", 443)),
+				},
+			},
+		},
+		AnnotationsConfig: &annotations.Ingress{},
+	}
+	passthrough := &common.WrapperConfig{
+		Config: &config.Config{
+			Meta: config.Meta{
+				Namespace: "default",
+				Name:      "passthrough",
+			},
+			Spec: ingress.IngressSpec{
+				Rules: []ingress.IngressRule{
+					ingressV1Beta1Rule("example.com", ingressV1Beta1Path("/passthrough", "passthrough", 443)),
+				},
+			},
+		},
+		AnnotationsConfig: &annotations.Ingress{
+			SSLPassthrough: &annotations.SSLPassthroughConfig{Enabled: true},
+		},
+	}
+
+	options := &common.ConvertOptions{
+		Gateways:                 map[string]*common.WrapperGateway{},
+		IngressDomainCache:       common.NewIngressDomainCache(),
+		PassthroughTLSHostOwners: map[string]*config.Config{"example.com": root.Config},
+	}
+	if err := c.ConvertGateway(options, root, nil); err != nil {
+		t.Fatalf("ConvertGateway(root) error = %v", err)
+	}
+	if err := c.ConvertGateway(options, passthrough, nil); err != nil {
+		t.Fatalf("ConvertGateway(passthrough) error = %v", err)
+	}
+	gateway := options.Gateways["example.com"].Gateway
+	if len(gateway.Servers) != 2 {
+		t.Fatalf("server count mismatch, want 2, got %d", len(gateway.Servers))
+	}
+	if gateway.Servers[1].Tls.GetMode() != v1alpha3.ServerTLSSettings_PASSTHROUGH {
+		t.Fatalf("tls mode mismatch, want PASSTHROUGH, got %s", gateway.Servers[1].Tls.GetMode())
+	}
+
+	routeOptions := &common.ConvertOptions{
+		PassthroughTLSHostOwners: map[string]*config.Config{"example.com": root.Config},
+	}
+	if err := c.ConvertHTTPRoute(routeOptions, root); err != nil {
+		t.Fatalf("ConvertHTTPRoute(root) error = %v", err)
+	}
+	if err := c.ConvertHTTPRoute(routeOptions, passthrough); err != nil {
+		t.Fatalf("ConvertHTTPRoute(passthrough) error = %v", err)
+	}
+	routes := routeOptions.VirtualServices["example.com"].VirtualService.Tls
+	if len(routes) != 1 {
+		t.Fatalf("tls route count mismatch, want 1, got %d", len(routes))
+	}
+	if got := routes[0].Route[0].Destination.Host; got != "root.default.svc.cluster.local" {
+		t.Fatalf("destination host mismatch, want root.default.svc.cluster.local, got %s", got)
+	}
+}
+
 func TestSSLPassthroughNonRootIngressDoesNotBlockLaterRootIngress(t *testing.T) {
 	c := controller{
 		options: common.Options{

--- a/pkg/ingress/kube/ingress/controller_test.go
+++ b/pkg/ingress/kube/ingress/controller_test.go
@@ -16,9 +16,11 @@ package ingress
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/alibaba/higress/v2/pkg/cert"
 	"github.com/google/go-cmp/cmp"
 	"istio.io/api/networking/v1alpha3"
 	"istio.io/istio/pilot/pkg/model"
@@ -345,6 +347,106 @@ func TestSSLPassthroughSkipsDuplicatedTLSHost(t *testing.T) {
 	}
 	if len(options.VirtualServices) != 0 {
 		t.Fatalf("unexpected virtual services: %+v", options.VirtualServices)
+	}
+}
+
+func TestSSLPassthroughDuplicateTLSHostUsesExistingGatewayOwner(t *testing.T) {
+	c := controller{
+		options: common.Options{
+			GatewayHttpPort:  80,
+			GatewayHttpsPort: 443,
+		},
+	}
+	primary := &common.WrapperConfig{
+		Config: &config.Config{
+			Meta: config.Meta{
+				Namespace: "default",
+				Name:      "tls-primary",
+			},
+			Spec: ingress.IngressSpec{
+				TLS: []ingress.IngressTLS{
+					{Hosts: []string{"example.com"}},
+				},
+				Rules: []ingress.IngressRule{
+					{
+						Host: "example.com",
+						IngressRuleValue: ingress.IngressRuleValue{
+							HTTP: &ingress.HTTPIngressRuleValue{
+								Paths: []ingress.HTTPIngressPath{
+									{
+										Path: "/",
+										Backend: ingress.IngressBackend{
+											ServiceName: "primary",
+											ServicePort: intstr.FromInt(443),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		AnnotationsConfig: &annotations.Ingress{},
+	}
+	duplicate := &common.WrapperConfig{
+		Config: &config.Config{
+			Meta: config.Meta{
+				Namespace: "default",
+				Name:      "tls-passthrough-duplicate",
+			},
+			Spec: ingress.IngressSpec{
+				Rules: []ingress.IngressRule{
+					{
+						Host: "example.com",
+						IngressRuleValue: ingress.IngressRuleValue{
+							HTTP: &ingress.HTTPIngressRuleValue{
+								Paths: []ingress.HTTPIngressPath{
+									{
+										Path: "/",
+										Backend: ingress.IngressBackend{
+											ServiceName: "duplicate",
+											ServicePort: intstr.FromInt(443),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		AnnotationsConfig: &annotations.Ingress{
+			SSLPassthrough: &annotations.SSLPassthroughConfig{Enabled: true},
+		},
+	}
+	httpsCredentialConfig := &cert.Config{
+		CredentialConfig: []cert.CredentialEntry{
+			{
+				Domains:   []string{"example.com"},
+				TLSSecret: "default/example-tls",
+			},
+		},
+	}
+
+	options := &common.ConvertOptions{
+		Gateways:           map[string]*common.WrapperGateway{},
+		IngressDomainCache: common.NewIngressDomainCache(),
+		DuplicateTLSHosts:  map[common.TLSHostKey]struct{}{common.NewTLSHostKey(duplicate.Config, "example.com"): {}},
+	}
+	if err := c.ConvertGateway(options, primary, httpsCredentialConfig); err != nil {
+		t.Fatalf("ConvertGateway(primary) error = %v", err)
+	}
+	if err := c.ConvertGateway(options, duplicate, httpsCredentialConfig); err != nil {
+		t.Fatalf("ConvertGateway(duplicate) error = %v", err)
+	}
+
+	if len(options.IngressDomainCache.Invalid) != 1 {
+		t.Fatalf("invalid domain count mismatch, want 1, got %d", len(options.IngressDomainCache.Invalid))
+	}
+	invalid := options.IngressDomainCache.Invalid[0]
+	if !strings.Contains(invalid.Error, "tls-primary") {
+		t.Fatalf("invalid domain error does not reference existing gateway owner: %s", invalid.Error)
 	}
 }
 

--- a/pkg/ingress/kube/ingress/controller_test.go
+++ b/pkg/ingress/kube/ingress/controller_test.go
@@ -68,6 +68,716 @@ func TestIngressControllerApplies(t *testing.T) {
 	}
 }
 
+func TestSSLPassthroughConvertGatewayAndTLSRoute(t *testing.T) {
+	c := controller{
+		options: common.Options{
+			GatewayHttpPort:  80,
+			GatewayHttpsPort: 443,
+		},
+	}
+	wrapper := &common.WrapperConfig{
+		Config: &config.Config{
+			Meta: config.Meta{
+				Namespace: "default",
+				Name:      "tls-passthrough",
+			},
+			Spec: ingress.IngressSpec{
+				Rules: []ingress.IngressRule{
+					{
+						Host: "example.com",
+						IngressRuleValue: ingress.IngressRuleValue{
+							HTTP: &ingress.HTTPIngressRuleValue{
+								Paths: []ingress.HTTPIngressPath{
+									{
+										Path: "/",
+										Backend: ingress.IngressBackend{
+											ServiceName: "app",
+											ServicePort: intstr.FromInt(443),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		AnnotationsConfig: &annotations.Ingress{
+			SSLPassthrough: &annotations.SSLPassthroughConfig{Enabled: true},
+		},
+	}
+
+	gatewayOptions := &common.ConvertOptions{
+		Gateways:           map[string]*common.WrapperGateway{},
+		IngressDomainCache: common.NewIngressDomainCache(),
+	}
+	if err := c.ConvertGateway(gatewayOptions, wrapper, nil); err != nil {
+		t.Fatalf("ConvertGateway() error = %v", err)
+	}
+	gateway := gatewayOptions.Gateways["example.com"].Gateway
+	if len(gateway.Servers) != 2 {
+		t.Fatalf("server count mismatch, want 2, got %d", len(gateway.Servers))
+	}
+	tlsServer := gateway.Servers[1]
+	if tlsServer.Port.Protocol != "TLS" {
+		t.Fatalf("protocol mismatch, want TLS, got %s", tlsServer.Port.Protocol)
+	}
+	if tlsServer.Port.Number != 443 {
+		t.Fatalf("port mismatch, want 443, got %d", tlsServer.Port.Number)
+	}
+	if tlsServer.Tls.GetMode() != v1alpha3.ServerTLSSettings_PASSTHROUGH {
+		t.Fatalf("tls mode mismatch, want PASSTHROUGH, got %s", tlsServer.Tls.GetMode())
+	}
+
+	routeOptions := &common.ConvertOptions{}
+	if err := c.ConvertHTTPRoute(routeOptions, wrapper); err != nil {
+		t.Fatalf("ConvertHTTPRoute() error = %v", err)
+	}
+	httpRoutes := routeOptions.HTTPRoutes["example.com"]
+	if len(httpRoutes) != 1 {
+		t.Fatalf("http route count mismatch, want 1, got %d", len(httpRoutes))
+	}
+	if got := httpRoutes[0].HTTPRoute.Route[0].Destination.Host; got != "app.default.svc.cluster.local" {
+		t.Fatalf("http destination host mismatch, got %s", got)
+	}
+	routes := routeOptions.VirtualServices["example.com"].VirtualService.Tls
+	if len(routes) != 1 {
+		t.Fatalf("tls route count mismatch, want 1, got %d", len(routes))
+	}
+	route := routes[0]
+	if got := route.Match[0].SniHosts[0]; got != "example.com" {
+		t.Fatalf("sni host mismatch, want example.com, got %s", got)
+	}
+	if got := route.Route[0].Destination.Host; got != "app.default.svc.cluster.local" {
+		t.Fatalf("destination host mismatch, got %s", got)
+	}
+	if got := route.Route[0].Destination.Port.Number; got != 443 {
+		t.Fatalf("destination port mismatch, got %d", got)
+	}
+}
+
+func TestSSLPassthroughUsesConfiguredHTTPSPort(t *testing.T) {
+	c := controller{
+		options: common.Options{
+			GatewayHttpPort:  80,
+			GatewayHttpsPort: 8443,
+		},
+	}
+	wrapper := &common.WrapperConfig{
+		Config: &config.Config{
+			Meta: config.Meta{
+				Namespace: "default",
+				Name:      "tls-passthrough",
+			},
+			Spec: ingress.IngressSpec{
+				Rules: []ingress.IngressRule{
+					{
+						Host: "example.com",
+						IngressRuleValue: ingress.IngressRuleValue{
+							HTTP: &ingress.HTTPIngressRuleValue{
+								Paths: []ingress.HTTPIngressPath{
+									{
+										Path: "/",
+										Backend: ingress.IngressBackend{
+											ServiceName: "app",
+											ServicePort: intstr.FromInt(443),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		AnnotationsConfig: &annotations.Ingress{
+			SSLPassthrough: &annotations.SSLPassthroughConfig{Enabled: true},
+		},
+	}
+
+	gatewayOptions := &common.ConvertOptions{
+		Gateways:           map[string]*common.WrapperGateway{},
+		IngressDomainCache: common.NewIngressDomainCache(),
+	}
+	if err := c.ConvertGateway(gatewayOptions, wrapper, nil); err != nil {
+		t.Fatalf("ConvertGateway() error = %v", err)
+	}
+	tlsServer := gatewayOptions.Gateways["example.com"].Gateway.Servers[1]
+	if tlsServer.Port.Number != 8443 {
+		t.Fatalf("port mismatch, want 8443, got %d", tlsServer.Port.Number)
+	}
+}
+
+func TestSSLPassthroughCanaryIngressKeepsCanaryHandling(t *testing.T) {
+	c := controller{}
+	wrapper := &common.WrapperConfig{
+		Config: &config.Config{
+			Meta: config.Meta{
+				Namespace: "default",
+				Name:      "tls-passthrough-canary",
+			},
+			Spec: ingress.IngressSpec{
+				Rules: []ingress.IngressRule{
+					{
+						Host: "example.com",
+						IngressRuleValue: ingress.IngressRuleValue{
+							HTTP: &ingress.HTTPIngressRuleValue{
+								Paths: []ingress.HTTPIngressPath{
+									{
+										Path: "/",
+										Backend: ingress.IngressBackend{
+											ServiceName: "app-canary",
+											ServicePort: intstr.FromInt(443),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		AnnotationsConfig: &annotations.Ingress{
+			Canary:         &annotations.CanaryConfig{Enabled: true},
+			SSLPassthrough: &annotations.SSLPassthroughConfig{Enabled: true},
+		},
+	}
+
+	routeOptions := &common.ConvertOptions{}
+	if err := c.ConvertHTTPRoute(routeOptions, wrapper); err != nil {
+		t.Fatalf("ConvertHTTPRoute() error = %v", err)
+	}
+	if len(routeOptions.CanaryIngresses) != 1 {
+		t.Fatalf("canary ingress count mismatch, want 1, got %d", len(routeOptions.CanaryIngresses))
+	}
+	if len(routeOptions.VirtualServices) != 0 {
+		t.Fatalf("unexpected virtual services: %+v", routeOptions.VirtualServices)
+	}
+}
+
+func TestSSLPassthroughSkipsDuplicatedTLSHost(t *testing.T) {
+	c := controller{
+		options: common.Options{
+			GatewayHttpPort:  80,
+			GatewayHttpsPort: 443,
+		},
+	}
+	primary := &common.WrapperConfig{
+		Config: &config.Config{
+			Meta: config.Meta{
+				Namespace: "default",
+				Name:      "tls-passthrough-primary",
+			},
+			Spec: ingress.IngressSpec{
+				Rules: []ingress.IngressRule{
+					{
+						Host: "example.com",
+						IngressRuleValue: ingress.IngressRuleValue{
+							HTTP: &ingress.HTTPIngressRuleValue{
+								Paths: []ingress.HTTPIngressPath{
+									{
+										Path: "/",
+										Backend: ingress.IngressBackend{
+											ServiceName: "primary",
+											ServicePort: intstr.FromInt(443),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		AnnotationsConfig: &annotations.Ingress{
+			SSLPassthrough: &annotations.SSLPassthroughConfig{Enabled: true},
+		},
+	}
+	duplicate := &common.WrapperConfig{
+		Config: &config.Config{
+			Meta: config.Meta{
+				Namespace: "default",
+				Name:      "tls-passthrough-duplicate",
+			},
+			Spec: ingress.IngressSpec{
+				Rules: []ingress.IngressRule{
+					{
+						Host: "example.com",
+						IngressRuleValue: ingress.IngressRuleValue{
+							HTTP: &ingress.HTTPIngressRuleValue{
+								Paths: []ingress.HTTPIngressPath{
+									{
+										Path: "/",
+										Backend: ingress.IngressBackend{
+											ServiceName: "duplicate",
+											ServicePort: intstr.FromInt(443),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		AnnotationsConfig: &annotations.Ingress{
+			SSLPassthrough: &annotations.SSLPassthroughConfig{Enabled: true},
+		},
+	}
+
+	options := &common.ConvertOptions{
+		Gateways:           map[string]*common.WrapperGateway{},
+		IngressDomainCache: common.NewIngressDomainCache(),
+	}
+	if err := c.ConvertGateway(options, primary, nil); err != nil {
+		t.Fatalf("ConvertGateway(primary) error = %v", err)
+	}
+	if err := c.ConvertGateway(options, duplicate, nil); err != nil {
+		t.Fatalf("ConvertGateway(duplicate) error = %v", err)
+	}
+	if !common.IsDuplicateTLSHost(options, duplicate.Config, "example.com") {
+		t.Fatal("duplicate TLS host was not recorded")
+	}
+
+	options.VirtualServices = map[string]*common.WrapperVirtualService{}
+	if err := c.ConvertTLSRoute(options, duplicate); err != nil {
+		t.Fatalf("ConvertTLSRoute() error = %v", err)
+	}
+	if len(options.VirtualServices) != 0 {
+		t.Fatalf("unexpected virtual services: %+v", options.VirtualServices)
+	}
+}
+
+func TestSSLPassthroughNonRootIngressDoesNotBlockLaterRootIngress(t *testing.T) {
+	c := controller{
+		options: common.Options{
+			GatewayHttpPort:  80,
+			GatewayHttpsPort: 443,
+		},
+	}
+	nonRoot := &common.WrapperConfig{
+		Config: &config.Config{
+			Meta: config.Meta{
+				Namespace: "default",
+				Name:      "tls-passthrough-non-root",
+			},
+			Spec: ingress.IngressSpec{
+				Rules: []ingress.IngressRule{
+					ingressV1Beta1Rule("example.com", ingressV1Beta1Path("/api", "api", 8443)),
+				},
+			},
+		},
+		AnnotationsConfig: &annotations.Ingress{
+			SSLPassthrough: &annotations.SSLPassthroughConfig{Enabled: true},
+		},
+	}
+	root := &common.WrapperConfig{
+		Config: &config.Config{
+			Meta: config.Meta{
+				Namespace: "default",
+				Name:      "tls-passthrough-root",
+			},
+			Spec: ingress.IngressSpec{
+				Rules: []ingress.IngressRule{
+					ingressV1Beta1Rule("example.com", ingressV1Beta1Path("/", "root", 443)),
+				},
+			},
+		},
+		AnnotationsConfig: &annotations.Ingress{
+			SSLPassthrough: &annotations.SSLPassthroughConfig{Enabled: true},
+		},
+	}
+
+	options := &common.ConvertOptions{
+		Gateways:           map[string]*common.WrapperGateway{},
+		IngressDomainCache: common.NewIngressDomainCache(),
+	}
+	if err := c.ConvertGateway(options, nonRoot, nil); err != nil {
+		t.Fatalf("ConvertGateway(nonRoot) error = %v", err)
+	}
+	if len(options.Gateways["example.com"].Gateway.Servers) != 1 {
+		t.Fatalf("non-root ingress server count mismatch, want 1, got %d", len(options.Gateways["example.com"].Gateway.Servers))
+	}
+	if err := c.ConvertGateway(options, root, nil); err != nil {
+		t.Fatalf("ConvertGateway(root) error = %v", err)
+	}
+	if common.IsDuplicateTLSHost(options, root.Config, "example.com") {
+		t.Fatal("root ingress was recorded as duplicated")
+	}
+	if options.Gateways["example.com"].Gateway.Servers[1].Tls.GetMode() != v1alpha3.ServerTLSSettings_PASSTHROUGH {
+		t.Fatal("root ingress did not create a TLS passthrough server")
+	}
+
+	options.VirtualServices = map[string]*common.WrapperVirtualService{}
+	if err := c.ConvertTLSRoute(options, root); err != nil {
+		t.Fatalf("ConvertTLSRoute(root) error = %v", err)
+	}
+	routes := options.VirtualServices["example.com"].VirtualService.Tls
+	if len(routes) != 1 {
+		t.Fatalf("tls route count mismatch, want 1, got %d", len(routes))
+	}
+	if got := routes[0].Route[0].Destination.Host; got != "root.default.svc.cluster.local" {
+		t.Fatalf("destination host mismatch, got %s", got)
+	}
+}
+
+func TestSSLPassthroughPreservesRepeatedHostInSameIngress(t *testing.T) {
+	c := controller{
+		options: common.Options{
+			GatewayHttpPort:  80,
+			GatewayHttpsPort: 443,
+		},
+	}
+	wrapper := &common.WrapperConfig{
+		Config: &config.Config{
+			Meta: config.Meta{
+				Namespace: "default",
+				Name:      "tls-passthrough-repeated-host",
+			},
+			Spec: ingress.IngressSpec{
+				Rules: []ingress.IngressRule{
+					{
+						Host: "example.com",
+						IngressRuleValue: ingress.IngressRuleValue{
+							HTTP: &ingress.HTTPIngressRuleValue{
+								Paths: []ingress.HTTPIngressPath{
+									{
+										Path: "/health",
+										Backend: ingress.IngressBackend{
+											ServiceName: "health",
+											ServicePort: intstr.FromInt(8443),
+										},
+									},
+								},
+							},
+						},
+					},
+					{
+						Host: "example.com",
+						IngressRuleValue: ingress.IngressRuleValue{
+							HTTP: &ingress.HTTPIngressRuleValue{
+								Paths: []ingress.HTTPIngressPath{
+									{
+										Path: "/",
+										Backend: ingress.IngressBackend{
+											ServiceName: "root",
+											ServicePort: intstr.FromInt(443),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		AnnotationsConfig: &annotations.Ingress{
+			SSLPassthrough: &annotations.SSLPassthroughConfig{Enabled: true},
+		},
+	}
+
+	options := &common.ConvertOptions{
+		Gateways:           map[string]*common.WrapperGateway{},
+		IngressDomainCache: common.NewIngressDomainCache(),
+	}
+	if err := c.ConvertGateway(options, wrapper, nil); err != nil {
+		t.Fatalf("ConvertGateway() error = %v", err)
+	}
+	if common.IsDuplicateTLSHost(options, wrapper.Config, "example.com") {
+		t.Fatal("same ingress host was recorded as duplicated")
+	}
+
+	options.VirtualServices = map[string]*common.WrapperVirtualService{}
+	if err := c.ConvertTLSRoute(options, wrapper); err != nil {
+		t.Fatalf("ConvertTLSRoute() error = %v", err)
+	}
+	routes := options.VirtualServices["example.com"].VirtualService.Tls
+	if len(routes) != 1 {
+		t.Fatalf("tls route count mismatch, want 1, got %d", len(routes))
+	}
+	if got := routes[0].Route[0].Destination.Host; got != "root.default.svc.cluster.local" {
+		t.Fatalf("destination host mismatch, got %s", got)
+	}
+}
+
+func TestSSLPassthroughUsesFirstRootBackendForRepeatedHost(t *testing.T) {
+	c := controller{}
+	wrapper := &common.WrapperConfig{
+		Config: &config.Config{
+			Meta: config.Meta{
+				Namespace: "default",
+				Name:      "tls-passthrough-repeated-root",
+			},
+			Spec: ingress.IngressSpec{
+				Rules: []ingress.IngressRule{
+					{
+						Host: "example.com",
+						IngressRuleValue: ingress.IngressRuleValue{
+							HTTP: &ingress.HTTPIngressRuleValue{
+								Paths: []ingress.HTTPIngressPath{
+									{
+										Path: "/",
+										Backend: ingress.IngressBackend{
+											ServiceName: "first",
+											ServicePort: intstr.FromInt(443),
+										},
+									},
+								},
+							},
+						},
+					},
+					{
+						Host: "example.com",
+						IngressRuleValue: ingress.IngressRuleValue{
+							HTTP: &ingress.HTTPIngressRuleValue{
+								Paths: []ingress.HTTPIngressPath{
+									{
+										Path: "/",
+										Backend: ingress.IngressBackend{
+											ServiceName: "second",
+											ServicePort: intstr.FromInt(443),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		AnnotationsConfig: &annotations.Ingress{
+			SSLPassthrough: &annotations.SSLPassthroughConfig{Enabled: true},
+		},
+	}
+
+	routeOptions := &common.ConvertOptions{}
+	if err := c.ConvertHTTPRoute(routeOptions, wrapper); err != nil {
+		t.Fatalf("ConvertHTTPRoute() error = %v", err)
+	}
+	routes := routeOptions.VirtualServices["example.com"].VirtualService.Tls
+	if len(routes) != 1 {
+		t.Fatalf("tls route count mismatch, want 1, got %d", len(routes))
+	}
+	if got := routes[0].Route[0].Destination.Host; got != "first.default.svc.cluster.local" {
+		t.Fatalf("destination host mismatch, got %s", got)
+	}
+}
+
+func TestSSLPassthroughHandlesMultipleHosts(t *testing.T) {
+	c := controller{}
+	testcases := []struct {
+		name       string
+		rules      []ingress.IngressRule
+		wantHosts  []string
+		wantRoutes map[string]string
+	}{
+		{
+			name: "root path first",
+			rules: []ingress.IngressRule{
+				ingressV1Beta1Rule("first.example.com", ingressV1Beta1Path("/", "first", 443)),
+				ingressV1Beta1Rule("middle.example.com", ingressV1Beta1Path("/health", "middle", 8443)),
+				ingressV1Beta1Rule("last.example.com", ingressV1Beta1Path("/health", "last", 8443)),
+			},
+			wantHosts: []string{"first.example.com"},
+			wantRoutes: map[string]string{
+				"first.example.com": "first.default.svc.cluster.local",
+			},
+		},
+		{
+			name: "root path middle",
+			rules: []ingress.IngressRule{
+				ingressV1Beta1Rule("first.example.com", ingressV1Beta1Path("/health", "first", 8443)),
+				ingressV1Beta1Rule("middle.example.com", ingressV1Beta1Path("/", "middle", 443)),
+				ingressV1Beta1Rule("last.example.com", ingressV1Beta1Path("/health", "last", 8443)),
+			},
+			wantHosts: []string{"middle.example.com"},
+			wantRoutes: map[string]string{
+				"middle.example.com": "middle.default.svc.cluster.local",
+			},
+		},
+		{
+			name: "root path last",
+			rules: []ingress.IngressRule{
+				ingressV1Beta1Rule("first.example.com", ingressV1Beta1Path("/health", "first", 8443)),
+				ingressV1Beta1Rule("middle.example.com", ingressV1Beta1Path("/health", "middle", 8443)),
+				ingressV1Beta1Rule("last.example.com", ingressV1Beta1Path("/", "last", 443)),
+			},
+			wantHosts: []string{"last.example.com"},
+			wantRoutes: map[string]string{
+				"last.example.com": "last.default.svc.cluster.local",
+			},
+		},
+		{
+			name: "multiple root hosts",
+			rules: []ingress.IngressRule{
+				ingressV1Beta1Rule("first.example.com", ingressV1Beta1Path("/", "first", 443)),
+				ingressV1Beta1Rule("middle.example.com", ingressV1Beta1Path("/", "middle", 443)),
+				ingressV1Beta1Rule("last.example.com", ingressV1Beta1Path("/", "last", 443)),
+			},
+			wantHosts: []string{"first.example.com", "middle.example.com", "last.example.com"},
+			wantRoutes: map[string]string{
+				"first.example.com":  "first.default.svc.cluster.local",
+				"middle.example.com": "middle.default.svc.cluster.local",
+				"last.example.com":   "last.default.svc.cluster.local",
+			},
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			wrapper := &common.WrapperConfig{
+				Config: &config.Config{
+					Meta: config.Meta{
+						Namespace: "default",
+						Name:      "tls-passthrough-multi-host",
+					},
+					Spec: ingress.IngressSpec{
+						Rules: tc.rules,
+					},
+				},
+				AnnotationsConfig: &annotations.Ingress{
+					SSLPassthrough: &annotations.SSLPassthroughConfig{Enabled: true},
+				},
+			}
+
+			routeOptions := &common.ConvertOptions{}
+			if err := c.ConvertHTTPRoute(routeOptions, wrapper); err != nil {
+				t.Fatalf("ConvertHTTPRoute() error = %v", err)
+			}
+			for _, host := range tc.wantHosts {
+				routes := routeOptions.VirtualServices[host].VirtualService.Tls
+				if len(routes) != 1 {
+					t.Fatalf("tls route count mismatch for host %s, want 1, got %d", host, len(routes))
+				}
+				if got := routes[0].Route[0].Destination.Host; got != tc.wantRoutes[host] {
+					t.Fatalf("destination host mismatch for host %s, want %s, got %s", host, tc.wantRoutes[host], got)
+				}
+			}
+		})
+	}
+}
+
+func ingressV1Beta1Path(path, service string, port int32) ingress.HTTPIngressPath {
+	return ingress.HTTPIngressPath{
+		Path: path,
+		Backend: ingress.IngressBackend{
+			ServiceName: service,
+			ServicePort: intstr.FromInt(int(port)),
+		},
+	}
+}
+
+func ingressV1Beta1Rule(host string, paths ...ingress.HTTPIngressPath) ingress.IngressRule {
+	return ingress.IngressRule{
+		Host: host,
+		IngressRuleValue: ingress.IngressRuleValue{
+			HTTP: &ingress.HTTPIngressRuleValue{
+				Paths: paths,
+			},
+		},
+	}
+}
+
+func TestSSLPassthroughUsesRootPathBackend(t *testing.T) {
+	c := controller{}
+	wrapper := &common.WrapperConfig{
+		Config: &config.Config{
+			Meta: config.Meta{
+				Namespace: "default",
+				Name:      "tls-passthrough-root",
+			},
+			Spec: ingress.IngressSpec{
+				Rules: []ingress.IngressRule{
+					{
+						Host: "example.com",
+						IngressRuleValue: ingress.IngressRuleValue{
+							HTTP: &ingress.HTTPIngressRuleValue{
+								Paths: []ingress.HTTPIngressPath{
+									{
+										Path: "/api",
+										Backend: ingress.IngressBackend{
+											ServiceName: "api",
+											ServicePort: intstr.FromInt(8443),
+										},
+									},
+									{
+										Path: "/",
+										Backend: ingress.IngressBackend{
+											ServiceName: "root",
+											ServicePort: intstr.FromInt(443),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		AnnotationsConfig: &annotations.Ingress{
+			SSLPassthrough: &annotations.SSLPassthroughConfig{Enabled: true},
+		},
+	}
+
+	routeOptions := &common.ConvertOptions{}
+	if err := c.ConvertHTTPRoute(routeOptions, wrapper); err != nil {
+		t.Fatalf("ConvertHTTPRoute() error = %v", err)
+	}
+	routes := routeOptions.VirtualServices["example.com"].VirtualService.Tls
+	if len(routes) != 1 {
+		t.Fatalf("tls route count mismatch, want 1, got %d", len(routes))
+	}
+	if got := routes[0].Route[0].Destination.Host; got != "root.default.svc.cluster.local" {
+		t.Fatalf("destination host mismatch, got %s", got)
+	}
+}
+
+func TestSSLPassthroughIgnoresNonRootPath(t *testing.T) {
+	c := controller{}
+	wrapper := &common.WrapperConfig{
+		Config: &config.Config{
+			Meta: config.Meta{
+				Namespace: "default",
+				Name:      "tls-passthrough-non-root",
+			},
+			Spec: ingress.IngressSpec{
+				Rules: []ingress.IngressRule{
+					{
+						Host: "example.com",
+						IngressRuleValue: ingress.IngressRuleValue{
+							HTTP: &ingress.HTTPIngressRuleValue{
+								Paths: []ingress.HTTPIngressPath{
+									{
+										Path: "/api",
+										Backend: ingress.IngressBackend{
+											ServiceName: "api",
+											ServicePort: intstr.FromInt(8443),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		AnnotationsConfig: &annotations.Ingress{
+			SSLPassthrough: &annotations.SSLPassthroughConfig{Enabled: true},
+		},
+	}
+
+	routeOptions := &common.ConvertOptions{}
+	if err := c.ConvertHTTPRoute(routeOptions, wrapper); err != nil {
+		t.Fatalf("ConvertHTTPRoute() error = %v", err)
+	}
+	if len(routeOptions.HTTPRoutes["example.com"]) != 1 {
+		t.Fatalf("http route count mismatch, want 1, got %d", len(routeOptions.HTTPRoutes["example.com"]))
+	}
+	if routes := routeOptions.VirtualServices["example.com"].VirtualService.Tls; len(routes) != 0 {
+		t.Fatalf("unexpected tls routes: %+v", routes)
+	}
+}
+
 func testApplyCanaryIngress(t *testing.T, c common.IngressController) {
 	testcases := []struct {
 		description string

--- a/pkg/ingress/kube/ingress/controller_test.go
+++ b/pkg/ingress/kube/ingress/controller_test.go
@@ -848,6 +848,59 @@ func TestSSLPassthroughUsesRootPathBackend(t *testing.T) {
 	}
 }
 
+func TestSSLPassthroughWildcardHostKeepsVirtualServiceConsistent(t *testing.T) {
+	c := controller{}
+	wrapper := &common.WrapperConfig{
+		Config: &config.Config{
+			Meta: config.Meta{
+				Namespace: "default",
+				Name:      "tls-passthrough-wildcard",
+			},
+			Spec: ingress.IngressSpec{
+				Rules: []ingress.IngressRule{
+					{
+						IngressRuleValue: ingress.IngressRuleValue{
+							HTTP: &ingress.HTTPIngressRuleValue{
+								Paths: []ingress.HTTPIngressPath{
+									{
+										Path: "/",
+										Backend: ingress.IngressBackend{
+											ServiceName: "root",
+											ServicePort: intstr.FromInt(443),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		AnnotationsConfig: &annotations.Ingress{
+			SSLPassthrough: &annotations.SSLPassthroughConfig{Enabled: true},
+		},
+	}
+
+	routeOptions := &common.ConvertOptions{}
+	if err := c.ConvertHTTPRoute(routeOptions, wrapper); err != nil {
+		t.Fatalf("ConvertHTTPRoute() error = %v", err)
+	}
+	if err := c.ConvertTLSRoute(routeOptions, wrapper); err != nil {
+		t.Fatalf("ConvertTLSRoute() error = %v", err)
+	}
+
+	vs := routeOptions.VirtualServices[""].VirtualService
+	if got := vs.Hosts; len(got) != 1 || got[0] != "*" {
+		t.Fatalf("virtual service hosts mismatch, got %+v", got)
+	}
+	if len(vs.Tls) != 1 {
+		t.Fatalf("tls route count mismatch, want 1, got %d", len(vs.Tls))
+	}
+	if got := vs.Tls[0].Match[0].SniHosts; len(got) != 1 || got[0] != "*" {
+		t.Fatalf("sni hosts mismatch, got %+v", got)
+	}
+}
+
 func TestSSLPassthroughIgnoresNonRootPath(t *testing.T) {
 	c := controller{}
 	wrapper := &common.WrapperConfig{

--- a/pkg/ingress/kube/ingress/controller_test.go
+++ b/pkg/ingress/kube/ingress/controller_test.go
@@ -343,8 +343,9 @@ func TestSSLPassthroughSkipsDuplicatedTLSHost(t *testing.T) {
 	}
 
 	options := &common.ConvertOptions{
-		Gateways:           map[string]*common.WrapperGateway{},
-		IngressDomainCache: common.NewIngressDomainCache(),
+		Gateways:                 map[string]*common.WrapperGateway{},
+		IngressDomainCache:       common.NewIngressDomainCache(),
+		PassthroughTLSHostOwners: map[string]*config.Config{"example.com": primary.Config},
 	}
 	if err := c.ConvertGateway(options, primary, nil); err != nil {
 		t.Fatalf("ConvertGateway(primary) error = %v", err)
@@ -352,10 +353,6 @@ func TestSSLPassthroughSkipsDuplicatedTLSHost(t *testing.T) {
 	if err := c.ConvertGateway(options, duplicate, nil); err != nil {
 		t.Fatalf("ConvertGateway(duplicate) error = %v", err)
 	}
-	if !common.IsSuppressedTLSHost(options, duplicate.Config, "example.com") {
-		t.Fatal("suppressed TLS host was not recorded")
-	}
-
 	options.VirtualServices = map[string]*common.WrapperVirtualService{}
 	if err := c.ConvertTLSRoute(options, duplicate); err != nil {
 		t.Fatalf("ConvertTLSRoute() error = %v", err)
@@ -447,7 +444,6 @@ func TestSSLPassthroughDuplicateTLSHostUsesExistingGatewayOwner(t *testing.T) {
 	options := &common.ConvertOptions{
 		Gateways:           map[string]*common.WrapperGateway{},
 		IngressDomainCache: common.NewIngressDomainCache(),
-		SuppressedTLSHosts: map[common.TLSHostKey]struct{}{common.NewTLSHostKey(duplicate.Config, "example.com"): {}},
 	}
 	if err := c.ConvertGateway(options, primary, httpsCredentialConfig); err != nil {
 		t.Fatalf("ConvertGateway(primary) error = %v", err)
@@ -532,9 +528,6 @@ func TestSSLPassthroughNonRootIngressDoesNotBlockLaterRootIngress(t *testing.T) 
 	if err := c.ConvertGateway(options, root, nil); err != nil {
 		t.Fatalf("ConvertGateway(root) error = %v", err)
 	}
-	if common.IsSuppressedTLSHost(options, root.Config, "example.com") {
-		t.Fatal("root ingress was recorded as suppressed")
-	}
 	if options.Gateways["example.com"].Gateway.Servers[1].Tls.GetMode() != v1alpha3.ServerTLSSettings_PASSTHROUGH {
 		t.Fatal("root ingress did not create a TLS passthrough server")
 	}
@@ -614,10 +607,6 @@ func TestSSLPassthroughPreservesRepeatedHostInSameIngress(t *testing.T) {
 	if err := c.ConvertGateway(options, wrapper, nil); err != nil {
 		t.Fatalf("ConvertGateway() error = %v", err)
 	}
-	if common.IsSuppressedTLSHost(options, wrapper.Config, "example.com") {
-		t.Fatal("same ingress host was recorded as suppressed")
-	}
-
 	options.VirtualServices = map[string]*common.WrapperVirtualService{}
 	if err := c.ConvertTLSRoute(options, wrapper); err != nil {
 		t.Fatalf("ConvertTLSRoute() error = %v", err)

--- a/pkg/ingress/kube/ingress/controller_test.go
+++ b/pkg/ingress/kube/ingress/controller_test.go
@@ -352,8 +352,8 @@ func TestSSLPassthroughSkipsDuplicatedTLSHost(t *testing.T) {
 	if err := c.ConvertGateway(options, duplicate, nil); err != nil {
 		t.Fatalf("ConvertGateway(duplicate) error = %v", err)
 	}
-	if !common.IsDuplicateTLSHost(options, duplicate.Config, "example.com") {
-		t.Fatal("duplicate TLS host was not recorded")
+	if !common.IsSuppressedTLSHost(options, duplicate.Config, "example.com") {
+		t.Fatal("suppressed TLS host was not recorded")
 	}
 
 	options.VirtualServices = map[string]*common.WrapperVirtualService{}
@@ -447,7 +447,7 @@ func TestSSLPassthroughDuplicateTLSHostUsesExistingGatewayOwner(t *testing.T) {
 	options := &common.ConvertOptions{
 		Gateways:           map[string]*common.WrapperGateway{},
 		IngressDomainCache: common.NewIngressDomainCache(),
-		DuplicateTLSHosts:  map[common.TLSHostKey]struct{}{common.NewTLSHostKey(duplicate.Config, "example.com"): {}},
+		SuppressedTLSHosts: map[common.TLSHostKey]struct{}{common.NewTLSHostKey(duplicate.Config, "example.com"): {}},
 	}
 	if err := c.ConvertGateway(options, primary, httpsCredentialConfig); err != nil {
 		t.Fatalf("ConvertGateway(primary) error = %v", err)
@@ -532,8 +532,8 @@ func TestSSLPassthroughNonRootIngressDoesNotBlockLaterRootIngress(t *testing.T) 
 	if err := c.ConvertGateway(options, root, nil); err != nil {
 		t.Fatalf("ConvertGateway(root) error = %v", err)
 	}
-	if common.IsDuplicateTLSHost(options, root.Config, "example.com") {
-		t.Fatal("root ingress was recorded as duplicated")
+	if common.IsSuppressedTLSHost(options, root.Config, "example.com") {
+		t.Fatal("root ingress was recorded as suppressed")
 	}
 	if options.Gateways["example.com"].Gateway.Servers[1].Tls.GetMode() != v1alpha3.ServerTLSSettings_PASSTHROUGH {
 		t.Fatal("root ingress did not create a TLS passthrough server")
@@ -614,8 +614,8 @@ func TestSSLPassthroughPreservesRepeatedHostInSameIngress(t *testing.T) {
 	if err := c.ConvertGateway(options, wrapper, nil); err != nil {
 		t.Fatalf("ConvertGateway() error = %v", err)
 	}
-	if common.IsDuplicateTLSHost(options, wrapper.Config, "example.com") {
-		t.Fatal("same ingress host was recorded as duplicated")
+	if common.IsSuppressedTLSHost(options, wrapper.Config, "example.com") {
+		t.Fatal("same ingress host was recorded as suppressed")
 	}
 
 	options.VirtualServices = map[string]*common.WrapperVirtualService{}

--- a/pkg/ingress/kube/ingress/controller_test.go
+++ b/pkg/ingress/kube/ingress/controller_test.go
@@ -158,6 +158,21 @@ func TestSSLPassthroughConvertGatewayAndTLSRoute(t *testing.T) {
 	}
 }
 
+func TestSSLPassthroughConvertTLSRouteRejectsNilInputs(t *testing.T) {
+	c := controller{}
+	wrapper := &common.WrapperConfig{
+		Config:            &config.Config{},
+		AnnotationsConfig: &annotations.Ingress{},
+	}
+
+	if err := c.ConvertTLSRoute(nil, wrapper); err == nil {
+		t.Fatal("ConvertTLSRoute() with nil convertOptions returned nil error")
+	}
+	if err := c.ConvertTLSRoute(&common.ConvertOptions{}, nil); err == nil {
+		t.Fatal("ConvertTLSRoute() with nil wrapper returned nil error")
+	}
+}
+
 func TestSSLPassthroughUsesConfiguredHTTPSPort(t *testing.T) {
 	c := controller{
 		options: common.Options{

--- a/pkg/ingress/kube/ingress/controller_test.go
+++ b/pkg/ingress/kube/ingress/controller_test.go
@@ -450,6 +450,20 @@ func TestSSLPassthroughDuplicateTLSHostUsesExistingGatewayOwner(t *testing.T) {
 	}
 }
 
+func TestBackendToTLSRouteDestinationRejectsEmptyMCPDestination(t *testing.T) {
+	c := controller{}
+	backend := &ingress.IngressBackend{}
+	config := &annotations.DestinationConfig{}
+
+	destinations, event := c.backendToTLSRouteDestination(backend, "default", config)
+	if event != common.InvalidBackendService {
+		t.Fatalf("event mismatch, want InvalidBackendService, got %s", event)
+	}
+	if len(destinations) != 0 {
+		t.Fatalf("destination count mismatch, want 0, got %d", len(destinations))
+	}
+}
+
 func TestSSLPassthroughNonRootIngressDoesNotBlockLaterRootIngress(t *testing.T) {
 	c := controller{
 		options: common.Options{

--- a/pkg/ingress/kube/ingressv1/controller.go
+++ b/pkg/ingress/kube/ingressv1/controller.go
@@ -389,7 +389,7 @@ func (c *controller) ConvertGateway(convertOptions *common.ConvertOptions, wrapp
 					Protocol: string(protocol.HTTP),
 					Name:     common.CreateConvertedName("http-"+strconv.FormatUint(uint64(c.options.GatewayHttpPort), 10)+"-ingress", string(c.options.ClusterId)),
 				},
-				Hosts: []string{rule.Host},
+				Hosts: []string{common.WildcardHost(rule.Host)},
 			})
 
 			// Add new gateway, builder
@@ -518,7 +518,7 @@ func (c *controller) ConvertGateway(convertOptions *common.ConvertOptions, wrapp
 				Protocol: string(protocol.HTTPS),
 				Name:     common.CreateConvertedName("https-"+strconv.FormatUint(uint64(c.options.GatewayHttpsPort), 10)+"-ingress", string(c.options.ClusterId)),
 			},
-			Hosts: []string{rule.Host},
+			Hosts: []string{common.WildcardHost(rule.Host)},
 			Tls: &networking.ServerTLSSettings{
 				Mode:           networking.ServerTLSSettings_SIMPLE,
 				CredentialName: credentials.ToKubernetesIngressResource(c.options.RawClusterId, secretNamespace, secretName),

--- a/pkg/ingress/kube/ingressv1/controller.go
+++ b/pkg/ingress/kube/ingressv1/controller.go
@@ -337,6 +337,13 @@ func extractTLSSecretName(host string, tls []ingress.IngressTLS) string {
 }
 
 func (c *controller) ConvertGateway(convertOptions *common.ConvertOptions, wrapper *common.WrapperConfig, httpsCredentialConfig *cert.Config) error {
+	if convertOptions == nil {
+		return fmt.Errorf("convertOptions is nil")
+	}
+	if wrapper == nil {
+		return fmt.Errorf("wrapperConfig is nil")
+	}
+
 	// Ignore canary config.
 	if wrapper.AnnotationsConfig.IsCanary() {
 		return nil
@@ -707,6 +714,13 @@ func (c *controller) ConvertHTTPRoute(convertOptions *common.ConvertOptions, wra
 }
 
 func (c *controller) ConvertTLSRoute(convertOptions *common.ConvertOptions, wrapper *common.WrapperConfig) error {
+	if convertOptions == nil {
+		return fmt.Errorf("convertOptions is nil")
+	}
+	if wrapper == nil {
+		return fmt.Errorf("wrapperConfig is nil")
+	}
+
 	if convertOptions.VirtualServices == nil {
 		convertOptions.VirtualServices = map[string]*common.WrapperVirtualService{}
 	}

--- a/pkg/ingress/kube/ingressv1/controller.go
+++ b/pkg/ingress/kube/ingressv1/controller.go
@@ -409,14 +409,19 @@ func (c *controller) ConvertGateway(convertOptions *common.ConvertOptions, wrapp
 			if _, ok := rootHTTPIngressPath(rule.HTTP.Paths); !ok {
 				continue
 			}
+			if passthroughOwner := common.PassthroughTLSHostOwner(convertOptions, rule.Host); passthroughOwner != nil && !common.SameConfig(passthroughOwner, cfg) {
+				domainBuilder.Protocol = common.HTTPS
+				domainBuilder.Event = common.DuplicatedTls
+				domainBuilder.PreIngress = passthroughOwner
+				convertOptions.IngressDomainCache.Invalid = append(convertOptions.IngressDomainCache.Invalid,
+					domainBuilder.Build())
+				continue
+			}
 			if !common.IsPassthroughTLSHostOwner(convertOptions, cfg, rule.Host) {
-				if common.IsSuppressedTLSHost(convertOptions, cfg, rule.Host) {
+				if preDomainBuilder != nil {
 					domainBuilder.Protocol = common.HTTPS
 					domainBuilder.Event = common.DuplicatedTls
-					domainBuilder.PreIngress = common.PassthroughTLSHostOwner(convertOptions, rule.Host)
-					if domainBuilder.PreIngress == nil && preDomainBuilder != nil {
-						domainBuilder.PreIngress = preDomainBuilder.Ingress
-					}
+					domainBuilder.PreIngress = preDomainBuilder.Ingress
 					convertOptions.IngressDomainCache.Invalid = append(convertOptions.IngressDomainCache.Invalid,
 						domainBuilder.Build())
 				}
@@ -430,7 +435,6 @@ func (c *controller) ConvertGateway(convertOptions *common.ConvertOptions, wrapp
 				}
 				domainBuilder.Event = common.DuplicatedTls
 				domainBuilder.PreIngress = preDomainBuilder.Ingress
-				common.AddSuppressedTLSHost(convertOptions, cfg, rule.Host)
 				convertOptions.IngressDomainCache.Invalid = append(convertOptions.IngressDomainCache.Invalid,
 					domainBuilder.Build())
 				continue
@@ -489,13 +493,9 @@ func (c *controller) ConvertGateway(convertOptions *common.ConvertOptions, wrapp
 		domainBuilder.Protocol = common.HTTPS
 		domainBuilder.SecretName = path.Join(c.options.ClusterId.String(), cfg.Namespace, secretName)
 
-		if common.IsSuppressedTLSHost(convertOptions, cfg, rule.Host) {
+		if passthroughOwner := common.PassthroughTLSHostOwner(convertOptions, rule.Host); passthroughOwner != nil && !common.SameConfig(passthroughOwner, cfg) {
 			domainBuilder.Event = common.DuplicatedTls
-			if sslPassthroughOwner := convertOptions.PassthroughTLSHostOwners[rule.Host]; sslPassthroughOwner != nil {
-				domainBuilder.PreIngress = sslPassthroughOwner
-			} else if preDomainBuilder != nil {
-				domainBuilder.PreIngress = preDomainBuilder.Ingress
-			}
+			domainBuilder.PreIngress = passthroughOwner
 			convertOptions.IngressDomainCache.Invalid = append(convertOptions.IngressDomainCache.Invalid,
 				domainBuilder.Build())
 			continue
@@ -506,7 +506,6 @@ func (c *controller) ConvertGateway(convertOptions *common.ConvertOptions, wrapp
 		if wrapperGateway.IsHTTPS() {
 			domainBuilder.Event = common.DuplicatedTls
 			domainBuilder.PreIngress = preDomainBuilder.Ingress
-			common.AddSuppressedTLSHost(convertOptions, cfg, rule.Host)
 			convertOptions.IngressDomainCache.Invalid = append(convertOptions.IngressDomainCache.Invalid,
 				domainBuilder.Build())
 			continue
@@ -737,7 +736,7 @@ func (c *controller) ConvertTLSRoute(convertOptions *common.ConvertOptions, wrap
 	}
 
 	for _, rule := range ingressV1.Rules {
-		if common.IsSuppressedTLSHost(convertOptions, cfg, rule.Host) {
+		if !common.IsPassthroughTLSHostOwner(convertOptions, cfg, rule.Host) {
 			IngressLog.Warnf("ignore duplicated ssl passthrough ingress rule %s:%s for host %q in cluster %s", cfg.Namespace, cfg.Name, rule.Host, c.options.ClusterId)
 			continue
 		}

--- a/pkg/ingress/kube/ingressv1/controller.go
+++ b/pkg/ingress/kube/ingressv1/controller.go
@@ -589,12 +589,7 @@ func (c *controller) ConvertHTTPRoute(convertOptions *common.ConvertOptions, wra
 
 		wrapperVS, exist := convertOptions.VirtualServices[rule.Host]
 		if !exist {
-			wrapperVS = &common.WrapperVirtualService{
-				VirtualService: &networking.VirtualService{
-					Hosts: []string{rule.Host},
-				},
-				WrapperConfig: wrapper,
-			}
+			wrapperVS = common.NewWrapperVirtualService(rule.Host, wrapper)
 			convertOptions.VirtualServices[rule.Host] = wrapperVS
 		}
 
@@ -834,12 +829,7 @@ func (c *controller) ApplyDefaultBackend(convertOptions *common.ConvertOptions, 
 		wirecardVS, exist := convertOptions.VirtualServices[host]
 		if !exist || !wirecardVS.ConfiguredDefaultBackend {
 			if !exist {
-				wirecardVS = &common.WrapperVirtualService{
-					VirtualService: &networking.VirtualService{
-						Hosts: []string{host},
-					},
-					WrapperConfig: wrapper,
-				}
+				wirecardVS = common.NewWrapperVirtualService(host, wrapper)
 				convertOptions.VirtualServices[host] = wirecardVS
 			}
 

--- a/pkg/ingress/kube/ingressv1/controller.go
+++ b/pkg/ingress/kube/ingressv1/controller.go
@@ -1231,7 +1231,7 @@ func (c *controller) backendToTLSRouteDestination(backend *ingress.IngressBacken
 	}
 
 	if backend.Service == nil {
-		if config != nil {
+		if config != nil && len(config.McpDestination) > 0 {
 			return httpRouteDestinationToRouteDestination(config.McpDestination), common.Normal
 		}
 		return nil, common.InvalidBackendService

--- a/pkg/ingress/kube/ingressv1/controller.go
+++ b/pkg/ingress/kube/ingressv1/controller.go
@@ -402,29 +402,13 @@ func (c *controller) ConvertGateway(convertOptions *common.ConvertOptions, wrapp
 			}
 		}
 
-		if wrapper.AnnotationsConfig.IsSSLPassthrough() {
+		passthroughOwner := common.PassthroughTLSHostOwner(convertOptions, rule.Host)
+		standaloneSSLPassthrough := convertOptions.PassthroughTLSHostOwners == nil && wrapper.AnnotationsConfig.IsSSLPassthrough()
+		if common.SameConfig(passthroughOwner, cfg) || standaloneSSLPassthrough {
 			if rule.HTTP == nil || len(rule.HTTP.Paths) == 0 {
 				continue
 			}
 			if _, ok := rootHTTPIngressPath(rule.HTTP.Paths); !ok {
-				continue
-			}
-			if passthroughOwner := common.PassthroughTLSHostOwner(convertOptions, rule.Host); passthroughOwner != nil && !common.SameConfig(passthroughOwner, cfg) {
-				domainBuilder.Protocol = common.HTTPS
-				domainBuilder.Event = common.DuplicatedTls
-				domainBuilder.PreIngress = passthroughOwner
-				convertOptions.IngressDomainCache.Invalid = append(convertOptions.IngressDomainCache.Invalid,
-					domainBuilder.Build())
-				continue
-			}
-			if !common.IsPassthroughTLSHostOwner(convertOptions, cfg, rule.Host) {
-				if preDomainBuilder != nil {
-					domainBuilder.Protocol = common.HTTPS
-					domainBuilder.Event = common.DuplicatedTls
-					domainBuilder.PreIngress = preDomainBuilder.Ingress
-					convertOptions.IngressDomainCache.Invalid = append(convertOptions.IngressDomainCache.Invalid,
-						domainBuilder.Build())
-				}
 				continue
 			}
 
@@ -442,6 +426,18 @@ func (c *controller) ConvertGateway(convertOptions *common.ConvertOptions, wrapp
 			wrapperGateway.Gateway.Servers = append(wrapperGateway.Gateway.Servers,
 				common.CreateSSLPassthroughServer(rule.Host, c.options.GatewayHttpsPort, c.options.ClusterId))
 			convertOptions.IngressDomainCache.Valid[rule.Host] = domainBuilder
+			continue
+		}
+		if wrapper.AnnotationsConfig.IsSSLPassthrough() {
+			if rule.HTTP != nil {
+				if _, ok := rootHTTPIngressPath(rule.HTTP.Paths); ok && passthroughOwner != nil {
+					domainBuilder.Protocol = common.HTTPS
+					domainBuilder.Event = common.DuplicatedTls
+					domainBuilder.PreIngress = passthroughOwner
+					convertOptions.IngressDomainCache.Invalid = append(convertOptions.IngressDomainCache.Invalid,
+						domainBuilder.Build())
+				}
+			}
 			continue
 		}
 
@@ -493,7 +489,7 @@ func (c *controller) ConvertGateway(convertOptions *common.ConvertOptions, wrapp
 		domainBuilder.Protocol = common.HTTPS
 		domainBuilder.SecretName = path.Join(c.options.ClusterId.String(), cfg.Namespace, secretName)
 
-		if passthroughOwner := common.PassthroughTLSHostOwner(convertOptions, rule.Host); passthroughOwner != nil && !common.SameConfig(passthroughOwner, cfg) {
+		if passthroughOwner != nil {
 			domainBuilder.Event = common.DuplicatedTls
 			domainBuilder.PreIngress = passthroughOwner
 			convertOptions.IngressDomainCache.Invalid = append(convertOptions.IngressDomainCache.Invalid,
@@ -558,8 +554,6 @@ func (c *controller) ConvertHTTPRoute(convertOptions *common.ConvertOptions, wra
 	if convertOptions.HTTPRoutes == nil {
 		convertOptions.HTTPRoutes = map[string][]*common.WrapperHTTPRoute{}
 	}
-
-	sslPassthrough := wrapper.AnnotationsConfig.IsSSLPassthrough()
 
 	cfg := wrapper.Config
 	ingressV1, ok := cfg.Spec.(ingress.IngressSpec)
@@ -705,7 +699,8 @@ func (c *controller) ConvertHTTPRoute(convertOptions *common.ConvertOptions, wra
 		}
 	}
 
-	if sslPassthrough {
+	if common.HasPassthroughTLSHostOwner(convertOptions, cfg) ||
+		(convertOptions.PassthroughTLSHostOwners == nil && wrapper.AnnotationsConfig.IsSSLPassthrough()) {
 		return c.ConvertTLSRoute(convertOptions, wrapper)
 	}
 

--- a/pkg/ingress/kube/ingressv1/controller.go
+++ b/pkg/ingress/kube/ingressv1/controller.go
@@ -409,11 +409,11 @@ func (c *controller) ConvertGateway(convertOptions *common.ConvertOptions, wrapp
 			if _, ok := rootHTTPIngressPath(rule.HTTP.Paths); !ok {
 				continue
 			}
-			if !common.IsSSLPassthroughTLSHostOwner(convertOptions, cfg, rule.Host) {
-				if common.IsDuplicateTLSHost(convertOptions, cfg, rule.Host) {
+			if !common.IsPassthroughTLSHostOwner(convertOptions, cfg, rule.Host) {
+				if common.IsSuppressedTLSHost(convertOptions, cfg, rule.Host) {
 					domainBuilder.Protocol = common.HTTPS
 					domainBuilder.Event = common.DuplicatedTls
-					domainBuilder.PreIngress = common.SSLPassthroughTLSHostOwner(convertOptions, rule.Host)
+					domainBuilder.PreIngress = common.PassthroughTLSHostOwner(convertOptions, rule.Host)
 					if domainBuilder.PreIngress == nil && preDomainBuilder != nil {
 						domainBuilder.PreIngress = preDomainBuilder.Ingress
 					}
@@ -430,7 +430,7 @@ func (c *controller) ConvertGateway(convertOptions *common.ConvertOptions, wrapp
 				}
 				domainBuilder.Event = common.DuplicatedTls
 				domainBuilder.PreIngress = preDomainBuilder.Ingress
-				common.AddDuplicateTLSHost(convertOptions, cfg, rule.Host)
+				common.AddSuppressedTLSHost(convertOptions, cfg, rule.Host)
 				convertOptions.IngressDomainCache.Invalid = append(convertOptions.IngressDomainCache.Invalid,
 					domainBuilder.Build())
 				continue
@@ -489,9 +489,9 @@ func (c *controller) ConvertGateway(convertOptions *common.ConvertOptions, wrapp
 		domainBuilder.Protocol = common.HTTPS
 		domainBuilder.SecretName = path.Join(c.options.ClusterId.String(), cfg.Namespace, secretName)
 
-		if common.IsDuplicateTLSHost(convertOptions, cfg, rule.Host) {
+		if common.IsSuppressedTLSHost(convertOptions, cfg, rule.Host) {
 			domainBuilder.Event = common.DuplicatedTls
-			if sslPassthroughOwner := convertOptions.SSLPassthroughTLSHosts[rule.Host]; sslPassthroughOwner != nil {
+			if sslPassthroughOwner := convertOptions.PassthroughTLSHostOwners[rule.Host]; sslPassthroughOwner != nil {
 				domainBuilder.PreIngress = sslPassthroughOwner
 			} else if preDomainBuilder != nil {
 				domainBuilder.PreIngress = preDomainBuilder.Ingress
@@ -506,7 +506,7 @@ func (c *controller) ConvertGateway(convertOptions *common.ConvertOptions, wrapp
 		if wrapperGateway.IsHTTPS() {
 			domainBuilder.Event = common.DuplicatedTls
 			domainBuilder.PreIngress = preDomainBuilder.Ingress
-			common.AddDuplicateTLSHost(convertOptions, cfg, rule.Host)
+			common.AddSuppressedTLSHost(convertOptions, cfg, rule.Host)
 			convertOptions.IngressDomainCache.Invalid = append(convertOptions.IngressDomainCache.Invalid,
 				domainBuilder.Build())
 			continue
@@ -737,7 +737,7 @@ func (c *controller) ConvertTLSRoute(convertOptions *common.ConvertOptions, wrap
 	}
 
 	for _, rule := range ingressV1.Rules {
-		if common.IsDuplicateTLSHost(convertOptions, cfg, rule.Host) {
+		if common.IsSuppressedTLSHost(convertOptions, cfg, rule.Host) {
 			IngressLog.Warnf("ignore duplicated ssl passthrough ingress rule %s:%s for host %q in cluster %s", cfg.Namespace, cfg.Name, rule.Host, c.options.ClusterId)
 			continue
 		}

--- a/pkg/ingress/kube/ingressv1/controller.go
+++ b/pkg/ingress/kube/ingressv1/controller.go
@@ -402,6 +402,19 @@ func (c *controller) ConvertGateway(convertOptions *common.ConvertOptions, wrapp
 			if _, ok := rootHTTPIngressPath(rule.HTTP.Paths); !ok {
 				continue
 			}
+			if !common.IsSSLPassthroughTLSHostOwner(convertOptions, cfg, rule.Host) {
+				if common.IsDuplicateTLSHost(convertOptions, cfg, rule.Host) {
+					domainBuilder.Protocol = common.HTTPS
+					domainBuilder.Event = common.DuplicatedTls
+					domainBuilder.PreIngress = common.SSLPassthroughTLSHostOwner(convertOptions, rule.Host)
+					if domainBuilder.PreIngress == nil && preDomainBuilder != nil {
+						domainBuilder.PreIngress = preDomainBuilder.Ingress
+					}
+					convertOptions.IngressDomainCache.Invalid = append(convertOptions.IngressDomainCache.Invalid,
+						domainBuilder.Build())
+				}
+				continue
+			}
 
 			domainBuilder.Protocol = common.HTTPS
 			if wrapperGateway.IsHTTPS() {
@@ -468,6 +481,18 @@ func (c *controller) ConvertGateway(convertOptions *common.ConvertOptions, wrapp
 
 		domainBuilder.Protocol = common.HTTPS
 		domainBuilder.SecretName = path.Join(c.options.ClusterId.String(), cfg.Namespace, secretName)
+
+		if common.IsDuplicateTLSHost(convertOptions, cfg, rule.Host) {
+			domainBuilder.Event = common.DuplicatedTls
+			if sslPassthroughOwner := convertOptions.SSLPassthroughTLSHosts[rule.Host]; sslPassthroughOwner != nil {
+				domainBuilder.PreIngress = sslPassthroughOwner
+			} else if preDomainBuilder != nil {
+				domainBuilder.PreIngress = preDomainBuilder.Ingress
+			}
+			convertOptions.IngressDomainCache.Invalid = append(convertOptions.IngressDomainCache.Invalid,
+				domainBuilder.Build())
+			continue
+		}
 
 		// There is a matching secret and the gateway has already a tls secret.
 		// We should report the duplicated tls secret event.

--- a/pkg/ingress/kube/ingressv1/controller.go
+++ b/pkg/ingress/kube/ingressv1/controller.go
@@ -395,6 +395,32 @@ func (c *controller) ConvertGateway(convertOptions *common.ConvertOptions, wrapp
 			}
 		}
 
+		if wrapper.AnnotationsConfig.IsSSLPassthrough() {
+			if rule.HTTP == nil || len(rule.HTTP.Paths) == 0 {
+				continue
+			}
+			if _, ok := rootHTTPIngressPath(rule.HTTP.Paths); !ok {
+				continue
+			}
+
+			domainBuilder.Protocol = common.HTTPS
+			if wrapperGateway.IsHTTPS() {
+				if common.SameConfig(preDomainBuilder.Ingress, cfg) {
+					continue
+				}
+				domainBuilder.Event = common.DuplicatedTls
+				domainBuilder.PreIngress = preDomainBuilder.Ingress
+				common.AddDuplicateTLSHost(convertOptions, cfg, rule.Host)
+				convertOptions.IngressDomainCache.Invalid = append(convertOptions.IngressDomainCache.Invalid,
+					domainBuilder.Build())
+				continue
+			}
+			wrapperGateway.Gateway.Servers = append(wrapperGateway.Gateway.Servers,
+				common.CreateSSLPassthroughServer(rule.Host, c.options.GatewayHttpsPort, c.options.ClusterId))
+			convertOptions.IngressDomainCache.Valid[rule.Host] = domainBuilder
+			continue
+		}
+
 		// There are no tls settings, so just skip.
 		if len(ingressV1.TLS) == 0 {
 			continue
@@ -448,6 +474,7 @@ func (c *controller) ConvertGateway(convertOptions *common.ConvertOptions, wrapp
 		if wrapperGateway.IsHTTPS() {
 			domainBuilder.Event = common.DuplicatedTls
 			domainBuilder.PreIngress = preDomainBuilder.Ingress
+			common.AddDuplicateTLSHost(convertOptions, cfg, rule.Host)
 			convertOptions.IngressDomainCache.Invalid = append(convertOptions.IngressDomainCache.Invalid,
 				domainBuilder.Build())
 			continue
@@ -475,11 +502,33 @@ func (c *controller) ConvertGateway(convertOptions *common.ConvertOptions, wrapp
 }
 
 func (c *controller) ConvertHTTPRoute(convertOptions *common.ConvertOptions, wrapper *common.WrapperConfig) error {
+	if convertOptions == nil {
+		return fmt.Errorf("convertOptions is nil")
+	}
+	if wrapper == nil {
+		return fmt.Errorf("wrapperConfig is nil")
+	}
+
 	// Canary ingress will be processed in the end.
 	if wrapper.AnnotationsConfig.IsCanary() {
 		convertOptions.CanaryIngresses = append(convertOptions.CanaryIngresses, wrapper)
 		return nil
 	}
+
+	if convertOptions.Route2Ingress == nil {
+		convertOptions.Route2Ingress = map[string]*common.WrapperConfigWithRuleKey{}
+	}
+	if convertOptions.IngressRouteCache == nil {
+		convertOptions.IngressRouteCache = common.NewIngressRouteCache()
+	}
+	if convertOptions.VirtualServices == nil {
+		convertOptions.VirtualServices = map[string]*common.WrapperVirtualService{}
+	}
+	if convertOptions.HTTPRoutes == nil {
+		convertOptions.HTTPRoutes = map[string][]*common.WrapperHTTPRoute{}
+	}
+
+	sslPassthrough := wrapper.AnnotationsConfig.IsSSLPassthrough()
 
 	cfg := wrapper.Config
 	ingressV1, ok := cfg.Spec.(ingress.IngressSpec)
@@ -549,7 +598,11 @@ func (c *controller) ConvertHTTPRoute(convertOptions *common.ConvertOptions, wra
 					pathType = common.PrefixRegex
 				}
 			} else {
-				switch *httpPath.PathType {
+				ingressPathType := defaultPathType
+				if httpPath.PathType != nil {
+					ingressPathType = *httpPath.PathType
+				}
+				switch ingressPathType {
 				case ingress.PathTypeExact:
 					pathType = common.Exact
 				case ingress.PathTypePrefix:
@@ -626,7 +679,74 @@ func (c *controller) ConvertHTTPRoute(convertOptions *common.ConvertOptions, wra
 		}
 	}
 
+	if sslPassthrough {
+		return c.ConvertTLSRoute(convertOptions, wrapper)
+	}
+
 	return nil
+}
+
+func (c *controller) ConvertTLSRoute(convertOptions *common.ConvertOptions, wrapper *common.WrapperConfig) error {
+	if convertOptions.VirtualServices == nil {
+		convertOptions.VirtualServices = map[string]*common.WrapperVirtualService{}
+	}
+
+	cfg := wrapper.Config
+	ingressV1, ok := cfg.Spec.(ingress.IngressSpec)
+	if !ok {
+		common.IncrementInvalidIngress(c.options.ClusterId, common.Unknown)
+		return fmt.Errorf("convert type is invalid in cluster %s", c.options.ClusterId)
+	}
+	if len(ingressV1.Rules) == 0 {
+		common.IncrementInvalidIngress(c.options.ClusterId, common.EmptyRule)
+		return fmt.Errorf("invalid ingress rule %s:%s in cluster %s, `rules` must be specified", cfg.Namespace, cfg.Name, c.options.ClusterId)
+	}
+
+	for _, rule := range ingressV1.Rules {
+		if common.IsDuplicateTLSHost(convertOptions, cfg, rule.Host) {
+			IngressLog.Warnf("ignore duplicated ssl passthrough ingress rule %s:%s for host %q in cluster %s", cfg.Namespace, cfg.Name, rule.Host, c.options.ClusterId)
+			continue
+		}
+
+		if rule.HTTP == nil || len(rule.HTTP.Paths) == 0 {
+			IngressLog.Warnf("invalid ssl passthrough ingress rule %s:%s for host %q in cluster %s, no paths defined", cfg.Namespace, cfg.Name, rule.Host, c.options.ClusterId)
+			continue
+		}
+
+		httpPath, ok := rootHTTPIngressPath(rule.HTTP.Paths)
+		if !ok {
+			IngressLog.Warnf("ignore ssl passthrough ingress rule %s:%s for host %q in cluster %s, root path is not defined", cfg.Namespace, cfg.Name, rule.Host, c.options.ClusterId)
+			continue
+		}
+
+		wrapperVS, exist := convertOptions.VirtualServices[rule.Host]
+		if !exist {
+			wrapperVS = common.NewWrapperVirtualService(rule.Host, wrapper)
+			convertOptions.VirtualServices[rule.Host] = wrapperVS
+		} else if wrapperVS.HasTLSRouteForHost(rule.Host) {
+			continue
+		}
+
+		routeDestination, event := c.backendToTLSRouteDestination(&httpPath.Backend, cfg.Namespace, wrapper.AnnotationsConfig.Destination)
+		if event != common.Normal {
+			common.IncrementInvalidIngress(c.options.ClusterId, event)
+			continue
+		}
+
+		wrapperVS.VirtualService.Tls = append(wrapperVS.VirtualService.Tls,
+			common.CreateTLSRoute(rule.Host, routeDestination))
+	}
+
+	return nil
+}
+
+func rootHTTPIngressPath(paths []ingress.HTTPIngressPath) (*ingress.HTTPIngressPath, bool) {
+	for idx := range paths {
+		if paths[idx].Path == "" || paths[idx].Path == "/" {
+			return &paths[idx], true
+		}
+	}
+	return nil, false
 }
 
 func (c *controller) generateHttpMatches(pathType common.PathType, path string, wrapperVS *common.WrapperVirtualService) []*networking.HTTPMatchRequest {
@@ -782,7 +902,11 @@ func (c *controller) ApplyCanaryIngress(convertOptions *common.ConvertOptions, w
 					pathType = common.PrefixRegex
 				}
 			} else {
-				switch *httpPath.PathType {
+				ingressPathType := defaultPathType
+				if httpPath.PathType != nil {
+					ingressPathType = *httpPath.PathType
+				}
+				switch ingressPathType {
 				case ingress.PathTypeExact:
 					pathType = common.Exact
 				case ingress.PathTypePrefix:
@@ -1072,6 +1196,54 @@ func (c *controller) backendToRouteDestination(backend *ingress.IngressBackend, 
 			Weight: 100,
 		},
 	}, common.Normal
+}
+
+func (c *controller) backendToTLSRouteDestination(backend *ingress.IngressBackend, namespace string,
+	config *annotations.DestinationConfig,
+) ([]*networking.RouteDestination, common.Event) {
+	if backend == nil {
+		return nil, common.InvalidBackendService
+	}
+
+	if backend.Service == nil {
+		if config != nil {
+			return httpRouteDestinationToRouteDestination(config.McpDestination), common.Normal
+		}
+		return nil, common.InvalidBackendService
+	}
+
+	service := backend.Service
+	port := &networking.PortSelector{}
+	if service.Port.Number > 0 {
+		port.Number = uint32(service.Port.Number)
+	} else {
+		resolvedPort, err := resolveNamedPort(service, namespace, c.serviceLister)
+		if err != nil {
+			return nil, common.PortNameResolveError
+		}
+		port.Number = uint32(resolvedPort)
+	}
+
+	return []*networking.RouteDestination{
+		{
+			Destination: &networking.Destination{
+				Host: util.CreateServiceFQDN(namespace, service.Name),
+				Port: port,
+			},
+			Weight: 100,
+		},
+	}, common.Normal
+}
+
+func httpRouteDestinationToRouteDestination(destinations []*networking.HTTPRouteDestination) []*networking.RouteDestination {
+	out := make([]*networking.RouteDestination, 0, len(destinations))
+	for _, destination := range destinations {
+		out = append(out, &networking.RouteDestination{
+			Destination: destination.Destination,
+			Weight:      destination.Weight,
+		})
+	}
+	return out
 }
 
 func resolveNamedPort(service *ingress.IngressServiceBackend, namespace string, serviceLister listerv1.ServiceLister) (int32, error) {

--- a/pkg/ingress/kube/ingressv1/controller_test.go
+++ b/pkg/ingress/kube/ingressv1/controller_test.go
@@ -747,6 +747,41 @@ func TestSSLPassthroughUsesRootPathBackend(t *testing.T) {
 	}
 }
 
+func TestSSLPassthroughWildcardHostKeepsVirtualServiceConsistent(t *testing.T) {
+	c := controller{}
+	wrapper := &common.WrapperConfig{
+		Config: &config.Config{
+			Meta: config.Meta{
+				Namespace: "default",
+				Name:      "tls-passthrough-wildcard",
+			},
+			Spec: ingressSpecWithSSLPassthroughBackend("", "root", 443),
+		},
+		AnnotationsConfig: &annotations.Ingress{
+			SSLPassthrough: &annotations.SSLPassthroughConfig{Enabled: true},
+		},
+	}
+
+	routeOptions := &common.ConvertOptions{}
+	if err := c.ConvertHTTPRoute(routeOptions, wrapper); err != nil {
+		t.Fatalf("ConvertHTTPRoute() error = %v", err)
+	}
+	if err := c.ConvertTLSRoute(routeOptions, wrapper); err != nil {
+		t.Fatalf("ConvertTLSRoute() error = %v", err)
+	}
+
+	vs := routeOptions.VirtualServices[""].VirtualService
+	if got := vs.Hosts; len(got) != 1 || got[0] != "*" {
+		t.Fatalf("virtual service hosts mismatch, got %+v", got)
+	}
+	if len(vs.Tls) != 1 {
+		t.Fatalf("tls route count mismatch, want 1, got %d", len(vs.Tls))
+	}
+	if got := vs.Tls[0].Match[0].SniHosts; len(got) != 1 || got[0] != "*" {
+		t.Fatalf("sni hosts mismatch, got %+v", got)
+	}
+}
+
 func TestSSLPassthroughIgnoresNonRootPath(t *testing.T) {
 	c := controller{}
 	wrapper := &common.WrapperConfig{

--- a/pkg/ingress/kube/ingressv1/controller_test.go
+++ b/pkg/ingress/kube/ingressv1/controller_test.go
@@ -331,8 +331,8 @@ func TestSSLPassthroughSkipsDuplicatedTLSHost(t *testing.T) {
 	if err := c.ConvertGateway(options, duplicate, nil); err != nil {
 		t.Fatalf("ConvertGateway(duplicate) error = %v", err)
 	}
-	if !common.IsDuplicateTLSHost(options, duplicate.Config, "example.com") {
-		t.Fatal("duplicate TLS host was not recorded")
+	if !common.IsSuppressedTLSHost(options, duplicate.Config, "example.com") {
+		t.Fatal("suppressed TLS host was not recorded")
 	}
 
 	options.VirtualServices = map[string]*common.WrapperVirtualService{}
@@ -377,10 +377,10 @@ func TestSSLPassthroughDuplicateTLSHostRecordsInvalidDomain(t *testing.T) {
 	}
 
 	options := &common.ConvertOptions{
-		Gateways:               map[string]*common.WrapperGateway{},
-		IngressDomainCache:     common.NewIngressDomainCache(),
-		SSLPassthroughTLSHosts: map[string]*config.Config{"example.com": primary.Config},
-		DuplicateTLSHosts:      map[common.TLSHostKey]struct{}{common.NewTLSHostKey(duplicate.Config, "example.com"): {}},
+		Gateways:                 map[string]*common.WrapperGateway{},
+		IngressDomainCache:       common.NewIngressDomainCache(),
+		PassthroughTLSHostOwners: map[string]*config.Config{"example.com": primary.Config},
+		SuppressedTLSHosts:       map[common.TLSHostKey]struct{}{common.NewTLSHostKey(duplicate.Config, "example.com"): {}},
 	}
 	if err := c.ConvertGateway(options, primary, nil); err != nil {
 		t.Fatalf("ConvertGateway(primary) error = %v", err)
@@ -449,7 +449,7 @@ func TestSSLPassthroughDuplicateTLSHostUsesExistingGatewayOwner(t *testing.T) {
 	options := &common.ConvertOptions{
 		Gateways:           map[string]*common.WrapperGateway{},
 		IngressDomainCache: common.NewIngressDomainCache(),
-		DuplicateTLSHosts:  map[common.TLSHostKey]struct{}{common.NewTLSHostKey(duplicate.Config, "example.com"): {}},
+		SuppressedTLSHosts: map[common.TLSHostKey]struct{}{common.NewTLSHostKey(duplicate.Config, "example.com"): {}},
 	}
 	if err := c.ConvertGateway(options, primary, httpsCredentialConfig); err != nil {
 		t.Fatalf("ConvertGateway(primary) error = %v", err)
@@ -514,8 +514,8 @@ func TestSSLPassthroughNonRootIngressDoesNotBlockLaterRootIngress(t *testing.T) 
 	if err := c.ConvertGateway(options, root, nil); err != nil {
 		t.Fatalf("ConvertGateway(root) error = %v", err)
 	}
-	if common.IsDuplicateTLSHost(options, root.Config, "example.com") {
-		t.Fatal("root ingress was recorded as duplicated")
+	if common.IsSuppressedTLSHost(options, root.Config, "example.com") {
+		t.Fatal("root ingress was recorded as suppressed")
 	}
 	if options.Gateways["example.com"].Gateway.Servers[1].Tls.GetMode() != networking.ServerTLSSettings_PASSTHROUGH {
 		t.Fatal("root ingress did not create a TLS passthrough server")
@@ -584,8 +584,8 @@ func TestSSLPassthroughPreservesRepeatedHostInSameIngress(t *testing.T) {
 	if err := c.ConvertGateway(options, wrapper, nil); err != nil {
 		t.Fatalf("ConvertGateway() error = %v", err)
 	}
-	if common.IsDuplicateTLSHost(options, wrapper.Config, "example.com") {
-		t.Fatal("same ingress host was recorded as duplicated")
+	if common.IsSuppressedTLSHost(options, wrapper.Config, "example.com") {
+		t.Fatal("same ingress host was recorded as suppressed")
 	}
 
 	options.VirtualServices = map[string]*common.WrapperVirtualService{}

--- a/pkg/ingress/kube/ingressv1/controller_test.go
+++ b/pkg/ingress/kube/ingressv1/controller_test.go
@@ -829,6 +829,27 @@ func TestSSLPassthroughKeepsMCPResourceBackend(t *testing.T) {
 	}
 }
 
+func TestBackendToTLSRouteDestinationRejectsEmptyMCPDestination(t *testing.T) {
+	c := controller{}
+	apiGroup := "networking.higress.io"
+	backend := &v1.IngressBackend{
+		Resource: &corev1.TypedLocalObjectReference{
+			APIGroup: &apiGroup,
+			Kind:     "McpBridge",
+			Name:     "default",
+		},
+	}
+	config := &annotations.DestinationConfig{}
+
+	destinations, event := c.backendToTLSRouteDestination(backend, "default", config)
+	if event != common.InvalidBackendService {
+		t.Fatalf("event mismatch, want InvalidBackendService, got %s", event)
+	}
+	if len(destinations) != 0 {
+		t.Fatalf("destination count mismatch, want 0, got %d", len(destinations))
+	}
+}
+
 func ingressSpecWithSSLPassthroughBackend(host, service string, port int32) v1.IngressSpec {
 	return ingressSpecWithSSLPassthroughPaths(host, []v1.HTTPIngressPath{
 		ingressPath("/", service, port),

--- a/pkg/ingress/kube/ingressv1/controller_test.go
+++ b/pkg/ingress/kube/ingressv1/controller_test.go
@@ -322,8 +322,9 @@ func TestSSLPassthroughSkipsDuplicatedTLSHost(t *testing.T) {
 	}
 
 	options := &common.ConvertOptions{
-		Gateways:           map[string]*common.WrapperGateway{},
-		IngressDomainCache: common.NewIngressDomainCache(),
+		Gateways:                 map[string]*common.WrapperGateway{},
+		IngressDomainCache:       common.NewIngressDomainCache(),
+		PassthroughTLSHostOwners: map[string]*config.Config{"example.com": primary.Config},
 	}
 	if err := c.ConvertGateway(options, primary, nil); err != nil {
 		t.Fatalf("ConvertGateway(primary) error = %v", err)
@@ -331,10 +332,6 @@ func TestSSLPassthroughSkipsDuplicatedTLSHost(t *testing.T) {
 	if err := c.ConvertGateway(options, duplicate, nil); err != nil {
 		t.Fatalf("ConvertGateway(duplicate) error = %v", err)
 	}
-	if !common.IsSuppressedTLSHost(options, duplicate.Config, "example.com") {
-		t.Fatal("suppressed TLS host was not recorded")
-	}
-
 	options.VirtualServices = map[string]*common.WrapperVirtualService{}
 	if err := c.ConvertTLSRoute(options, duplicate); err != nil {
 		t.Fatalf("ConvertTLSRoute() error = %v", err)
@@ -380,7 +377,6 @@ func TestSSLPassthroughDuplicateTLSHostRecordsInvalidDomain(t *testing.T) {
 		Gateways:                 map[string]*common.WrapperGateway{},
 		IngressDomainCache:       common.NewIngressDomainCache(),
 		PassthroughTLSHostOwners: map[string]*config.Config{"example.com": primary.Config},
-		SuppressedTLSHosts:       map[common.TLSHostKey]struct{}{common.NewTLSHostKey(duplicate.Config, "example.com"): {}},
 	}
 	if err := c.ConvertGateway(options, primary, nil); err != nil {
 		t.Fatalf("ConvertGateway(primary) error = %v", err)
@@ -449,7 +445,6 @@ func TestSSLPassthroughDuplicateTLSHostUsesExistingGatewayOwner(t *testing.T) {
 	options := &common.ConvertOptions{
 		Gateways:           map[string]*common.WrapperGateway{},
 		IngressDomainCache: common.NewIngressDomainCache(),
-		SuppressedTLSHosts: map[common.TLSHostKey]struct{}{common.NewTLSHostKey(duplicate.Config, "example.com"): {}},
 	}
 	if err := c.ConvertGateway(options, primary, httpsCredentialConfig); err != nil {
 		t.Fatalf("ConvertGateway(primary) error = %v", err)
@@ -513,9 +508,6 @@ func TestSSLPassthroughNonRootIngressDoesNotBlockLaterRootIngress(t *testing.T) 
 	}
 	if err := c.ConvertGateway(options, root, nil); err != nil {
 		t.Fatalf("ConvertGateway(root) error = %v", err)
-	}
-	if common.IsSuppressedTLSHost(options, root.Config, "example.com") {
-		t.Fatal("root ingress was recorded as suppressed")
 	}
 	if options.Gateways["example.com"].Gateway.Servers[1].Tls.GetMode() != networking.ServerTLSSettings_PASSTHROUGH {
 		t.Fatal("root ingress did not create a TLS passthrough server")
@@ -584,10 +576,6 @@ func TestSSLPassthroughPreservesRepeatedHostInSameIngress(t *testing.T) {
 	if err := c.ConvertGateway(options, wrapper, nil); err != nil {
 		t.Fatalf("ConvertGateway() error = %v", err)
 	}
-	if common.IsSuppressedTLSHost(options, wrapper.Config, "example.com") {
-		t.Fatal("same ingress host was recorded as suppressed")
-	}
-
 	options.VirtualServices = map[string]*common.WrapperVirtualService{}
 	if err := c.ConvertTLSRoute(options, wrapper); err != nil {
 		t.Fatalf("ConvertTLSRoute() error = %v", err)

--- a/pkg/ingress/kube/ingressv1/controller_test.go
+++ b/pkg/ingress/kube/ingressv1/controller_test.go
@@ -462,6 +462,79 @@ func TestSSLPassthroughDuplicateTLSHostUsesExistingGatewayOwner(t *testing.T) {
 	}
 }
 
+func TestSSLPassthroughUsesFirstRootOwnerWhenLaterIngressEnablesPassthrough(t *testing.T) {
+	c := controller{
+		options: common.Options{
+			GatewayHttpPort:  80,
+			GatewayHttpsPort: 443,
+		},
+	}
+	root := &common.WrapperConfig{
+		Config: &config.Config{
+			Meta: config.Meta{
+				Namespace: "default",
+				Name:      "root",
+			},
+			Spec: v1.IngressSpec{
+				Rules: []v1.IngressRule{
+					ingressRule("example.com", ingressPath("/", "root", 443)),
+				},
+			},
+		},
+		AnnotationsConfig: &annotations.Ingress{},
+	}
+	passthrough := &common.WrapperConfig{
+		Config: &config.Config{
+			Meta: config.Meta{
+				Namespace: "default",
+				Name:      "passthrough",
+			},
+			Spec: ingressSpecWithSSLPassthroughPaths("example.com", []v1.HTTPIngressPath{
+				ingressPath("/passthrough", "passthrough", 443),
+			}),
+		},
+		AnnotationsConfig: &annotations.Ingress{
+			SSLPassthrough: &annotations.SSLPassthroughConfig{Enabled: true},
+		},
+	}
+
+	options := &common.ConvertOptions{
+		Gateways:                 map[string]*common.WrapperGateway{},
+		IngressDomainCache:       common.NewIngressDomainCache(),
+		PassthroughTLSHostOwners: map[string]*config.Config{"example.com": root.Config},
+	}
+	if err := c.ConvertGateway(options, root, nil); err != nil {
+		t.Fatalf("ConvertGateway(root) error = %v", err)
+	}
+	if err := c.ConvertGateway(options, passthrough, nil); err != nil {
+		t.Fatalf("ConvertGateway(passthrough) error = %v", err)
+	}
+	gateway := options.Gateways["example.com"].Gateway
+	if len(gateway.Servers) != 2 {
+		t.Fatalf("server count mismatch, want 2, got %d", len(gateway.Servers))
+	}
+	if gateway.Servers[1].Tls.GetMode() != networking.ServerTLSSettings_PASSTHROUGH {
+		t.Fatalf("tls mode mismatch, want PASSTHROUGH, got %s", gateway.Servers[1].Tls.GetMode())
+	}
+
+	routeOptions := &common.ConvertOptions{
+		PassthroughTLSHostOwners: map[string]*config.Config{"example.com": root.Config},
+	}
+	if err := c.ConvertHTTPRoute(routeOptions, root); err != nil {
+		t.Fatalf("ConvertHTTPRoute(root) error = %v", err)
+	}
+	if err := c.ConvertHTTPRoute(routeOptions, passthrough); err != nil {
+		t.Fatalf("ConvertHTTPRoute(passthrough) error = %v", err)
+	}
+	routes := routeOptions.VirtualServices["example.com"].VirtualService.Tls
+	if len(routes) != 1 {
+		t.Fatalf("tls route count mismatch, want 1, got %d", len(routes))
+	}
+	if got := routes[0].Route[0].Destination.Host; got != "root.default.svc.cluster.local" {
+		t.Fatalf("destination host mismatch, want root.default.svc.cluster.local, got %s", got)
+	}
+}
+
 func TestSSLPassthroughNonRootIngressDoesNotBlockLaterRootIngress(t *testing.T) {
 	c := controller{
 		options: common.Options{

--- a/pkg/ingress/kube/ingressv1/controller_test.go
+++ b/pkg/ingress/kube/ingressv1/controller_test.go
@@ -193,6 +193,36 @@ func TestSSLPassthroughConvertGatewayAndTLSRoute(t *testing.T) {
 	}
 }
 
+func TestSSLPassthroughConvertGatewayRejectsNilInputs(t *testing.T) {
+	c := controller{}
+	wrapper := &common.WrapperConfig{
+		Config:            &config.Config{},
+		AnnotationsConfig: &annotations.Ingress{},
+	}
+
+	if err := c.ConvertGateway(nil, wrapper, nil); err == nil {
+		t.Fatal("ConvertGateway() with nil convertOptions returned nil error")
+	}
+	if err := c.ConvertGateway(&common.ConvertOptions{}, nil, nil); err == nil {
+		t.Fatal("ConvertGateway() with nil wrapper returned nil error")
+	}
+}
+
+func TestSSLPassthroughConvertTLSRouteRejectsNilInputs(t *testing.T) {
+	c := controller{}
+	wrapper := &common.WrapperConfig{
+		Config:            &config.Config{},
+		AnnotationsConfig: &annotations.Ingress{},
+	}
+
+	if err := c.ConvertTLSRoute(nil, wrapper); err == nil {
+		t.Fatal("ConvertTLSRoute() with nil convertOptions returned nil error")
+	}
+	if err := c.ConvertTLSRoute(&common.ConvertOptions{}, nil); err == nil {
+		t.Fatal("ConvertTLSRoute() with nil wrapper returned nil error")
+	}
+}
+
 func TestSSLPassthroughUsesConfiguredHTTPSPort(t *testing.T) {
 	c := controller{
 		options: common.Options{

--- a/pkg/ingress/kube/ingressv1/controller_test.go
+++ b/pkg/ingress/kube/ingressv1/controller_test.go
@@ -17,10 +17,13 @@ package ingressv1
 import (
 	"testing"
 
+	"github.com/alibaba/higress/v2/pkg/ingress/kube/annotations"
 	"github.com/alibaba/higress/v2/pkg/ingress/kube/common"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	networking "istio.io/api/networking/v1alpha3"
+	"istio.io/istio/pkg/config"
+	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -116,5 +119,636 @@ func TestGenerateHttpMatches(t *testing.T) {
 				t.Errorf("generateHttpMatches() mismatch (-want +got):\n%s", diff)
 			}
 		}
+	}
+}
+
+func TestSSLPassthroughConvertGatewayAndTLSRoute(t *testing.T) {
+	c := controller{
+		options: common.Options{
+			GatewayHttpPort:  80,
+			GatewayHttpsPort: 443,
+		},
+	}
+	wrapper := &common.WrapperConfig{
+		Config: &config.Config{
+			Meta: config.Meta{
+				Namespace: "default",
+				Name:      "tls-passthrough",
+			},
+			Spec: ingressSpecWithSSLPassthroughBackend("example.com", "app", 443),
+		},
+		AnnotationsConfig: &annotations.Ingress{
+			SSLPassthrough: &annotations.SSLPassthroughConfig{Enabled: true},
+		},
+	}
+
+	gatewayOptions := &common.ConvertOptions{
+		Gateways:           map[string]*common.WrapperGateway{},
+		IngressDomainCache: common.NewIngressDomainCache(),
+	}
+	if err := c.ConvertGateway(gatewayOptions, wrapper, nil); err != nil {
+		t.Fatalf("ConvertGateway() error = %v", err)
+	}
+	gateway := gatewayOptions.Gateways["example.com"].Gateway
+	if len(gateway.Servers) != 2 {
+		t.Fatalf("server count mismatch, want 2, got %d", len(gateway.Servers))
+	}
+	tlsServer := gateway.Servers[1]
+	if tlsServer.Port.Protocol != "TLS" {
+		t.Fatalf("protocol mismatch, want TLS, got %s", tlsServer.Port.Protocol)
+	}
+	if tlsServer.Port.Number != 443 {
+		t.Fatalf("port mismatch, want 443, got %d", tlsServer.Port.Number)
+	}
+	if tlsServer.Tls.GetMode() != networking.ServerTLSSettings_PASSTHROUGH {
+		t.Fatalf("tls mode mismatch, want PASSTHROUGH, got %s", tlsServer.Tls.GetMode())
+	}
+
+	routeOptions := &common.ConvertOptions{}
+	if err := c.ConvertHTTPRoute(routeOptions, wrapper); err != nil {
+		t.Fatalf("ConvertHTTPRoute() error = %v", err)
+	}
+	httpRoutes := routeOptions.HTTPRoutes["example.com"]
+	if len(httpRoutes) != 1 {
+		t.Fatalf("http route count mismatch, want 1, got %d", len(httpRoutes))
+	}
+	if got := httpRoutes[0].HTTPRoute.Route[0].Destination.Host; got != "app.default.svc.cluster.local" {
+		t.Fatalf("http destination host mismatch, got %s", got)
+	}
+	routes := routeOptions.VirtualServices["example.com"].VirtualService.Tls
+	if len(routes) != 1 {
+		t.Fatalf("tls route count mismatch, want 1, got %d", len(routes))
+	}
+	route := routes[0]
+	if got := route.Match[0].SniHosts[0]; got != "example.com" {
+		t.Fatalf("sni host mismatch, want example.com, got %s", got)
+	}
+	if got := route.Route[0].Destination.Host; got != "app.default.svc.cluster.local" {
+		t.Fatalf("destination host mismatch, got %s", got)
+	}
+	if got := route.Route[0].Destination.Port.Number; got != 443 {
+		t.Fatalf("destination port mismatch, got %d", got)
+	}
+}
+
+func TestSSLPassthroughUsesConfiguredHTTPSPort(t *testing.T) {
+	c := controller{
+		options: common.Options{
+			GatewayHttpPort:  80,
+			GatewayHttpsPort: 8443,
+		},
+	}
+	wrapper := &common.WrapperConfig{
+		Config: &config.Config{
+			Meta: config.Meta{
+				Namespace: "default",
+				Name:      "tls-passthrough",
+			},
+			Spec: ingressSpecWithSSLPassthroughBackend("example.com", "app", 443),
+		},
+		AnnotationsConfig: &annotations.Ingress{
+			SSLPassthrough: &annotations.SSLPassthroughConfig{Enabled: true},
+		},
+	}
+
+	gatewayOptions := &common.ConvertOptions{
+		Gateways:           map[string]*common.WrapperGateway{},
+		IngressDomainCache: common.NewIngressDomainCache(),
+	}
+	if err := c.ConvertGateway(gatewayOptions, wrapper, nil); err != nil {
+		t.Fatalf("ConvertGateway() error = %v", err)
+	}
+	tlsServer := gatewayOptions.Gateways["example.com"].Gateway.Servers[1]
+	if tlsServer.Port.Number != 8443 {
+		t.Fatalf("port mismatch, want 8443, got %d", tlsServer.Port.Number)
+	}
+}
+
+func TestSSLPassthroughCanaryIngressKeepsCanaryHandling(t *testing.T) {
+	c := controller{
+		options: common.Options{
+			GatewayHttpPort:  80,
+			GatewayHttpsPort: 443,
+		},
+	}
+	wrapper := &common.WrapperConfig{
+		Config: &config.Config{
+			Meta: config.Meta{
+				Namespace: "default",
+				Name:      "tls-passthrough-canary",
+			},
+			Spec: ingressSpecWithSSLPassthroughBackend("example.com", "app-canary", 443),
+		},
+		AnnotationsConfig: &annotations.Ingress{
+			Canary:         &annotations.CanaryConfig{Enabled: true},
+			SSLPassthrough: &annotations.SSLPassthroughConfig{Enabled: true},
+		},
+	}
+
+	routeOptions := &common.ConvertOptions{}
+	if err := c.ConvertHTTPRoute(routeOptions, wrapper); err != nil {
+		t.Fatalf("ConvertHTTPRoute() error = %v", err)
+	}
+	if len(routeOptions.CanaryIngresses) != 1 {
+		t.Fatalf("canary ingress count mismatch, want 1, got %d", len(routeOptions.CanaryIngresses))
+	}
+	if len(routeOptions.VirtualServices) != 0 {
+		t.Fatalf("unexpected virtual services: %+v", routeOptions.VirtualServices)
+	}
+}
+
+func TestSSLPassthroughSkipsDuplicatedTLSHost(t *testing.T) {
+	c := controller{
+		options: common.Options{
+			GatewayHttpPort:  80,
+			GatewayHttpsPort: 443,
+		},
+	}
+	primary := &common.WrapperConfig{
+		Config: &config.Config{
+			Meta: config.Meta{
+				Namespace: "default",
+				Name:      "tls-passthrough-primary",
+			},
+			Spec: ingressSpecWithSSLPassthroughBackend("example.com", "primary", 443),
+		},
+		AnnotationsConfig: &annotations.Ingress{
+			SSLPassthrough: &annotations.SSLPassthroughConfig{Enabled: true},
+		},
+	}
+	duplicate := &common.WrapperConfig{
+		Config: &config.Config{
+			Meta: config.Meta{
+				Namespace: "default",
+				Name:      "tls-passthrough-duplicate",
+			},
+			Spec: ingressSpecWithSSLPassthroughBackend("example.com", "duplicate", 443),
+		},
+		AnnotationsConfig: &annotations.Ingress{
+			SSLPassthrough: &annotations.SSLPassthroughConfig{Enabled: true},
+		},
+	}
+
+	options := &common.ConvertOptions{
+		Gateways:           map[string]*common.WrapperGateway{},
+		IngressDomainCache: common.NewIngressDomainCache(),
+	}
+	if err := c.ConvertGateway(options, primary, nil); err != nil {
+		t.Fatalf("ConvertGateway(primary) error = %v", err)
+	}
+	if err := c.ConvertGateway(options, duplicate, nil); err != nil {
+		t.Fatalf("ConvertGateway(duplicate) error = %v", err)
+	}
+	if !common.IsDuplicateTLSHost(options, duplicate.Config, "example.com") {
+		t.Fatal("duplicate TLS host was not recorded")
+	}
+
+	options.VirtualServices = map[string]*common.WrapperVirtualService{}
+	if err := c.ConvertTLSRoute(options, duplicate); err != nil {
+		t.Fatalf("ConvertTLSRoute() error = %v", err)
+	}
+	if len(options.VirtualServices) != 0 {
+		t.Fatalf("unexpected virtual services: %+v", options.VirtualServices)
+	}
+}
+
+func TestSSLPassthroughNonRootIngressDoesNotBlockLaterRootIngress(t *testing.T) {
+	c := controller{
+		options: common.Options{
+			GatewayHttpPort:  80,
+			GatewayHttpsPort: 443,
+		},
+	}
+	nonRoot := &common.WrapperConfig{
+		Config: &config.Config{
+			Meta: config.Meta{
+				Namespace: "default",
+				Name:      "tls-passthrough-non-root",
+			},
+			Spec: ingressSpecWithSSLPassthroughPaths("example.com", []v1.HTTPIngressPath{
+				ingressPath("/api", "api", 8443),
+			}),
+		},
+		AnnotationsConfig: &annotations.Ingress{
+			SSLPassthrough: &annotations.SSLPassthroughConfig{Enabled: true},
+		},
+	}
+	root := &common.WrapperConfig{
+		Config: &config.Config{
+			Meta: config.Meta{
+				Namespace: "default",
+				Name:      "tls-passthrough-root",
+			},
+			Spec: ingressSpecWithSSLPassthroughBackend("example.com", "root", 443),
+		},
+		AnnotationsConfig: &annotations.Ingress{
+			SSLPassthrough: &annotations.SSLPassthroughConfig{Enabled: true},
+		},
+	}
+
+	options := &common.ConvertOptions{
+		Gateways:           map[string]*common.WrapperGateway{},
+		IngressDomainCache: common.NewIngressDomainCache(),
+	}
+	if err := c.ConvertGateway(options, nonRoot, nil); err != nil {
+		t.Fatalf("ConvertGateway(nonRoot) error = %v", err)
+	}
+	if len(options.Gateways["example.com"].Gateway.Servers) != 1 {
+		t.Fatalf("non-root ingress server count mismatch, want 1, got %d", len(options.Gateways["example.com"].Gateway.Servers))
+	}
+	if err := c.ConvertGateway(options, root, nil); err != nil {
+		t.Fatalf("ConvertGateway(root) error = %v", err)
+	}
+	if common.IsDuplicateTLSHost(options, root.Config, "example.com") {
+		t.Fatal("root ingress was recorded as duplicated")
+	}
+	if options.Gateways["example.com"].Gateway.Servers[1].Tls.GetMode() != networking.ServerTLSSettings_PASSTHROUGH {
+		t.Fatal("root ingress did not create a TLS passthrough server")
+	}
+
+	options.VirtualServices = map[string]*common.WrapperVirtualService{}
+	if err := c.ConvertTLSRoute(options, root); err != nil {
+		t.Fatalf("ConvertTLSRoute(root) error = %v", err)
+	}
+	routes := options.VirtualServices["example.com"].VirtualService.Tls
+	if len(routes) != 1 {
+		t.Fatalf("tls route count mismatch, want 1, got %d", len(routes))
+	}
+	if got := routes[0].Route[0].Destination.Host; got != "root.default.svc.cluster.local" {
+		t.Fatalf("destination host mismatch, got %s", got)
+	}
+}
+
+func TestSSLPassthroughPreservesRepeatedHostInSameIngress(t *testing.T) {
+	c := controller{
+		options: common.Options{
+			GatewayHttpPort:  80,
+			GatewayHttpsPort: 443,
+		},
+	}
+	wrapper := &common.WrapperConfig{
+		Config: &config.Config{
+			Meta: config.Meta{
+				Namespace: "default",
+				Name:      "tls-passthrough-repeated-host",
+			},
+			Spec: v1.IngressSpec{
+				Rules: []v1.IngressRule{
+					{
+						Host: "example.com",
+						IngressRuleValue: v1.IngressRuleValue{
+							HTTP: &v1.HTTPIngressRuleValue{
+								Paths: []v1.HTTPIngressPath{
+									ingressPath("/health", "health", 8443),
+								},
+							},
+						},
+					},
+					{
+						Host: "example.com",
+						IngressRuleValue: v1.IngressRuleValue{
+							HTTP: &v1.HTTPIngressRuleValue{
+								Paths: []v1.HTTPIngressPath{
+									ingressPath("/", "root", 443),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		AnnotationsConfig: &annotations.Ingress{
+			SSLPassthrough: &annotations.SSLPassthroughConfig{Enabled: true},
+		},
+	}
+
+	options := &common.ConvertOptions{
+		Gateways:           map[string]*common.WrapperGateway{},
+		IngressDomainCache: common.NewIngressDomainCache(),
+	}
+	if err := c.ConvertGateway(options, wrapper, nil); err != nil {
+		t.Fatalf("ConvertGateway() error = %v", err)
+	}
+	if common.IsDuplicateTLSHost(options, wrapper.Config, "example.com") {
+		t.Fatal("same ingress host was recorded as duplicated")
+	}
+
+	options.VirtualServices = map[string]*common.WrapperVirtualService{}
+	if err := c.ConvertTLSRoute(options, wrapper); err != nil {
+		t.Fatalf("ConvertTLSRoute() error = %v", err)
+	}
+	routes := options.VirtualServices["example.com"].VirtualService.Tls
+	if len(routes) != 1 {
+		t.Fatalf("tls route count mismatch, want 1, got %d", len(routes))
+	}
+	if got := routes[0].Route[0].Destination.Host; got != "root.default.svc.cluster.local" {
+		t.Fatalf("destination host mismatch, got %s", got)
+	}
+}
+
+func TestSSLPassthroughUsesFirstRootBackendForRepeatedHost(t *testing.T) {
+	c := controller{}
+	wrapper := &common.WrapperConfig{
+		Config: &config.Config{
+			Meta: config.Meta{
+				Namespace: "default",
+				Name:      "tls-passthrough-repeated-root",
+			},
+			Spec: v1.IngressSpec{
+				Rules: []v1.IngressRule{
+					{
+						Host: "example.com",
+						IngressRuleValue: v1.IngressRuleValue{
+							HTTP: &v1.HTTPIngressRuleValue{
+								Paths: []v1.HTTPIngressPath{
+									ingressPath("/", "first", 443),
+								},
+							},
+						},
+					},
+					{
+						Host: "example.com",
+						IngressRuleValue: v1.IngressRuleValue{
+							HTTP: &v1.HTTPIngressRuleValue{
+								Paths: []v1.HTTPIngressPath{
+									ingressPath("/", "second", 443),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		AnnotationsConfig: &annotations.Ingress{
+			SSLPassthrough: &annotations.SSLPassthroughConfig{Enabled: true},
+		},
+	}
+
+	routeOptions := &common.ConvertOptions{}
+	if err := c.ConvertHTTPRoute(routeOptions, wrapper); err != nil {
+		t.Fatalf("ConvertHTTPRoute() error = %v", err)
+	}
+	routes := routeOptions.VirtualServices["example.com"].VirtualService.Tls
+	if len(routes) != 1 {
+		t.Fatalf("tls route count mismatch, want 1, got %d", len(routes))
+	}
+	if got := routes[0].Route[0].Destination.Host; got != "first.default.svc.cluster.local" {
+		t.Fatalf("destination host mismatch, got %s", got)
+	}
+}
+
+func TestSSLPassthroughHandlesMultipleHosts(t *testing.T) {
+	c := controller{}
+	testcases := []struct {
+		name       string
+		rules      []v1.IngressRule
+		wantHosts  []string
+		wantRoutes map[string]string
+	}{
+		{
+			name: "root path first",
+			rules: []v1.IngressRule{
+				ingressRule("first.example.com", ingressPath("/", "first", 443)),
+				ingressRule("middle.example.com", ingressPath("/health", "middle", 8443)),
+				ingressRule("last.example.com", ingressPath("/health", "last", 8443)),
+			},
+			wantHosts: []string{"first.example.com"},
+			wantRoutes: map[string]string{
+				"first.example.com": "first.default.svc.cluster.local",
+			},
+		},
+		{
+			name: "root path middle",
+			rules: []v1.IngressRule{
+				ingressRule("first.example.com", ingressPath("/health", "first", 8443)),
+				ingressRule("middle.example.com", ingressPath("/", "middle", 443)),
+				ingressRule("last.example.com", ingressPath("/health", "last", 8443)),
+			},
+			wantHosts: []string{"middle.example.com"},
+			wantRoutes: map[string]string{
+				"middle.example.com": "middle.default.svc.cluster.local",
+			},
+		},
+		{
+			name: "root path last",
+			rules: []v1.IngressRule{
+				ingressRule("first.example.com", ingressPath("/health", "first", 8443)),
+				ingressRule("middle.example.com", ingressPath("/health", "middle", 8443)),
+				ingressRule("last.example.com", ingressPath("/", "last", 443)),
+			},
+			wantHosts: []string{"last.example.com"},
+			wantRoutes: map[string]string{
+				"last.example.com": "last.default.svc.cluster.local",
+			},
+		},
+		{
+			name: "multiple root hosts",
+			rules: []v1.IngressRule{
+				ingressRule("first.example.com", ingressPath("/", "first", 443)),
+				ingressRule("middle.example.com", ingressPath("/", "middle", 443)),
+				ingressRule("last.example.com", ingressPath("/", "last", 443)),
+			},
+			wantHosts: []string{"first.example.com", "middle.example.com", "last.example.com"},
+			wantRoutes: map[string]string{
+				"first.example.com":  "first.default.svc.cluster.local",
+				"middle.example.com": "middle.default.svc.cluster.local",
+				"last.example.com":   "last.default.svc.cluster.local",
+			},
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			wrapper := &common.WrapperConfig{
+				Config: &config.Config{
+					Meta: config.Meta{
+						Namespace: "default",
+						Name:      "tls-passthrough-multi-host",
+					},
+					Spec: v1.IngressSpec{
+						Rules: tc.rules,
+					},
+				},
+				AnnotationsConfig: &annotations.Ingress{
+					SSLPassthrough: &annotations.SSLPassthroughConfig{Enabled: true},
+				},
+			}
+
+			routeOptions := &common.ConvertOptions{}
+			if err := c.ConvertHTTPRoute(routeOptions, wrapper); err != nil {
+				t.Fatalf("ConvertHTTPRoute() error = %v", err)
+			}
+			for _, host := range tc.wantHosts {
+				routes := routeOptions.VirtualServices[host].VirtualService.Tls
+				if len(routes) != 1 {
+					t.Fatalf("tls route count mismatch for host %s, want 1, got %d", host, len(routes))
+				}
+				if got := routes[0].Route[0].Destination.Host; got != tc.wantRoutes[host] {
+					t.Fatalf("destination host mismatch for host %s, want %s, got %s", host, tc.wantRoutes[host], got)
+				}
+			}
+		})
+	}
+}
+
+func TestSSLPassthroughUsesRootPathBackend(t *testing.T) {
+	c := controller{}
+	wrapper := &common.WrapperConfig{
+		Config: &config.Config{
+			Meta: config.Meta{
+				Namespace: "default",
+				Name:      "tls-passthrough-root",
+			},
+			Spec: ingressSpecWithSSLPassthroughPaths("example.com", []v1.HTTPIngressPath{
+				ingressPath("/api", "api", 8443),
+				ingressPath("/", "root", 443),
+			}),
+		},
+		AnnotationsConfig: &annotations.Ingress{
+			SSLPassthrough: &annotations.SSLPassthroughConfig{Enabled: true},
+		},
+	}
+
+	routeOptions := &common.ConvertOptions{}
+	if err := c.ConvertHTTPRoute(routeOptions, wrapper); err != nil {
+		t.Fatalf("ConvertHTTPRoute() error = %v", err)
+	}
+	routes := routeOptions.VirtualServices["example.com"].VirtualService.Tls
+	if len(routes) != 1 {
+		t.Fatalf("tls route count mismatch, want 1, got %d", len(routes))
+	}
+	if got := routes[0].Route[0].Destination.Host; got != "root.default.svc.cluster.local" {
+		t.Fatalf("destination host mismatch, got %s", got)
+	}
+}
+
+func TestSSLPassthroughIgnoresNonRootPath(t *testing.T) {
+	c := controller{}
+	wrapper := &common.WrapperConfig{
+		Config: &config.Config{
+			Meta: config.Meta{
+				Namespace: "default",
+				Name:      "tls-passthrough-non-root",
+			},
+			Spec: ingressSpecWithSSLPassthroughPaths("example.com", []v1.HTTPIngressPath{
+				ingressPath("/api", "api", 8443),
+			}),
+		},
+		AnnotationsConfig: &annotations.Ingress{
+			SSLPassthrough: &annotations.SSLPassthroughConfig{Enabled: true},
+		},
+	}
+
+	routeOptions := &common.ConvertOptions{}
+	if err := c.ConvertHTTPRoute(routeOptions, wrapper); err != nil {
+		t.Fatalf("ConvertHTTPRoute() error = %v", err)
+	}
+	if len(routeOptions.HTTPRoutes["example.com"]) != 1 {
+		t.Fatalf("http route count mismatch, want 1, got %d", len(routeOptions.HTTPRoutes["example.com"]))
+	}
+	if routes := routeOptions.VirtualServices["example.com"].VirtualService.Tls; len(routes) != 0 {
+		t.Fatalf("unexpected tls routes: %+v", routes)
+	}
+}
+
+func TestSSLPassthroughKeepsMCPResourceBackend(t *testing.T) {
+	c := controller{}
+	apiGroup := "networking.higress.io"
+	wrapper := &common.WrapperConfig{
+		Config: &config.Config{
+			Meta: config.Meta{
+				Namespace: "default",
+				Name:      "tls-passthrough-mcp",
+			},
+			Spec: ingressSpecWithSSLPassthroughPaths("example.com", []v1.HTTPIngressPath{
+				{
+					Path:     "/",
+					PathType: pathTypePtr(v1.PathTypePrefix),
+					Backend: v1.IngressBackend{
+						Resource: &corev1.TypedLocalObjectReference{
+							APIGroup: &apiGroup,
+							Kind:     "McpBridge",
+							Name:     "default",
+						},
+					},
+				},
+			}),
+		},
+		AnnotationsConfig: &annotations.Ingress{
+			Destination: &annotations.DestinationConfig{
+				McpDestination: []*networking.HTTPRouteDestination{
+					{
+						Destination: &networking.Destination{
+							Host: "mcp.example.internal",
+							Port: &networking.PortSelector{Number: 443},
+						},
+						Weight: 100,
+					},
+				},
+				WeightSum: 100,
+			},
+			SSLPassthrough: &annotations.SSLPassthroughConfig{Enabled: true},
+		},
+	}
+
+	routeOptions := &common.ConvertOptions{}
+	if err := c.ConvertHTTPRoute(routeOptions, wrapper); err != nil {
+		t.Fatalf("ConvertHTTPRoute() error = %v", err)
+	}
+	routes := routeOptions.VirtualServices["example.com"].VirtualService.Tls
+	if len(routes) != 1 {
+		t.Fatalf("tls route count mismatch, want 1, got %d", len(routes))
+	}
+	if got := routes[0].Route[0].Destination.Host; got != "mcp.example.internal" {
+		t.Fatalf("destination host mismatch, got %s", got)
+	}
+}
+
+func ingressSpecWithSSLPassthroughBackend(host, service string, port int32) v1.IngressSpec {
+	return ingressSpecWithSSLPassthroughPaths(host, []v1.HTTPIngressPath{
+		ingressPath("/", service, port),
+	})
+}
+
+func ingressSpecWithSSLPassthroughPaths(host string, paths []v1.HTTPIngressPath) v1.IngressSpec {
+	return v1.IngressSpec{
+		Rules: []v1.IngressRule{
+			{
+				Host: host,
+				IngressRuleValue: v1.IngressRuleValue{
+					HTTP: &v1.HTTPIngressRuleValue{
+						Paths: paths,
+					},
+				},
+			},
+		},
+	}
+}
+
+func ingressPath(path, service string, port int32) v1.HTTPIngressPath {
+	return v1.HTTPIngressPath{
+		Path:     path,
+		PathType: pathTypePtr(v1.PathTypePrefix),
+		Backend: v1.IngressBackend{
+			Service: &v1.IngressServiceBackend{
+				Name: service,
+				Port: v1.ServiceBackendPort{Number: port},
+			},
+		},
+	}
+}
+
+func pathTypePtr(pathType v1.PathType) *v1.PathType {
+	return &pathType
+}
+
+func ingressRule(host string, paths ...v1.HTTPIngressPath) v1.IngressRule {
+	return v1.IngressRule{
+		Host: host,
+		IngressRuleValue: v1.IngressRuleValue{
+			HTTP: &v1.HTTPIngressRuleValue{
+				Paths: paths,
+			},
+		},
 	}
 }

--- a/pkg/ingress/kube/ingressv1/controller_test.go
+++ b/pkg/ingress/kube/ingressv1/controller_test.go
@@ -15,8 +15,10 @@
 package ingressv1
 
 import (
+	"strings"
 	"testing"
 
+	"github.com/alibaba/higress/v2/pkg/cert"
 	"github.com/alibaba/higress/v2/pkg/ingress/kube/annotations"
 	"github.com/alibaba/higress/v2/pkg/ingress/kube/common"
 	"github.com/google/go-cmp/cmp"
@@ -309,6 +311,129 @@ func TestSSLPassthroughSkipsDuplicatedTLSHost(t *testing.T) {
 	}
 	if len(options.VirtualServices) != 0 {
 		t.Fatalf("unexpected virtual services: %+v", options.VirtualServices)
+	}
+}
+
+func TestSSLPassthroughDuplicateTLSHostRecordsInvalidDomain(t *testing.T) {
+	c := controller{
+		options: common.Options{
+			GatewayHttpPort:  80,
+			GatewayHttpsPort: 443,
+		},
+	}
+	primary := &common.WrapperConfig{
+		Config: &config.Config{
+			Meta: config.Meta{
+				Namespace: "default",
+				Name:      "tls-passthrough-primary",
+			},
+			Spec: ingressSpecWithSSLPassthroughBackend("example.com", "primary", 443),
+		},
+		AnnotationsConfig: &annotations.Ingress{
+			SSLPassthrough: &annotations.SSLPassthroughConfig{Enabled: true},
+		},
+	}
+	duplicate := &common.WrapperConfig{
+		Config: &config.Config{
+			Meta: config.Meta{
+				Namespace: "default",
+				Name:      "tls-passthrough-duplicate",
+			},
+			Spec: ingressSpecWithSSLPassthroughBackend("example.com", "duplicate", 443),
+		},
+		AnnotationsConfig: &annotations.Ingress{
+			SSLPassthrough: &annotations.SSLPassthroughConfig{Enabled: true},
+		},
+	}
+
+	options := &common.ConvertOptions{
+		Gateways:               map[string]*common.WrapperGateway{},
+		IngressDomainCache:     common.NewIngressDomainCache(),
+		SSLPassthroughTLSHosts: map[string]*config.Config{"example.com": primary.Config},
+		DuplicateTLSHosts:      map[common.TLSHostKey]struct{}{common.NewTLSHostKey(duplicate.Config, "example.com"): {}},
+	}
+	if err := c.ConvertGateway(options, primary, nil); err != nil {
+		t.Fatalf("ConvertGateway(primary) error = %v", err)
+	}
+	if err := c.ConvertGateway(options, duplicate, nil); err != nil {
+		t.Fatalf("ConvertGateway(duplicate) error = %v", err)
+	}
+
+	if len(options.IngressDomainCache.Invalid) != 1 {
+		t.Fatalf("invalid domain count mismatch, want 1, got %d", len(options.IngressDomainCache.Invalid))
+	}
+	invalid := options.IngressDomainCache.Invalid[0]
+	if invalid.Error == "" {
+		t.Fatal("duplicated tls invalid domain error is empty")
+	}
+	if !strings.Contains(invalid.Error, "tls-passthrough-primary") {
+		t.Fatalf("invalid domain error does not reference previous ingress: %s", invalid.Error)
+	}
+}
+
+func TestSSLPassthroughDuplicateTLSHostUsesExistingGatewayOwner(t *testing.T) {
+	c := controller{
+		options: common.Options{
+			GatewayHttpPort:  80,
+			GatewayHttpsPort: 443,
+		},
+	}
+	primary := &common.WrapperConfig{
+		Config: &config.Config{
+			Meta: config.Meta{
+				Namespace: "default",
+				Name:      "tls-primary",
+			},
+			Spec: v1.IngressSpec{
+				TLS: []v1.IngressTLS{
+					{Hosts: []string{"example.com"}},
+				},
+				Rules: []v1.IngressRule{
+					ingressRule("example.com", ingressPath("/", "primary", 443)),
+				},
+			},
+		},
+		AnnotationsConfig: &annotations.Ingress{},
+	}
+	duplicate := &common.WrapperConfig{
+		Config: &config.Config{
+			Meta: config.Meta{
+				Namespace: "default",
+				Name:      "tls-passthrough-duplicate",
+			},
+			Spec: ingressSpecWithSSLPassthroughBackend("example.com", "duplicate", 443),
+		},
+		AnnotationsConfig: &annotations.Ingress{
+			SSLPassthrough: &annotations.SSLPassthroughConfig{Enabled: true},
+		},
+	}
+	httpsCredentialConfig := &cert.Config{
+		CredentialConfig: []cert.CredentialEntry{
+			{
+				Domains:   []string{"example.com"},
+				TLSSecret: "default/example-tls",
+			},
+		},
+	}
+
+	options := &common.ConvertOptions{
+		Gateways:           map[string]*common.WrapperGateway{},
+		IngressDomainCache: common.NewIngressDomainCache(),
+		DuplicateTLSHosts:  map[common.TLSHostKey]struct{}{common.NewTLSHostKey(duplicate.Config, "example.com"): {}},
+	}
+	if err := c.ConvertGateway(options, primary, httpsCredentialConfig); err != nil {
+		t.Fatalf("ConvertGateway(primary) error = %v", err)
+	}
+	if err := c.ConvertGateway(options, duplicate, httpsCredentialConfig); err != nil {
+		t.Fatalf("ConvertGateway(duplicate) error = %v", err)
+	}
+
+	if len(options.IngressDomainCache.Invalid) != 1 {
+		t.Fatalf("invalid domain count mismatch, want 1, got %d", len(options.IngressDomainCache.Invalid))
+	}
+	invalid := options.IngressDomainCache.Invalid[0]
+	if !strings.Contains(invalid.Error, "tls-primary") {
+		t.Fatalf("invalid domain error does not reference existing gateway owner: %s", invalid.Error)
 	}
 }
 


### PR DESCRIPTION
fixes: #1596

This pull request introduces support for SSL passthrough in Ingress resources, allowing certain hosts to be handled using TLS passthrough mode based on annotations. The changes include new annotation parsing logic, updates to the conversion pipeline to honor passthrough ownership, and comprehensive tests to verify the correct behavior. The implementation ensures that only the first root path Ingress for a host can claim SSL passthrough ownership, which is critical for correct gateway and virtual service generation.

Key changes include:

**SSL Passthrough Annotation Support:**
* Added a new annotation parser (`ssl_passthrough.go`) to recognize and parse the `ssl-passthrough` annotation, with a corresponding config struct and logic to set passthrough mode when enabled.
* Registered the new annotation handler in the annotation manager and added a helper method `IsSSLPassthrough` to check if passthrough is enabled on an Ingress. [[1]](diffhunk://#diff-ddb75c5114f0e92c04e27acc0f35c66d3eac13a0d3cf8a10bfe87e59b149dcf5R60-R61) [[2]](diffhunk://#diff-ddb75c5114f0e92c04e27acc0f35c66d3eac13a0d3cf8a10bfe87e59b149dcf5R120-R123) [[3]](diffhunk://#diff-ddb75c5114f0e92c04e27acc0f35c66d3eac13a0d3cf8a10bfe87e59b149dcf5R166)

**Ingress Conversion Pipeline Updates:**
* Updated the gateway and virtual service conversion logic to call `preparePassthroughTLSHostOwners`, which determines which hosts are claimed for passthrough by the first root path Ingress with passthrough enabled. [[1]](diffhunk://#diff-0edc009a5759e00729c3aba40c397870430d0173388d20bef28681f0b0665aa8R443) [[2]](diffhunk://#diff-0edc009a5759e00729c3aba40c397870430d0173388d20bef28681f0b0665aa8R510-R511) [[3]](diffhunk://#diff-0edc009a5759e00729c3aba40c397870430d0173388d20bef28681f0b0665aa8R629-R716)
* Modified the virtual service conversion to use new naming and cluster ID logic, ensuring correct association for passthrough and non-passthrough hosts. [[1]](diffhunk://#diff-0edc009a5759e00729c3aba40c397870430d0173388d20bef28681f0b0665aa8L573-R579) [[2]](diffhunk://#diff-0edc009a5759e00729c3aba40c397870430d0173388d20bef28681f0b0665aa8L588-R610) [[3]](diffhunk://#diff-0edc009a5759e00729c3aba40c397870430d0173388d20bef28681f0b0665aa8R629-R716)
* Added helper functions for extracting root path hosts and for creating passthrough servers. [[1]](diffhunk://#diff-0edc009a5759e00729c3aba40c397870430d0173388d20bef28681f0b0665aa8R629-R716) [[2]](diffhunk://#diff-db0bb2eb8fe267c708bbb870132c07a825cfaeada314b39c174766bef94ebd69R83-R96)

**Testing Improvements:**
* Added comprehensive unit tests for passthrough annotation parsing and the new passthrough ownership logic, including edge cases for multiple Ingresses and fallback scenarios. [[1]](diffhunk://#diff-d6cdd0d4b68843dc3624939b817af46ef3275b6e29cab7dfc6876c3da9da42bbR1-R112) [[2]](diffhunk://#diff-6ecb1b3bc77fc20474e6d94f443d966d84ade708b3b6a10aa4b89902f1df2f2cR113-R440)

**Dependency and Import Updates:**
* Imported the necessary Kubernetes networking API packages and constants for TLS passthrough handling. [[1]](diffhunk://#diff-0edc009a5759e00729c3aba40c397870430d0173388d20bef28681f0b0665aa8R49-R50) [[2]](diffhunk://#diff-6ecb1b3bc77fc20474e6d94f443d966d84ade708b3b6a10aa4b89902f1df2f2cR26) [[3]](diffhunk://#diff-db0bb2eb8fe267c708bbb870132c07a825cfaeada314b39c174766bef94ebd69R18) [[4]](diffhunk://#diff-db0bb2eb8fe267c708bbb870132c07a825cfaeada314b39c174766bef94ebd69R27)

These changes collectively enable robust, annotation-driven SSL passthrough support in the Ingress controller, with clear precedence and test coverage for correct behavior.
