### PR TITLE
feat(ai-load-balancer): support SGLang inference engine metrics

### DIFF
--- a/plugins/wasm-go/extensions/ai-load-balancer/README.md
+++ b/plugins/wasm-go/extensions/ai-load-balancer/README.md
@@ -170,6 +170,7 @@ sequenceDiagram
 |--------------------|-----------------|------------------|-------------|-------------------------------------|
 | `metric_policy`      | string | 必填 | | 如何使用llm暴露的metrics做负载均衡，当前支持`[default, least, most]` |
 | `target_metric`      | string | 选填 | | 要使用的metric名称，`metric_policy` 取值为 `least` 或者 `most` 时生效 |
+| `engine`      | string | 选填 | vllm | 暴露 metrics 的推理引擎，当前支持`[vllm, sglang]` |
 | `rate_limit`      | string | 选填 | 1 | 单个节点处理请求比例上限，取值范围0~1 |
 
 
@@ -204,6 +205,18 @@ lb_policy: metrics_based
 lb_config:
   metric_policy: least
   target_metric: vllm:num_requests_running
+  rate_limit: 0.6 # 单个节点承载的最大请求比例
+```
+
+当后端推理引擎是 SGLang 而非 vLLM 时，设置 `engine: sglang` ，metrics 会按照 SGLang 的指标名称解析
+（对应的 `target_metric` 为 `sglang:num_queue_reqs` / `sglang:num_running_reqs`）
+
+```yaml
+lb_type: endpoint
+lb_policy: metrics_based
+lb_config:
+  metric_policy: default
+  engine: sglang
   rate_limit: 0.6 # 单个节点承载的最大请求比例
 ```
 

--- a/plugins/wasm-go/extensions/ai-load-balancer/README_EN.md
+++ b/plugins/wasm-go/extensions/ai-load-balancer/README_EN.md
@@ -174,6 +174,7 @@ sequenceDiagram
 |--------------------|-----------------|------------------|-------------|-------------------------------------|
 | `metric_policy`      | string | required | | How to use the metrics exposed by LLM for load balancing, currently supporting `[default, least, most]` |
 | `target_metric`      | string | optional | | The metric name to use. This is valid only when `metric_policy` is `least` or `most` |
+| `engine`      | string | optional | vllm | The inference engine that exposes the metrics, supporting `[vllm, sglang]` |
 | `rate_limit`      | string | optional | 1 | The maximum percentage of requests a single node can receive, 0~1 |
 
 ## Configuration Example
@@ -207,6 +208,19 @@ lb_policy: metrics_based
 lb_config:
   metric_policy: least
   target_metric: vllm:num_requests_running
+  rate_limit: 0.6
+```
+
+When the backend is SGLang instead of vLLM, set `engine: sglang` so the metrics are
+parsed with the SGLang metric names (the equivalent `target_metric` would be
+`sglang:num_queue_reqs` / `sglang:num_running_reqs`):
+
+```yaml
+lb_type: endpoint
+lb_policy: metrics_based
+lb_config:
+  metric_policy: default
+  engine: sglang
   rate_limit: 0.6
 ```
 

