### PR TITLE
feat(ai-statistics): extend default attributes with custom attributes

### DIFF
--- a/plugins/wasm-go/extensions/ai-statistics/README.md
+++ b/plugins/wasm-go/extensions/ai-statistics/README.md
@@ -26,7 +26,7 @@ description: AI可观测配置参考
 |----------------|-------|------|-----|------------------------|
 | `use_default_attributes` | bool | 非必填  | false   | 是否使用默认完整属性配置，包含 messages、answer、question 等所有字段。适用于调试、审计场景 |
 | `use_default_response_attributes` | bool | 非必填  | false   | 是否使用轻量级默认属性配置（推荐），包含 model 和 token 统计，不缓冲流式响应体。适用于高并发生产环境 |
-| `attributes` | []Attribute | 非必填  | -   | 用户希望记录在log/span中的信息 |
+| `attributes` | []Attribute | 非必填  | -   | 用户希望记录在log/span中的信息。当同时开启 `use_default_attributes` 或 `use_default_response_attributes` 时，这里配置的属性会追加到默认属性集之后，无需重新声明整套默认属性 |
 | `disable_openai_usage` | bool | 非必填  | false   | 非openai兼容协议时，model、token的支持非标，配置为true时可以避免报错 |
 | `value_length_limit` | int | 非必填  | 4000   | 记录的单个value的长度限制 |
 | `enable_path_suffixes` | []string    | 非必填   | []     | 只对这些特定路径后缀的请求生效，可以配置为 "\*" 以匹配所有路径（通配符检查会优先进行以提高性能）。如果为空数组，则对所有路径生效 |
@@ -464,6 +464,19 @@ use_default_attributes: true
 | `output_token_details` | 输出 token 详情 | 无 |
 
 **注意**：完整模式适用于调试、审计等需要完整对话记录的场景，但在高并发生产环境可能消耗大量内存。
+
+#### 默认属性 + 自定义属性
+
+开启 `use_default_attributes` 或 `use_default_response_attributes` 时，仍可在 `attributes` 中追加自定义属性，它们会附加到默认属性集之后，无需重新声明整套默认属性：
+
+```yaml
+use_default_attributes: true
+attributes:
+  - key: custom_tag
+    value_source: request_header
+    value: x-tag
+    apply_to_log: true
+```
 
 ### 流式日志示例
 

--- a/plugins/wasm-go/extensions/ai-statistics/README_EN.md
+++ b/plugins/wasm-go/extensions/ai-statistics/README_EN.md
@@ -24,7 +24,7 @@ Users can also expand observable values ​​through configuration:
 
 | Name             | Type  | Required | Default | Description |
 |----------------|-------|------|-----|------------------------|
-| `attributes` | []Attribute | optional  | -   | Information that the user wants to record in log/span |
+| `attributes` | []Attribute | optional  | -   | Information that the user wants to record in log/span. When `use_default_attributes` or `use_default_response_attributes` is enabled, attributes configured here are appended to the default attribute set, so there is no need to re-declare the full default list |
 | `disable_openai_usage` | bool | optional  | false   | When using a non-OpenAI-compatible protocol, the support for model and token is non-standard. Setting the configuration to true can prevent errors. |
 | `value_length_limit` | int | optional  | 4000   | length limit for each value |
 | `enable_path_suffixes`   | []string    | optional | ["/v1/chat/completions","/v1/completions","/v1/embeddings","/v1/models","/generateContent","/streamGenerateContent"] | Only effective for requests with these specific path suffixes, can be configured as "\*" to match all paths                                         |

--- a/plugins/wasm-go/extensions/ai-statistics/main.go
+++ b/plugins/wasm-go/extensions/ai-statistics/main.go
@@ -563,35 +563,40 @@ func parseConfig(configJson gjson.Result, config *AIStatisticsConfig) error {
 		config.valueLengthLimit = 32000
 	}
 
