### PR TITLE
fix(ai-proxy): fix Claude->OpenAI image content conversion causing 'certain modal' error

### DIFF
--- a/plugins/wasm-go/extensions/ai-proxy/provider/claude_to_openai.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/claude_to_openai.go
@@ -127,6 +127,11 @@ type contentConversionResult struct {
 	toolResults         []claudeChatMessageContent
 	openaiContents      []chatMessageContent
 	hasReasoningBlocks  bool
+	// toolResultImages holds images extracted from tool_result content arrays.
+	// OpenAI tool messages only support string content, so images cannot live
+	// inside the tool message itself. They are emitted as a follow-up user
+	// message after the tool messages.
+	toolResultImages []chatMessageContent
 }
 
 type ClaudeToOpenAIConvertOptions struct {
@@ -230,7 +235,27 @@ func (c *ClaudeToOpenAIConverter) ConvertClaudeRequestToOpenAIWithOptions(body [
 				// Also add visible text content if present alongside tool results.
 				// This companion message intentionally does not carry reasoning_content:
 				// tool_result content is user/tool-side data, while thinking belongs to assistant turns.
-				if len(conversionResult.textParts) > 0 {
+				// When images were extracted from tool_result content, emit them here as
+				// a multimodal user message (OpenAI tool messages only accept string content).
+				hasImages := len(conversionResult.toolResultImages) > 0
+				hasText := len(conversionResult.textParts) > 0
+				if hasImages && hasText {
+					var contents []chatMessageContent
+					contents = append(contents, chatMessageContent{
+						Type: contentTypeText,
+						Text: strings.Join(conversionResult.textParts, "\n\n"),
+					})
+					contents = append(contents, conversionResult.toolResultImages...)
+					openaiRequest.Messages = append(openaiRequest.Messages, chatMessage{
+						Role:    claudeMsg.Role,
+						Content: contents,
+					})
+				} else if hasImages {
+					openaiRequest.Messages = append(openaiRequest.Messages, chatMessage{
+						Role:    claudeMsg.Role,
+						Content: conversionResult.toolResultImages,
+					})
+				} else if hasText {
 					textMsg := chatMessage{
 						Role:    claudeMsg.Role,
 						Content: strings.Join(conversionResult.textParts, "\n\n"),
@@ -1040,6 +1065,30 @@ func openAIFinishReasonToClaude(reason string) string {
 	}
 }
 
+// claudeImageToOpenAIContent converts a Claude image content block to an OpenAI
+// image_url chatMessageContent. Returns ok=false when the source is missing or
+// uses an unsupported transport type.
+func claudeImageToOpenAIContent(claudeContent claudeChatMessageContent) (chatMessageContent, bool) {
+	if claudeContent.Source == nil {
+		return chatMessageContent{}, false
+	}
+	switch claudeContent.Source.Type {
+	case "base64":
+		dataUrl := fmt.Sprintf("data:%s;base64,%s", claudeContent.Source.MediaType, claudeContent.Source.Data)
+		return chatMessageContent{
+			Type:     contentTypeImageUrl,
+			ImageUrl: &chatMessageContentImageUrl{Url: dataUrl},
+		}, true
+	case "url":
+		return chatMessageContent{
+			Type:     contentTypeImageUrl,
+			ImageUrl: &chatMessageContentImageUrl{Url: claudeContent.Source.Url},
+		}, true
+	default:
+		return chatMessageContent{}, false
+	}
+}
+
 // convertContentArray converts an array of Claude content to OpenAI content format
 func (c *ClaudeToOpenAIConverter) convertContentArray(claudeContents []claudeChatMessageContent) *contentConversionResult {
 	result := &contentConversionResult{
@@ -1079,24 +1128,8 @@ func (c *ClaudeToOpenAIConverter) convertContentArray(claudeContents []claudeCha
 			preserveClaudeContentBlocks = true
 			// data is an opaque Claude blob, not portable reasoning text.
 		case "image":
-			if claudeContent.Source != nil {
-				if claudeContent.Source.Type == "base64" {
-					// Convert base64 image to OpenAI format
-					dataUrl := fmt.Sprintf("data:%s;base64,%s", claudeContent.Source.MediaType, claudeContent.Source.Data)
-					result.openaiContents = append(result.openaiContents, chatMessageContent{
-						Type: contentTypeImageUrl,
-						ImageUrl: &chatMessageContentImageUrl{
-							Url: dataUrl,
-						},
-					})
-				} else if claudeContent.Source.Type == "url" {
-					result.openaiContents = append(result.openaiContents, chatMessageContent{
-						Type: contentTypeImageUrl,
-						ImageUrl: &chatMessageContentImageUrl{
-							Url: claudeContent.Source.Url,
-						},
-					})
-				}
+			if imgContent, ok := claudeImageToOpenAIContent(claudeContent); ok {
+				result.openaiContents = append(result.openaiContents, imgContent)
 			}
 		case "tool_use":
 			preserveClaudeContentBlocks = true
@@ -1126,6 +1159,20 @@ func (c *ClaudeToOpenAIConverter) convertContentArray(claudeContents []claudeCha
 			// Store tool results for processing
 			result.toolResults = append(result.toolResults, claudeContent)
 			log.Debugf("[Claude->OpenAI] Found tool_result for tool_use_id: %s", claudeContent.ToolUseId)
+			// Extract images embedded in tool_result content arrays.
+			// OpenAI tool messages only accept string content, so we cannot
+			// place images inside the tool message. Collect them here and emit
+			// them as a follow-up user message after the tool messages.
+			if claudeContent.Content != nil {
+				for _, innerBlock := range claudeContent.Content.GetArrayValue() {
+					if innerBlock.Type != "image" || innerBlock.Source == nil {
+						continue
+					}
+					if imgContent, ok := claudeImageToOpenAIContent(innerBlock); ok {
+						result.toolResultImages = append(result.toolResultImages, imgContent)
+					}
+				}
+			}
 		}
 		claudeContentBlocks = append(claudeContentBlocks, preservedClaudeContent)
 	}

--- a/plugins/wasm-go/extensions/ai-proxy/provider/claude_to_openai_test.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/claude_to_openai_test.go
@@ -272,6 +272,12 @@ func TestClaudeToOpenAIConverter_ConvertClaudeRequestToOpenAI(t *testing.T) {
 		imageUrl, ok := secondElement["image_url"].(map[string]interface{})
 		require.True(t, ok)
 		assert.Contains(t, imageUrl["url"], "data:image/jpeg;base64,")
+
+		// Verify that the image_url item does NOT carry an empty "text" field.
+		// Strict providers reject content items that mix text and image_url modalities
+		// with "The item of `content` should be a message of a certain modal".
+		_, hasTextKey := secondElement["text"]
+		assert.False(t, hasTextKey, "image_url content item must not include an empty text field")
 	})
 
 	t.Run("convert_simple_string_content", func(t *testing.T) {
@@ -893,6 +899,169 @@ func TestClaudeToOpenAIConverter_ConvertClaudeRequestToOpenAI(t *testing.T) {
 		assert.Equal(t, "user", rawCompanionText["role"])
 		assert.Equal(t, "continue", rawCompanionText["content"])
 		assert.NotContains(t, rawCompanionText, "reasoning_content")
+	})
+
+	t.Run("convert_tool_result_with_image_content", func(t *testing.T) {
+		// A tool_result whose content array contains only an image.
+		// The image cannot live inside the OpenAI tool message (string-only),
+		// so it should be emitted as a follow-up user message.
+		claudeRequest := `{
+			"model": "anthropic/claude-sonnet-4",
+			"messages": [{
+				"role": "user",
+				"content": [{
+					"type": "tool_result",
+					"tool_use_id": "toolu_screenshot",
+					"content": [{
+						"type": "image",
+						"source": {
+							"type": "base64",
+							"media_type": "image/png",
+							"data": "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
+						}
+					}]
+				}]
+			}],
+			"max_tokens": 1000
+		}`
+
+		result, err := converter.ConvertClaudeRequestToOpenAI([]byte(claudeRequest))
+		require.NoError(t, err)
+
+		var rawJSON map[string]interface{}
+		err = json.Unmarshal(result, &rawJSON)
+		require.NoError(t, err)
+		messages := rawJSON["messages"].([]interface{})
+		require.Len(t, messages, 2)
+
+		// First message: tool role with empty text content
+		rawTool := messages[0].(map[string]interface{})
+		assert.Equal(t, "tool", rawTool["role"])
+		assert.Equal(t, "", rawTool["content"])
+		assert.Equal(t, "toolu_screenshot", rawTool["tool_call_id"])
+
+		// Second message: user role carrying the image
+		rawImageMsg := messages[1].(map[string]interface{})
+		assert.Equal(t, "user", rawImageMsg["role"])
+		contentArray, ok := rawImageMsg["content"].([]interface{})
+		require.True(t, ok)
+		require.Len(t, contentArray, 1)
+		imgItem, ok := contentArray[0].(map[string]interface{})
+		require.True(t, ok)
+		assert.Equal(t, contentTypeImageUrl, imgItem["type"])
+		imgUrl, ok := imgItem["image_url"].(map[string]interface{})
+		require.True(t, ok)
+		assert.Contains(t, imgUrl["url"], "data:image/png;base64,")
+		// Verify no spurious text field on the image item
+		_, hasTextKey := imgItem["text"]
+		assert.False(t, hasTextKey)
+	})
+
+	t.Run("convert_tool_result_with_text_and_image", func(t *testing.T) {
+		// A tool_result whose content array contains text + image, plus a
+		// sibling text block at the message level.
+		claudeRequest := `{
+			"model": "anthropic/claude-sonnet-4",
+			"messages": [{
+				"role": "user",
+				"content": [{
+					"type": "tool_result",
+					"tool_use_id": "toolu_read_img",
+					"content": [{
+						"type": "text",
+						"text": "Screenshot captured."
+					}, {
+						"type": "image",
+						"source": {
+							"type": "base64",
+							"media_type": "image/png",
+							"data": "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
+						}
+					}]
+				}, {
+					"type": "text",
+					"text": "What do you see?"
+				}]
+			}],
+			"max_tokens": 1000
+		}`
+
+		result, err := converter.ConvertClaudeRequestToOpenAI([]byte(claudeRequest))
+		require.NoError(t, err)
+
+		var rawJSON map[string]interface{}
+		err = json.Unmarshal(result, &rawJSON)
+		require.NoError(t, err)
+		messages := rawJSON["messages"].([]interface{})
+		require.Len(t, messages, 2)
+
+		// First: tool message with text extracted from tool_result
+		rawTool := messages[0].(map[string]interface{})
+		assert.Equal(t, "tool", rawTool["role"])
+		assert.Equal(t, "Screenshot captured.", rawTool["content"])
+		assert.Equal(t, "toolu_read_img", rawTool["tool_call_id"])
+
+		// Second: user message with sibling text + extracted image
+		rawUserMsg := messages[1].(map[string]interface{})
+		assert.Equal(t, "user", rawUserMsg["role"])
+		contentArray, ok := rawUserMsg["content"].([]interface{})
+		require.True(t, ok)
+		require.Len(t, contentArray, 2)
+
+		textItem, ok := contentArray[0].(map[string]interface{})
+		require.True(t, ok)
+		assert.Equal(t, contentTypeText, textItem["type"])
+		assert.Equal(t, "What do you see?", textItem["text"])
+
+		imgItem, ok := contentArray[1].(map[string]interface{})
+		require.True(t, ok)
+		assert.Equal(t, contentTypeImageUrl, imgItem["type"])
+	})
+
+	t.Run("convert_tool_result_with_url_image", func(t *testing.T) {
+		// A tool_result whose content array contains a URL-type image.
+		claudeRequest := `{
+			"model": "anthropic/claude-sonnet-4",
+			"messages": [{
+				"role": "user",
+				"content": [{
+					"type": "tool_result",
+					"tool_use_id": "toolu_fetch",
+					"content": [{
+						"type": "image",
+						"source": {
+							"type": "url",
+							"url": "https://example.com/image.png"
+						}
+					}]
+				}]
+			}],
+			"max_tokens": 1000
+		}`
+
+		result, err := converter.ConvertClaudeRequestToOpenAI([]byte(claudeRequest))
+		require.NoError(t, err)
+
+		var rawJSON map[string]interface{}
+		err = json.Unmarshal(result, &rawJSON)
+		require.NoError(t, err)
+		messages := rawJSON["messages"].([]interface{})
+		require.Len(t, messages, 2)
+
+		rawTool := messages[0].(map[string]interface{})
+		assert.Equal(t, "tool", rawTool["role"])
+
+		rawImageMsg := messages[1].(map[string]interface{})
+		assert.Equal(t, "user", rawImageMsg["role"])
+		contentArray, ok := rawImageMsg["content"].([]interface{})
+		require.True(t, ok)
+		require.Len(t, contentArray, 1)
+		imgItem, ok := contentArray[0].(map[string]interface{})
+		require.True(t, ok)
+		assert.Equal(t, contentTypeImageUrl, imgItem["type"])
+		imgUrl, ok := imgItem["image_url"].(map[string]interface{})
+		require.True(t, ok)
+		assert.Equal(t, "https://example.com/image.png", imgUrl["url"])
 	})
 
 	t.Run("convert_multiple_tool_calls", func(t *testing.T) {

--- a/plugins/wasm-go/extensions/ai-proxy/provider/model.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/model.go
@@ -348,7 +348,7 @@ func isContentEmpty(content any) bool {
 type chatMessageContent struct {
 	CacheControl map[string]interface{}      `json:"cache_control,omitempty"`
 	Type         string                      `json:"type,omitempty"`
-	Text         string                      `json:"text"`
+	Text         string                      `json:"text,omitempty"`
 	ImageUrl     *chatMessageContentImageUrl `json:"image_url,omitempty"`
 	File         *chatMessageContentFile     `json:"file,omitempty"`
 	InputAudio   *chatMessageContentAudio    `json:"input_audio,omitempty"`


### PR DESCRIPTION
Two issues caused upstream providers to reject image-bearing requests from ClaudeCode:

1. chatMessageContent.Text lacked omitempty, so image_url content items serialized with a spurious "text":"" field. Strict providers see mixed modalities and reject with "The item of content should be a message of a certain modal".

2. Images nested inside tool_result content arrays were silently dropped because GetStringValue() only extracts text blocks. The upstream never received the image data.

Fixes:
- Add omitempty to chatMessageContent.Text json tag
- Extract images from tool_result content and emit them as a follow-up multimodal user message (OpenAI tool messages only accept string content)
- Refactored image conversion into shared claudeImageToOpenAIContent helper

<!-- Please make sure you have read and understood the contributing guidelines -->

## Ⅰ. Describe what this PR did

在 Claude Code 中以 Anthropic Messages 协议接入到上游 OpenAI Chat Completions 接口时， 如果携带了图片资源时，在转换过程中会导致参数错误，在部分检验较严格的上游会报错

```json
{"error":{"code":"invalid_parameter_error","param":null,"message":"The item of `content` should be a message of a certain modal","type":"invalid_request_error"},"id":"chatcmpl-2eafca17-96a2-4ce9-a67b-23bbe8838af1"}
```
<img width="1533" height="526" alt="image" src="https://github.com/user-attachments/assets/ef234b1d-5237-4b3b-98d6-7d57bfa849a5" />


## Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


## Ⅲ. Why don't you add test cases (unit test/integration test)? 


## Ⅳ. Describe how to verify it

<img width="1057" height="954" alt="image" src="https://github.com/user-attachments/assets/76934a1f-30b1-486a-aacf-ed5a3748f036" />


## Ⅴ. Special notes for reviews


## Ⅵ. AI Coding Tool Usage Checklist (if applicable)
<!-- 
**IMPORTANT**: If you used AI Coding tools (e.g., Cursor, GitHub Copilot, etc.) to generate this PR, please check the following items.
PRs that don't meet these requirements will have **LOWER REVIEW PRIORITY** and we **CANNOT GUARANTEE** timely reviews.

If you did NOT use AI Coding tools, you can skip this section entirely.
-->

**Please check all applicable items:**

- [ ] **For new standalone features** (e.g., new wasm plugin or golang-filter plugin):
  - [ ] I have created a `design/` directory in the plugin folder
  - [ ] I have added the design document to the `design/` directory
  - [ ] I have included the AI Coding summary below

- [ ] **For regular updates/changes** (not new plugins):
  - [ ] I have provided the prompts/instructions I gave to the AI Coding tool below
  - [ ] I have included the AI Coding summary below

### AI Coding Prompts (for regular updates)
<!-- Paste the prompts/instructions you provided to the AI Coding tool -->


### AI Coding Summary
<!-- 
AI Coding tool should provide a summary after completing the work, including:
- Key decisions made
- Major changes implemented  
- Important considerations or limitations
-->