--- a/plugins/wasm-go/extensions/ai-load-balancer/endpoint_metrics/backend/sglang/metrics.go
+++ b/plugins/wasm-go/extensions/ai-load-balancer/endpoint_metrics/backend/sglang/metrics.go
@@ -1,0 +1,100 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package sglang provides sglang specific pod metrics implementation.
+package sglang
+
+import (
+	"fmt"
+
+	"github.com/alibaba/higress/plugins/wasm-go/extensions/ai-load-balancer/endpoint_metrics/backend"
+
+	dto "github.com/prometheus/client_model/go"
+	"go.uber.org/multierr"
+)
+
+const (
+	// SGLang exposes its scheduler state as standard Prometheus gauges when the
+	// server is started with `--enable-metrics`.
+	// See https://docs.sglang.io/references/production_metrics.html
+	RunningQueueSizeMetricName    = "sglang:num_running_reqs"
+	WaitingQueueSizeMetricName    = "sglang:num_queue_reqs"
+	KVCacheUsagePercentMetricName = "sglang:token_usage"
+)
+
+// PromToPodMetrics updates internal pod metrics with scraped prometheus metrics.
+// A combined error is returned if errors occur in one or more metric processing.
+// It returns a new PodMetrics pointer which can be used to atomically update the
+// pod metrics map.
+//
+// SGLang has no LoRA-adapter metric analogous to vLLM's `vllm:lora_requests_info`,
+// so ActiveModels is left unpopulated; the default metric policy works on queue
+// sizes and KV cache usage.
+func PromToPodMetrics(
+	metricFamilies map[string]*dto.MetricFamily,
+	existing *backend.PodMetrics,
+) (*backend.PodMetrics, error) {
+	var errs error
+	updated := existing.Clone()
+	// User selected metric
+	if updated.MetricName != "" {
+		metricValue, err := getLatestMetric(metricFamilies, updated.MetricName)
+		errs = multierr.Append(errs, err)
+		if err == nil {
+			updated.MetricValue = metricValue.GetGauge().GetValue()
+		}
+		return updated, errs
+	}
+	// Default metric
+	runningQueueSize, err := getLatestMetric(metricFamilies, RunningQueueSizeMetricName)
+	errs = multierr.Append(errs, err)
+	if err == nil {
+		updated.RunningQueueSize = int(runningQueueSize.GetGauge().GetValue())
+	}
+	waitingQueueSize, err := getLatestMetric(metricFamilies, WaitingQueueSizeMetricName)
+	errs = multierr.Append(errs, err)
+	if err == nil {
+		updated.WaitingQueueSize = int(waitingQueueSize.GetGauge().GetValue())
+	}
+	cachePercent, err := getLatestMetric(metricFamilies, KVCacheUsagePercentMetricName)
+	errs = multierr.Append(errs, err)
+	if err == nil {
+		updated.KVCacheUsagePercent = cachePercent.GetGauge().GetValue()
+	}
+
+	return updated, errs
+}
+
+// getLatestMetric gets the latest metric of a family. This should be used to get the latest Gauge metric.
+// Since sglang doesn't set the timestamp in metric, this metric essentially gets the first metric.
+func getLatestMetric(metricFamilies map[string]*dto.MetricFamily, metricName string) (*dto.Metric, error) {
+	mf, ok := metricFamilies[metricName]
+	if !ok {
+		return nil, fmt.Errorf("metric family %q not found", metricName)
+	}
+	if len(mf.GetMetric()) == 0 {
+		return nil, fmt.Errorf("no metrics available for %q", metricName)
+	}
+	var latestTs int64
+	var latest *dto.Metric
+	for _, m := range mf.GetMetric() {
+		if m.GetTimestampMs() >= latestTs {
+			latestTs = m.GetTimestampMs()
+			latest = m
+		}
+	}
+	return latest, nil
+}