-	// Parse attributes or use defaults
+	// Parse user-supplied attributes (validated the same way regardless of mode).
+	customAttributes := make([]Attribute, len(attributeConfigs))
+	for i, attributeConfig := range attributeConfigs {
+		attribute := Attribute{}
+		err := json.Unmarshal([]byte(attributeConfig.Raw), &attribute)
+		if err != nil {
+			log.Errorf("parse config failed, %v", err)
+			return err
+		}
+		if attribute.Rule != "" && attribute.Rule != RuleFirst && attribute.Rule != RuleReplace && attribute.Rule != RuleAppend {
+			return errors.New("value of rule must be one of [nil, first, replace, append]")
+		}
+		customAttributes[i] = attribute
+	}
+
+	// Parse attributes or use defaults. When a default mode is enabled, any
+	// user-supplied attributes extend (not replace) the default set, so callers
+	// can add a few custom fields without re-declaring the whole default list.
 	if useDefaultAttributes {
-		config.attributes = getDefaultAttributes()
+		config.attributes = append(getDefaultAttributes(), customAttributes...)
 		// Update value_length_limit to default when using default attributes
 		if !configJson.Get("value_length_limit").Exists() {
 			config.valueLengthLimit = 10485760 // 10MB
 		}
 		log.Infof("Using default attributes configuration")
 	} else if useDefaultResponseAttributes {
-		config.attributes = getDefaultResponseAttributes()
+		config.attributes = append(getDefaultResponseAttributes(), customAttributes...)
 		// Use a reasonable default for lightweight mode
 		if !configJson.Get("value_length_limit").Exists() {
 			config.valueLengthLimit = 4000
 		}
 		log.Infof("Using default response attributes configuration (lightweight mode)")
 	} else {
-		config.attributes = make([]Attribute, len(attributeConfigs))
-		for i, attributeConfig := range attributeConfigs {
-			attribute := Attribute{}
-			err := json.Unmarshal([]byte(attributeConfig.Raw), &attribute)
-			if err != nil {
-				log.Errorf("parse config failed, %v", err)
-				return err
-			}
-			if attribute.Rule != "" && attribute.Rule != RuleFirst && attribute.Rule != RuleReplace && attribute.Rule != RuleAppend {
-				return errors.New("value of rule must be one of [nil, first, replace, append]")
-			}
-			config.attributes[i] = attribute
-		}
+		config.attributes = customAttributes
 	}
 
 	// Check if any attribute needs request body or streaming body buffering
@@ -1470,10 +1475,10 @@ func setSpanAttribute(key string, value interface{}) {
 
 // isErrorResponse checks whether the LLM response indicates an error.
 // Detects errors by:
-// 1. Response body contains non-null "error" field at root level (OpenAI/Anthropic format).
-//    Handles both raw JSON and SSE "data: " prefixed chunks, including multi-event
-//    streaming buffers.
-// 2. HTTP status code >= 400 as fallback when body is empty.
+//  1. Response body contains non-null "error" field at root level (OpenAI/Anthropic format).
+//     Handles both raw JSON and SSE "data: " prefixed chunks, including multi-event
+//     streaming buffers.
+//  2. HTTP status code >= 400 as fallback when body is empty.
 //
 // Note: some providers (e.g. Anthropic streaming responses) emit {"error":""}
 // even on success; an empty-string error is treated as not-an-error to avoid

--- a/plugins/wasm-go/extensions/ai-statistics/main_test.go
+++ b/plugins/wasm-go/extensions/ai-statistics/main_test.go
@@ -3156,3 +3156,46 @@ func TestStreamingFramerResyncIntegration(t *testing.T) {
 		})
 	})
 }
