### PR TITLE
fix(ai-proxy): omit null error field in Anthropic non-stream response

### DIFF
--- a/plugins/wasm-go/extensions/ai-proxy/provider/claude.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/claude.go
@@ -249,7 +249,7 @@ type claudeTextGenResponse struct {
 	StopReason   *string                `json:"stop_reason"`
 	StopSequence *string                `json:"stop_sequence"`
 	Usage        claudeTextGenUsage     `json:"usage"`
-	Error        *claudeTextGenError    `json:"error"`
+	Error        *claudeTextGenError    `json:"error,omitempty"`
 }
 
 type claudeTextGenContent struct {

--- a/plugins/wasm-go/extensions/ai-proxy/provider/claude.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/claude.go
@@ -250,7 +250,7 @@ type claudeTextGenResponse struct {
 	StopReason   *string                `json:"stop_reason"`
 	StopSequence *string                `json:"stop_sequence"`
 	Usage        claudeTextGenUsage     `json:"usage"`
-	Error        *claudeTextGenError    `json:"error"`
+	Error        *claudeTextGenError    `json:"error,omitempty"`
 }
 
 type claudeTextGenContent struct {

--- a/plugins/wasm-go/extensions/ai-proxy/provider/claude_to_openai_test.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/claude_to_openai_test.go
@@ -1066,6 +1066,10 @@ func TestClaudeToOpenAIConverter_ConvertOpenAIResponseToClaude(t *testing.T) {
 		result, err := converter.ConvertOpenAIResponseToClaude(nil, []byte(openaiResponse))
 		require.NoError(t, err)
 
+		// A successful conversion must not include the non-standard "error" field;
+		// it confuses native Anthropic clients (see issue #3957).
+		assert.NotContains(t, string(result), "\"error\"")
+
 		var claudeResponse claudeTextGenResponse
 		err = json.Unmarshal(result, &claudeResponse)
 		require.NoError(t, err)


### PR DESCRIPTION
## Ⅰ. Describe what this PR did

When a client calls the gateway via the native Anthropic protocol (`/v1/messages`) against an OpenAI-protocol upstream and the response is converted back to Claude format, the non-stream response body carries a non-standard `"error": null` field. Native Anthropic clients (Claude Code, the Anthropic SDKs) do not expect `error` on a successful message and reject the response.

The struct tag on `claudeTextGenResponse.Error` was missing `omitempty`, so `json.Marshal` always emitted `"error": null` on success. This adds `,omitempty` to the tag so the field is dropped when nil. `stop_reason` / `stop_sequence` are deliberately left non-omitempty: they are standard, legitimately nullable Anthropic fields.

## Ⅱ. Does this pull request fix one issue?

fixes #3957

## Ⅲ. Why don't you add test cases (unit test/integration test)?

Added. `TestClaudeToOpenAIConverter_ConvertOpenAIResponseToClaude` now asserts the marshaled bytes contain no `"error"` key. The existing assertions unmarshal back into the struct, so a stray `null` round-trips invisibly; the new check is on the raw JSON, which is what the client sees and what the issue reports.

## Ⅳ. Describe how to verify it

From `plugins/wasm-go/extensions/ai-proxy`:

```
go build ./...
go test ./provider/ -count=1
gofmt -l provider/claude.go provider/claude_to_openai_test.go   # expect empty
```

Regression check: revert the tag to `json:"error"`, run `go test ./provider/ -run TestClaudeToOpenAIConverter_ConvertOpenAIResponseToClaude` -> the new assertion fails on `"error":null` (the exact symptom from the issue); restore `,omitempty` -> green.

## Ⅴ. Special notes for reviews

Single behavior-preserving struct-tag change plus a test. Real upstream errors are still raised before conversion in `TransformResponseBody` (`claude.go:406-407`), so `Error` is only ever nil on success; `omitempty` just drops the redundant `null`. The alternative (never building the `Error` pointer on success) would be a larger diff for the same observable result.

## Ⅵ. AI Coding Tool Usage Checklist (if applicable)

**Please check all applicable items:**

- [ ] **For new standalone features** (e.g., new wasm plugin or golang-filter plugin):
  - [ ] I have created a `design/` directory in the plugin folder
  - [ ] I have added the design document to the `design/` directory
  - [ ] I have included the AI Coding summary below

- [x] **For regular updates/changes** (not new plugins):
  - [x] I have provided the prompts/instructions I gave to the AI Coding tool below
  - [x] I have included the AI Coding summary below

### AI Coding Prompts (for regular updates)

> Fix issue #3957: native Anthropic non-stream responses include `"error": null` and break Anthropic clients. Find the root cause in ai-proxy, apply the smallest behavior-preserving fix, and add a regression test. Keep the diff surgical.

### AI Coding Summary

- **Key decisions:** Root cause is `claudeTextGenResponse.Error` lacking `omitempty` (`claude.go:252`); `ConvertOpenAIResponseToClaude` never sets `Error`, so success responses marshaled `"error":null`. Chose `,omitempty` over removing the field to stay minimal and behavior-preserving. Left `stop_reason`/`stop_sequence` alone since those are standard nullable Anthropic fields.
- **Changes:** struct tag `json:"error"` -> `json:"error,omitempty"`; added a raw-bytes `assert.NotContains(..., "\"error\"")` to the existing converter test (existing asserts unmarshal back into the struct so cannot catch a stray null).
- **Limitations:** marshal-only change; inbound real upstream errors are raised earlier (`claude.go:406-407`) and are unaffected. Verified with `go build`, `go test ./provider/`, `gofmt`; reproduced the bug and confirmed the test fails without the fix.