--- a/plugins/wasm-go/extensions/ai-load-balancer/endpoint_metrics/backend/sglang/metrics_test.go
+++ b/plugins/wasm-go/extensions/ai-load-balancer/endpoint_metrics/backend/sglang/metrics_test.go
@@ -1,0 +1,117 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sglang
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/alibaba/higress/plugins/wasm-go/extensions/ai-load-balancer/endpoint_metrics/backend"
+
+	dto "github.com/prometheus/client_model/go"
+	"github.com/prometheus/common/expfmt"
+)
+
+// sample mirrors the gauges from a real SGLang /metrics endpoint
+// (https://docs.sglang.io/references/production_metrics.html), trimmed to the
+// gauges the load balancer reads plus an unrelated counter that must be ignored.
+const sample = `# HELP sglang:prompt_tokens_total Number of prefill tokens processed.
+# TYPE sglang:prompt_tokens_total counter
+sglang:prompt_tokens_total{model_name="meta-llama/Llama-3.1-8B-Instruct"} 8128902
+# HELP sglang:num_running_reqs The number of running requests
+# TYPE sglang:num_running_reqs gauge
+sglang:num_running_reqs{model_name="meta-llama/Llama-3.1-8B-Instruct"} 162
+# HELP sglang:num_queue_reqs The number of requests in the waiting queue
+# TYPE sglang:num_queue_reqs gauge
+sglang:num_queue_reqs{model_name="meta-llama/Llama-3.1-8B-Instruct"} 2826
+# HELP sglang:token_usage The token usage
+# TYPE sglang:token_usage gauge
+sglang:token_usage{model_name="meta-llama/Llama-3.1-8B-Instruct"} 0.28
+`
+
+func parse(t *testing.T, metrics string) map[string]*dto.MetricFamily {
+	t.Helper()
+	parser := expfmt.TextParser{}
+	mfs, err := parser.TextToMetricFamilies(strings.NewReader(metrics))
+	if err != nil {
+		t.Fatalf("failed to parse metrics: %v", err)
+	}
+	return mfs
+}
+
+func newPodMetrics(targetMetric string) *backend.PodMetrics {
+	return &backend.PodMetrics{
+		Pod:                backend.Pod{Name: "pod-a", Address: "10.0.0.1:30000"},
+		Metrics:            backend.Metrics{},
+		UserSelectedMetric: backend.UserSelectedMetric{MetricName: targetMetric},
+	}
+}
+
+func TestPromToPodMetrics_DefaultGauges(t *testing.T) {
+	got, err := PromToPodMetrics(parse(t, sample), newPodMetrics(""))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.RunningQueueSize != 162 {
+		t.Errorf("RunningQueueSize: got %d, want 162", got.RunningQueueSize)
+	}
+	if got.WaitingQueueSize != 2826 {
+		t.Errorf("WaitingQueueSize: got %d, want 2826", got.WaitingQueueSize)
+	}
+	if got.KVCacheUsagePercent != 0.28 {
+		t.Errorf("KVCacheUsagePercent: got %v, want 0.28", got.KVCacheUsagePercent)
+	}
+}
+
+func TestPromToPodMetrics_UserSelectedMetric(t *testing.T) {
+	got, err := PromToPodMetrics(parse(t, sample), newPodMetrics(WaitingQueueSizeMetricName))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.MetricValue != 2826 {
+		t.Errorf("MetricValue: got %v, want 2826", got.MetricValue)
+	}
+	// When a target metric is selected, the default gauges are not populated.
+	if got.RunningQueueSize != 0 {
+		t.Errorf("RunningQueueSize should stay 0 when a target metric is set, got %d", got.RunningQueueSize)
+	}
+}
+
+func TestPromToPodMetrics_MissingFamilies(t *testing.T) {
+	// Only one of the three default gauges is present; the others must error via
+	// multierr without aborting parsing of the family that is present.
+	const partial = `# TYPE sglang:num_running_reqs gauge
+sglang:num_running_reqs{model_name="m"} 7
+`
+	got, err := PromToPodMetrics(parse(t, partial), newPodMetrics(""))
+	if err == nil {
+		t.Fatal("expected an error for the missing metric families")
+	}
+	if got.RunningQueueSize != 7 {
+		t.Errorf("RunningQueueSize: got %d, want 7", got.RunningQueueSize)
+	}
+	if got.WaitingQueueSize != 0 {
+		t.Errorf("WaitingQueueSize: got %d, want 0", got.WaitingQueueSize)
+	}
+}
+
+func TestPromToPodMetrics_UserSelectedMetricMissing(t *testing.T) {
+	_, err := PromToPodMetrics(parse(t, sample), newPodMetrics("sglang:does_not_exist"))
+	if err == nil {
+		t.Fatal("expected an error when the selected metric is absent")
+	}
+}