+
+// use_default_attributes / use_default_response_attributes combined with a
+// custom attributes list: the custom attributes must extend (not replace) the
+// default set, so callers can add a few fields without re-declaring the whole
+// default list. See issue #4018. GetMatchConfig only returns the parsed config
+// in go mode, so these run via RunGoTest.
+func TestConfigDefaultAttributesExtendedByCustom(t *testing.T) {
+	test.RunGoTest(t, func(t *testing.T) {
+		t.Run("default attributes extended by custom", func(t *testing.T) {
+			host, status := test.NewTestHost([]byte(`{
+				"use_default_attributes": true,
+				"attributes": [
+					{"key": "custom_tag", "value_source": "request_header", "value": "x-tag", "apply_to_log": true}
+				]
+			}`))
+			defer host.Reset()
+			require.Equal(t, types.OnPluginStartStatusOK, status)
+
+			conf, err := host.GetMatchConfig()
+			require.NoError(t, err)
+			c := conf.(*AIStatisticsConfig)
+			require.Len(t, c.attributes, len(getDefaultAttributes())+1)
+			require.Equal(t, "custom_tag", c.attributes[len(c.attributes)-1].Key)
+		})
+
+		t.Run("default response attributes extended by custom", func(t *testing.T) {
+			host, status := test.NewTestHost([]byte(`{
+				"use_default_response_attributes": true,
+				"attributes": [
+					{"key": "custom_tag", "value_source": "request_header", "value": "x-tag", "apply_to_log": true}
+				]
+			}`))
+			defer host.Reset()
+			require.Equal(t, types.OnPluginStartStatusOK, status)
+
+			conf, err := host.GetMatchConfig()
+			require.NoError(t, err)
+			c := conf.(*AIStatisticsConfig)
+			require.Len(t, c.attributes, len(getDefaultResponseAttributes())+1)
+			require.Equal(t, "custom_tag", c.attributes[len(c.attributes)-1].Key)
+		})
+	})
+}


### PR DESCRIPTION
## Ⅰ. Describe what this PR did

The `ai-statistics` plugin treated `use_default_attributes` /
`use_default_response_attributes` and the custom `attributes` list as mutually
exclusive: turning on a default mode silently discarded any user `attributes`.
To add a single custom field you had to copy the entire default attribute set
into your config.

This change makes custom `attributes` extend the chosen default set instead of
replacing it. `parseConfig` now parses and validates the user attributes once
(unchanged rule check), and when a default mode is enabled it appends them after
the defaults. When no default mode is set, behavior is identical to before
(custom-only). When no custom attributes are configured, the default sets are
unchanged.

## Ⅱ. Does this pull request fix one issue?

fixes #4018

## Ⅲ. Why don't you add test cases (unit test/integration test)?

Added. `TestConfigDefaultAttributesExtendedByCustom` covers both
`use_default_attributes` and `use_default_response_attributes` combined with a
custom attribute, asserting the result is `len(defaults)+1` and that the custom
attribute is appended last.

## Ⅳ. Describe how to verify it

```
cd plugins/wasm-go/extensions/ai-statistics
go test ./... -count=1
```

Or set `use_default_attributes: true` and add one `attributes` entry: the
emitted ai_log now contains the full default set plus the custom field.

## Ⅴ. Special notes for reviews

- Append-only; no dedup of duplicate keys (none required today, no key
  collisions with defaults). Happy to add dedup if you'd prefer.
- Validation (the `rule` check) now also applies to custom attributes when a
  default mode is on; previously they were ignored entirely.
- README.md keeps a worked example; README_EN.md has no default-attrs example
  section, so only the `attributes` row note was updated.

## Ⅵ. AI Coding Tool Usage Checklist (if applicable)

**Please check all applicable items:**

- [x] **For regular updates/changes** (not new plugins):
  - [x] I have provided the prompts/instructions I gave to the AI Coding tool below
  - [x] I have included the AI Coding summary below

### AI Coding Prompts (for regular updates)

Extend the `ai-statistics` plugin so that `use_default_attributes` /
`use_default_response_attributes` combined with a custom `attributes` list
appends the custom attributes to the default set instead of discarding them.
Keep behavior unchanged when no custom attributes are configured, add unit
tests, and update both READMEs.

### AI Coding Summary

- Parse the user `attributes` once into a slice (reusing the existing
  `json.Unmarshal` + `rule` validation path), then `append(defaults, custom...)`
  in the two default-mode branches; custom-only otherwise.
- `getDefaultAttributes()` / `getDefaultResponseAttributes()` return a fresh
  slice literal per call, so the append has no shared-backing aliasing.
- Default sets are unchanged when no custom attributes are configured.
- Added `TestConfigDefaultAttributesExtendedByCustom` (two subtests) and noted
  the new extend behavior in `README.md` and `README_EN.md`.