--- a/plugins/wasm-go/extensions/ai-load-balancer/endpoint_metrics/lb_policy.go
+++ b/plugins/wasm-go/extensions/ai-load-balancer/endpoint_metrics/lb_policy.go
@@ -19,6 +19,7 @@ const (
 type MetricsEndpointLoadBalancer struct {
 	metricPolicy     string
 	targetMetric     string
+	engine           string
 	endpointRequests *utils.FixedQueue[string]
 	maxRate          float64
 }
@@ -32,6 +33,11 @@ func NewMetricsEndpointLoadBalancer(json gjson.Result) (MetricsEndpointLoadBalan
 	}
 	if json.Get("target_metric").Exists() {
 		lb.targetMetric = json.Get("target_metric").String()
+	}
+	if json.Get("engine").Exists() {
+		lb.engine = json.Get("engine").String()
+	} else {
+		lb.engine = scheduling.EngineVLLM
 	}
 	if json.Get("rate_limit").Exists() {
 		lb.maxRate = json.Get("rate_limit").Float()
@@ -67,7 +73,7 @@ func (lb MetricsEndpointLoadBalancer) HandleHttpRequestBody(ctx wrapper.HttpCont
 			hostMetrics[hostInfo[0]] = gjson.Get(hostInfo[1], "metrics").String()
 		}
 	}
-	scheduler, err := scheduling.GetScheduler(hostMetrics, lb.metricPolicy, lb.targetMetric)
+	scheduler, err := scheduling.GetScheduler(hostMetrics, lb.metricPolicy, lb.targetMetric, lb.engine)
 	if err != nil {
 		log.Debugf("initial scheduler failed: %v", err)
 		return types.ActionContinue

--- a/plugins/wasm-go/extensions/ai-load-balancer/endpoint_metrics/scheduling/scheduler.go
+++ b/plugins/wasm-go/extensions/ai-load-balancer/endpoint_metrics/scheduling/scheduler.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 
 	"github.com/alibaba/higress/plugins/wasm-go/extensions/ai-load-balancer/endpoint_metrics/backend"
+	"github.com/alibaba/higress/plugins/wasm-go/extensions/ai-load-balancer/endpoint_metrics/backend/sglang"
 	"github.com/alibaba/higress/plugins/wasm-go/extensions/ai-load-balancer/endpoint_metrics/backend/vllm"
 
 	"github.com/prometheus/common/expfmt"
@@ -34,6 +35,11 @@ const (
 	MetricPolicyDefault = "default"
 	MetricPolicyLeast   = "least"
 	MetricPolicyMost    = "most"
+)
+
+const (
+	EngineVLLM   = "vllm"
+	EngineSGLang = "sglang"
 )
 
 const (
@@ -137,7 +143,7 @@ func (s *Scheduler) Schedule(req *LLMRequest) (targetPod backend.Pod, err error)
 	return pods[i].Pod, nil
 }
 
-func GetScheduler(hostMetrics map[string]string, metricPolicy string, targetMetric string) (*Scheduler, error) {
+func GetScheduler(hostMetrics map[string]string, metricPolicy string, targetMetric string, engine string) (*Scheduler, error) {
 	if len(hostMetrics) == 0 {
 		return nil, errors.New("backend is not support llm scheduling")
 	}
@@ -158,7 +164,12 @@ func GetScheduler(hostMetrics map[string]string, metricPolicy string, targetMetr
 				MetricName: targetMetric,
 			},
 		}
-		pm, err = vllm.PromToPodMetrics(metricFamilies, pm)
+		switch engine {
+		case EngineSGLang:
+			pm, err = sglang.PromToPodMetrics(metricFamilies, pm)
+		default:
+			pm, err = vllm.PromToPodMetrics(metricFamilies, pm)
+		}
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
## Ⅰ. Describe what this PR did

Adds an SGLang metrics backend alongside the existing vLLM one so the
`endpoint_metrics` load balancer can route across SGLang servers, not just vLLM.

A new optional `engine` config key (`vllm` (default) | `sglang`) selects which
engine's Prometheus metric names are parsed. It defaults to `vllm`, so existing
deployments are unaffected.

The SGLang backend maps the gauges exposed at `/metrics` (server started with
`--enable-metrics`):

| field (`backend.Metrics`) | vLLM | SGLang |
|---|---|---|
| RunningQueueSize | `vllm:num_requests_running` | `sglang:num_running_reqs` |
| WaitingQueueSize | `vllm:num_requests_waiting` | `sglang:num_queue_reqs` |
| KVCacheUsagePercent | `vllm:gpu_cache_usage_perc` | `sglang:token_usage` |

SGLang has no LoRA-adapter metric analogous to vLLM's `vllm:lora_requests_info`,
so `ActiveModels` is left unpopulated; the default metric policy works on queue
sizes and KV-cache usage.

## Ⅱ. Does this pull request fix one issue?

fixes #3392

## Ⅲ. Why don't you add test cases (unit test/integration test)?

Added a table-driven unit test `endpoint_metrics/backend/sglang/metrics_test.go`
(4 cases: default gauges, user-selected `target_metric`, missing families via
multierr, missing selected metric). It parses a real SGLang `/metrics` sample.

## Ⅳ. Describe how to verify it

From `plugins/wasm-go/extensions/ai-load-balancer`:

```
go build ./...
go test ./...
gofmt -l endpoint_metrics/backend/sglang endpoint_metrics/lb_policy.go endpoint_metrics/scheduling/scheduler.go
go vet ./...
```

Functionally: set `engine: sglang` for an endpoint-metrics load balancer pointing
at SGLang servers; metrics are then parsed with SGLang names. Default (no
`engine`) behaves exactly as before.

## Ⅴ. Special notes for reviews

- Default-unchanged: `engine` defaults to `vllm`; the only non-additive lines
  thread one parameter through `GetScheduler` and branch the previously hardcoded
  `vllm.PromToPodMetrics` call. The new backend mirrors `backend/vllm/metrics.go`
  (it only drops the LoRA block, which SGLang does not expose).
- Config key name: I chose a top-level `engine` key to match the existing flat
  `metric_policy` / `target_metric` keys. The original issue discussion sketched a
  unified backend abstraction, so I am happy to rename to `backend` / `backend.type`
  or refactor toward an interface if you prefer.
- Triton was mentioned in the issue as also compatible; I kept this PR SGLang-only
  to stay surgical and can follow up with Triton separately.

## Ⅵ. AI Coding Tool Usage Checklist (if applicable)

**Please check all applicable items:**

- [x] **For regular updates/changes** (not new plugins):
  - [x] I have provided the prompts/instructions I gave to the AI Coding tool below
  - [x] I have included the AI Coding summary below

### AI Coding Prompts (for regular updates)

Instruction given: "Implement issue #3392: add SGLang support to the
ai-load-balancer `endpoint_metrics` plugin, next to the existing vLLM backend, as
suggested in the issue. Make the smallest additive change: a new `sglang` metrics
backend that mirrors `backend/vllm/metrics.go`, an optional `engine` config key
(default `vllm`) to select the engine, and a unit test. Map the SGLang Prometheus
gauges from the production-metrics docs, keep default behavior unchanged, match the
repo's existing style, and run `go build`/`go test`/`go vet`/`gofmt`."

### AI Coding Summary

- Key decisions:
  - New package `endpoint_metrics/backend/sglang` mirroring the vLLM backend
    (same `PromToPodMetrics` signature, `getLatestMetric` helper, per-metric
    `multierr` accumulation, and `UserSelectedMetric`/`target_metric` handling).
  - Engine selection is a single optional top-level `engine` key parsed in
    `lb_policy.go`, threaded into `scheduling.GetScheduler` and branched at the
    one previously hardcoded `vllm.PromToPodMetrics` call site; `default` keeps
    vLLM, so every existing caller is unchanged.
  - Metric mapping taken from SGLang's official production-metrics docs:
    `sglang:num_running_reqs` -> RunningQueueSize, `sglang:num_queue_reqs` ->
    WaitingQueueSize, `sglang:token_usage` (0..1) -> KVCacheUsagePercent. The
    test sample values match the doc's example.
- Major changes: 6 files, additive (new backend + test, engine constants and an
  engine-aware branch in `scheduling/scheduler.go`, the optional `engine` key in
  `lb_policy.go`, and a short `engine` note in `README.md` / `README_EN.md`).
- Considerations / limitations: SGLang exposes no LoRA-adapter metric, so
  `ActiveModels` is left empty; the LoRA filter predicates read an empty map and
  fall through to queue-size / KV-cache routing (identical to vLLM serving zero
  LoRA adapters). No new dependencies. Verified with `go build` / `go test` /
  `go vet` / `gofmt` from the `ai-load-balancer` module; the new SGLang suite is
  green.
