### PR TITLE
fix(mcp-server): guard nacos MCP registry maps against concurrent access

### DIFF
--- a/plugins/golang-filter/mcp-server/registry/nacos/nacos.go
+++ b/plugins/golang-filter/mcp-server/registry/nacos/nacos.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+	"sync"
 
 	"github.com/alibaba/higress/plugins/golang-filter/mcp-server/registry"
 	"github.com/envoyproxy/envoy/contrib/golang/common/go/api"
@@ -15,6 +16,10 @@ import (
 )
 
 type NacosMcpRegistry struct {
+	// mu guards toolsDescription, toolsRpcContext and currentServiceSet, which are
+	// mutated by the background poll goroutine and the Nacos config/naming callback
+	// goroutines while being read on the Envoy request path.
+	mu                       sync.RWMutex
 	serviceMatcher           map[string]string
 	configClient             config_client.IConfigClient
 	namingClient             naming_client.INamingClient
@@ -30,10 +35,8 @@ const (
 )
 
 func (n *NacosMcpRegistry) ListToolsDescription() []*registry.ToolDescription {
-	if n.toolsDescription == nil {
-		n.refreshToolsList()
-	}
-
+	n.mu.RLock()
+	defer n.mu.RUnlock()
 	result := []*registry.ToolDescription{}
 	for _, tool := range n.toolsDescription {
 		result = append(result, tool)
@@ -42,9 +45,8 @@ func (n *NacosMcpRegistry) ListToolsDescription() []*registry.ToolDescription {
 }
 
 func (n *NacosMcpRegistry) GetToolRpcContext(toolName string) (*registry.RpcContext, bool) {
-	if n.toolsRpcContext == nil {
-		n.refreshToolsList()
-	}
+	n.mu.RLock()
+	defer n.mu.RUnlock()
 	tool, ok := n.toolsRpcContext[toolName]
 	return tool, ok
 }
@@ -90,7 +92,10 @@ func (n *NacosMcpRegistry) refreshToolsListForGroup(group string, serviceMatcher
 		}
 
 		formatServiceName := getFormatServiceName(group, service)
-		if _, ok := n.currentServiceSet[formatServiceName]; !ok {
+		n.mu.RLock()
+		_, known := n.currentServiceSet[formatServiceName]
+		n.mu.RUnlock()
+		if !known {
 			refreshed := n.refreshToolsListForService(group, service)
 			n.listenToService(group, service)
 			if refreshed {
@@ -101,6 +106,7 @@ func (n *NacosMcpRegistry) refreshToolsListForGroup(group string, serviceMatcher
 		currentServiceList[formatServiceName] = true
 	}
 
+	n.mu.Lock()
 	serviceShouldBeDeleted := []string{}
 	for serviceName := range n.currentServiceSet {
 		if !strings.HasPrefix(serviceName, group) {
@@ -127,6 +133,7 @@ func (n *NacosMcpRegistry) refreshToolsListForGroup(group string, serviceMatcher
 	for _, service := range serviceShouldBeDeleted {
 		delete(n.currentServiceSet, service)
 	}
+	n.mu.Unlock()
 
 	return changed
 }
@@ -135,6 +142,8 @@ func getFormatServiceName(group string, service string) string {
 	return fmt.Sprintf("%s_%s", group, service)
 }
 
+// deleteToolForService removes all tools registered for a service. Callers must
+// hold n.mu for writing.
 func (n *NacosMcpRegistry) deleteToolForService(group string, service string) {
 	toolsNeedReset := []string{}
 
@@ -187,7 +196,9 @@ func (n *NacosMcpRegistry) refreshToolsListForServiceWithContent(group string, s
 
 	// config deleted, tools should be removed
 	if len(*newConfig) == 0 {
+		n.mu.Lock()
 		n.deleteToolForService(group, service)
+		n.mu.Unlock()
 		return true
 	}
 
@@ -207,16 +218,14 @@ func (n *NacosMcpRegistry) refreshToolsListForServiceWithContent(group string, s
 		wrappedInstances = append(wrappedInstances, wrappedInstance)
 	}
 
-	if n.toolsDescription == nil {
-		n.toolsDescription = map[string]*registry.ToolDescription{}
+	// Build the tool entries before taking the lock: GetCredential performs a
+	// blocking Nacos network call and must not run inside the critical section.
+	type toolEntry struct {
+		name    string
+		desc    *registry.ToolDescription
+		context *registry.RpcContext
 	}
-
-	if n.toolsRpcContext == nil {
-		n.toolsRpcContext = map[string]*registry.RpcContext{}
-	}
-
-	n.deleteToolForService(group, service)
-
+	entries := make([]toolEntry, 0, len(applicationDescription.ToolsDescription))
 	for _, tool := range applicationDescription.ToolsDescription {
 		meta := applicationDescription.ToolsMeta[tool.Name]
 
@@ -234,10 +243,17 @@ func (n *NacosMcpRegistry) refreshToolsListForServiceWithContent(group string, s
 		}
 
 		tool.Name = makeToolName(group, service, tool.Name)
-		n.toolsDescription[tool.Name] = tool
-		n.toolsRpcContext[tool.Name] = &context
+		entries = append(entries, toolEntry{name: tool.Name, desc: tool, context: &context})
+	}
+
+	n.mu.Lock()
+	n.deleteToolForService(group, service)
+	for _, entry := range entries {
+		n.toolsDescription[entry.name] = entry.desc
+		n.toolsRpcContext[entry.name] = entry.context
 	}
 	n.currentServiceSet[getFormatServiceName(group, service)] = true
+	n.mu.Unlock()
 	return true
 }
 

--- a/plugins/golang-filter/mcp-server/registry/nacos/nacos_test.go
+++ b/plugins/golang-filter/mcp-server/registry/nacos/nacos_test.go
@@ -1,0 +1,91 @@
+package nacos
+
+import (
+	"encoding/json"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/alibaba/higress/plugins/golang-filter/mcp-server/registry"
+	"github.com/nacos-group/nacos-sdk-go/v2/model"
+)
+
+// newTestRegistry builds a NacosMcpRegistry with initialized maps and no Nacos
+// clients. The clients stay nil on purpose: the concurrency test only drives the
+// map mutators/readers directly and passes non-nil config/instances so the Nacos
+// SDK network paths in refreshToolsListForServiceWithContent are never taken.
+func newTestRegistry() *NacosMcpRegistry {
+	return &NacosMcpRegistry{
+		toolsDescription:  map[string]*registry.ToolDescription{},
+		toolsRpcContext:   map[string]*registry.RpcContext{},
+		currentServiceSet: map[string]bool{},
+	}
+}
+
+// toolsConfig serializes a minimal McpApplicationDescription for a single tool,
+// deliberately without a credentialRef so GetCredential (which needs a client) is
+// never invoked.
+func toolsConfig(toolName string) string {
+	desc := registry.McpApplicationDescription{
+		Protocol: registry.PROTOCOL_HTTP,
+		ToolsDescription: []*registry.ToolDescription{
+			{
+				Name:        toolName,
+				Description: "test tool",
+				InputSchema: json.RawMessage(`{"type":"object"}`),
+			},
+		},
+		ToolsMeta: map[string]registry.ToolMeta{},
+	}
+	raw, _ := json.Marshal(desc)
+	return string(raw)
+}
+
+// TestNacosMcpRegistryConcurrentAccess reproduces the concurrent map access
+// between the Nacos refresh goroutines (config OnChange / naming SubscribeCallback
+// / the background poll) that mutate toolsDescription, toolsRpcContext and
+// currentServiceSet, and the Envoy request path that reads them via
+// GetToolRpcContext and ListToolsDescription.
+//
+// Before the maps are guarded by a mutex this fails under `go test -race` with a
+// DATA RACE (and can escalate to an unrecoverable `fatal error: concurrent map
+// read and map write`). With the mutex in place it passes.
+func TestNacosMcpRegistryConcurrentAccess(t *testing.T) {
+	n := newTestRegistry()
+
+	const (
+		group      = "test-group"
+		service    = "test-service"
+		goroutines = 8
+		iterations = 500
+	)
+
+	instances := []model.Instance{{Ip: "127.0.0.1", Port: 8080}}
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func(id int) {
+			defer wg.Done()
+			for j := 0; j < iterations; j++ {
+				switch id % 4 {
+				case 0, 1:
+					// Simulate the Nacos config OnChange / naming callback and
+					// poll goroutines mutating the shared maps.
+					toolName := fmt.Sprintf("t-%d", j%3)
+					cfg := toolsConfig(toolName)
+					insts := instances
+					n.refreshToolsListForServiceWithContent(group, service, &cfg, &insts)
+				case 2:
+					// Simulate the request path: tools/call -> GetToolRpcContext.
+					n.GetToolRpcContext(makeToolName(group, service, fmt.Sprintf("t-%d", j%3)))
+				case 3:
+					// Simulate the request/reset path: tools/list ->
+					// ListToolsDescription.
+					_ = n.ListToolsDescription()
+				}
+			}
+		}(i)
+	}
+	wg.Wait()
+}

--- a/plugins/golang-filter/mcp-server/registry/nacos/server.go
+++ b/plugins/golang-filter/mcp-server/registry/nacos/server.go
@@ -93,6 +93,8 @@ func CreateNacosMcpRegistry(config *NacosConfig) (*NacosMcpRegistry, error) {
 		namingClient:             namingClient,
 		serviceMatcher:           *config.ServiceMatcher,
 		toolChangeEventListeners: []registry.ToolChangeEventListener{},
+		toolsDescription:         map[string]*registry.ToolDescription{},
+		toolsRpcContext:          map[string]*registry.RpcContext{},
 		currentServiceSet:        map[string]bool{},
 	}, nil
 }

--- a/plugins/golang-filter/mcp-server/registry/nacos/server.go
+++ b/plugins/golang-filter/mcp-server/registry/nacos/server.go
@@ -119,6 +119,8 @@ func CreateNacosMcpRegistry(config *NacosConfig) (*NacosMcpRegistry, error) {
 		namingClient:             namingClient,
 		serviceMatcher:           *config.ServiceMatcher,
 		toolChangeEventListeners: []registry.ToolChangeEventListener{},
+		toolsDescription:         map[string]*registry.ToolDescription{},
+		toolsRpcContext:          map[string]*registry.RpcContext{},
 		currentServiceSet:        map[string]bool{},
 	}, nil
 }


### PR DESCRIPTION

<!-- Please make sure you have read and understood the contributing guidelines -->

## Ⅰ. Describe what this PR did

`NacosMcpRegistry` (in the golang-filter MCP server, `plugins/golang-filter/mcp-server/registry/nacos/`) keeps `toolsDescription`, `toolsRpcContext` and `currentServiceSet` as plain maps with no synchronization. These maps are written by the 3-second background refresh goroutine and by the Nacos SDK callbacks (config `OnChange` and naming `SubscribeCallback`, which fire on the SDK's own goroutines whenever a watched tool config or instance list changes), while they are read on the Envoy request path via `GetToolRpcContext` (tools/call) and `ListToolsDescription` (tools/list).

A read that races a write on these maps triggers Go's runtime check `fatal error: concurrent map read and map write` (or `concurrent map writes`). This is a fatal error, not a panic: the deferred `recover()` in the poll goroutine cannot catch it, and the request goroutines have no recover at all, so it takes down the worker.

This PR adds a `sync.RWMutex` to `NacosMcpRegistry` and guards every access to the three maps:
- readers `ListToolsDescription` and `GetToolRpcContext` take `RLock`;
- the map-mutation regions in `refreshToolsListForServiceWithContent`, the config-deleted `deleteToolForService` path, and the delete block in `refreshToolsListForGroup` take `Lock`.

The blocking Nacos calls (`GetConfig`, `SelectInstances`, `GetCredential`) stay outside the critical section: the tool entries are built into a local slice first and then applied under a single `Lock`, so the request path never serializes behind Nacos network I/O. The two tool maps are now initialized in the constructor (`CreateNacosMcpRegistry`) so their headers are never reassigned, which lets the readers drop their unsynchronized lazy-init. Behavior is otherwise unchanged.

## Ⅱ. Does this pull request fix one issue?

No linked issue. This fixes a concurrency bug I found by reading the code and reproduced with a race test (see below).

## Ⅲ. Why don't you add test cases (unit test/integration test)?

A regression test is included: `TestNacosMcpRegistryConcurrentAccess` in `plugins/golang-filter/mcp-server/registry/nacos/nacos_test.go`. It drives the map mutators and the readers from several goroutines to reproduce the race between the Nacos refresh goroutines and the request path. It fails under `go test -race` before the fix (DATA RACE, which can escalate to the fatal concurrent-map error) and passes after. The test exercises the maps directly and passes non-nil config/instances without a `credentialRef`, so no Nacos client, Envoy, or network is required.

## Ⅳ. Describe how to verify it

From `plugins/golang-filter/`:

```
gofmt -l mcp-server/registry/nacos/*.go        # clean
go vet ./mcp-server/registry/nacos/            # clean
go build ./...                                 # builds
go test -race ./mcp-server/registry/nacos/     # passes
```

To see the bug before the fix, revert the changes to `nacos.go` and `server.go` while keeping the new test, then run `go test -race -run TestNacosMcpRegistryConcurrentAccess ./mcp-server/registry/nacos/`: it reports a DATA RACE at the reads in `ListToolsDescription`/`GetToolRpcContext` versus the map writes in `refreshToolsListForServiceWithContent`/`deleteToolForService`.

## Ⅴ. Special notes for reviews

- The fix is behavioral-only: no exported API or config change. The critical sections guard only the map accesses; all Nacos network calls remain outside the lock.
- Lock discipline: `sync.RWMutex` is not reentrant, so `deleteToolForService` no longer locks and documents that callers must hold `n.mu` for writing; both of its callers take `Lock`. In `refreshToolsListForGroup` the `RLock` for the `currentServiceSet` membership check is released before `refreshToolsListForService` runs, so there is no nested acquisition.
- The mutex pattern mirrors the synchronization already used elsewhere in this module (e.g. the `mcp-session` server), so it should read as idiomatic to this codebase.

## Ⅵ. AI Coding Tool Usage Checklist (if applicable)

**Please check all applicable items:**

- [ ] **For new standalone features** (e.g., new wasm plugin or golang-filter plugin):
  - [ ] I have created a `design/` directory in the plugin folder
  - [ ] I have added the design document to the `design/` directory
  - [ ] I have included the AI Coding summary below

- [x] **For regular updates/changes** (not new plugins):
  - [x] I have provided the prompts/instructions I gave to the AI Coding tool below
  - [x] I have included the AI Coding summary below

### AI Coding Prompts (for regular updates)

> In `plugins/golang-filter/mcp-server/registry/nacos/`, `NacosMcpRegistry`'s
> `toolsDescription`, `toolsRpcContext` and `currentServiceSet` maps are written by the
> background refresh goroutine and the Nacos config/naming callbacks while being read on
> the request path, with no lock, so a concurrent read/write can hit Go's fatal
> concurrent-map error and crash the worker. Add a `sync.RWMutex` and guard every access
> with the smallest surgical diff: `RLock` in the readers, `Lock` around the map-mutation
> regions in the writers, keep the blocking Nacos network calls outside the critical
> section, and initialize the maps in the constructor so the readers can drop their
> unsynchronized lazy-init. Add a colocated `-race` regression test that fails before the
> change and passes after. Keep behavior unchanged and match the module's existing style.

### AI Coding Summary

- **Key decisions:**
  - Used a single `sync.RWMutex` on the struct rather than per-map locks; all three maps are mutated together in the refresh paths, so one lock keeps the invariant simple and matches the module's existing RWMutex usage.
  - Kept `GetConfig`/`SelectInstances`/`GetCredential` outside the lock by building the tool entries into a local slice and applying them under one `Lock`, so the request path never blocks on Nacos I/O.
  - Made `deleteToolForService` lock-free and documented that callers must hold the write lock, since `RWMutex` is non-reentrant and every caller already holds it.
  - Initialized `toolsDescription`/`toolsRpcContext` in the constructor so their map headers are never reassigned, which let me remove the readers' unsynchronized lazy-init (itself one of the race sources, as it ran a full synchronous refresh on the request goroutine).
- **Major changes:** `sync.RWMutex` added to `NacosMcpRegistry`; `RLock` in `ListToolsDescription`/`GetToolRpcContext`; `Lock` around the map mutations in `refreshToolsListForServiceWithContent`, the config-deleted path, and the `refreshToolsListForGroup` delete block; maps initialized in `CreateNacosMcpRegistry`; new `nacos_test.go` regression test.
- **Limitations:** The regression test asserts race-freedom under `-race` (that is what the fix targets); it does not spin up a real Nacos server or Envoy. A read that arrives before the first background refresh now returns `(nil, false)` rather than force-refreshing synchronously, which is the intended behavior (a registered tool implies a prior refresh) and removes the request-path refresh that was itself unsafe.

<!--This is a translation content dividing line, the content below is generated by machine, please do not modify the content below-->
---
<!-- Please make sure you have read and understood the contributing guidelines -->

## Ⅰ. Describe what this PR did

`NacosMcpRegistry` (in the golang-filter MCP server, `plugins/golang-filter/mcp-server/registry/nacos/`) keeps `toolsDescription`, `toolsRpcContext` and `currentServiceSet` as plain maps with no synchronization. These maps are written by the 3-second background refresh goroutine and by the Nacos SDK callbacks (config `OnChange` and naming `SubscribeCallback`, which fire on the SDK's own goroutines whenever a watched tool config or instance list changes), while they are read on the Envoy request path via `GetToolRpcContext` (tools/call) and `ListToolsDescription` (tools/list).

A read that races a write on these maps triggers Go's runtime check `fatal error: concurrent map read and map write` (or `concurrent map writes`). This is a fatal error, not a panic: the deferred `recover()` in the poll goroutine cannot catch it, and the request goroutines have no recover at all, so it takes down the worker.

This PR adds a `sync.RWMutex` to `NacosMcpRegistry` and guards every access to the three maps:
- readers `ListToolsDescription` and `GetToolRpcContext` take `RLock`;
- the map-mutation regions in `refreshToolsListForServiceWithContent`, the config-deleted `deleteToolForService` path, and the delete block in `refreshToolsListForGroup` take `Lock`.

The blocking Nacos calls (`GetConfig`, `SelectInstances`, `GetCredential`) stay outside the critical section: the tool entries are built into a local slice first and then applied under a single `Lock`, so the request path never serializes behind Nacos network I/O. The two tool maps are now initialized in the constructor (`CreateNacosMcpRegistry`) so their headers are never reassigned, which lets the readers drop their unsynchronized lazy-init. Behavior is otherwise unchanged.

## Ⅱ. Does this pull request fix one issue?

No linked issue. This fixes a concurrency bug I found by reading the code and reproduced with a race test (see below).

## Ⅲ. Why don't you add test cases (unit test/integration test)?

A regression test is included: `TestNacosMcpRegistryConcurrentAccess` in `plugins/golang-filter/mcp-server/registry/nacos/nacos_test.go`. It drives the map mutators and the readers from several goroutines to reproduce the race between the Nacos refresh goroutines and the request path. It fails under `go test -race` before the fix (DATA RACE, which can escalate to the fatal concurrent-map error) and passes after. The test exercises the maps directly and passes non-nil config/instances without a `credentialRef`, so no Nacos client, Envoy, or network is required.

## Ⅳ. Describe how to verify it

From `plugins/golang-filter/`:

```
gofmt -l mcp-server/registry/nacos/*.go        # clean
go vet ./mcp-server/registry/nacos/            # clean
go build ./...                                 # builds
go test -race ./mcp-server/registry/nacos/     # passes
```

To see the bug before the fix, revert the changes to `nacos.go` and `server.go` while keeping the new test, then run `go test -race -run TestNacosMcpRegistryConcurrentAccess ./mcp-server/registry/nacos/`: it reports a DATA RACE at the reads in `ListToolsDescription`/`GetToolRpcContext` versus the map writes in `refreshToolsListForServiceWithContent`/`deleteToolForService`.

## Ⅴ. Special notes for reviews

- The fix is behavioral-only: no exported API or config change. The critical sections guard only the map accesses; all Nacos network calls remain outside the lock.
- Lock discipline: `sync.RWMutex` is not reentrant, so `deleteToolForService` no longer locks and documents that callers must hold `n.mu` for writing; both of its callers take `Lock`. In `refreshToolsListForGroup` the `RLock` for the `currentServiceSet` membership check is released before `refreshToolsListForService` runs, so there is no nested acquisition.
- The mutex pattern mirrors the synchronization already used elsewhere in this module (e.g. the `mcp-session` server), so it should read as idiomatic to this codebase.

## Ⅵ. AI Coding Tool Usage Checklist (if applicable)

**Please check all applicable items:**

- [ ] **For new standalone features** (e.g., new wasm plugin or golang-filter plugin):
  - [ ] I have created a `design/` directory in the plugin folder
  - [ ] I have added the design document to the `design/` directory
  - [ ] I have included the AI Coding summary below

- [x] **For regular updates/changes** (not new plugins):
  - [x] I have provided the prompts/instructions I gave to the AI Coding tool below
  - [x] I have included the AI Coding summary below

### AI Coding Prompts (for regular updates)

> In `plugins/golang-filter/mcp-server/registry/nacos/`, `NacosMcpRegistry`'s
> `toolsDescription`, `toolsRpcContext` and `currentServiceSet` maps are written by the
> background refresh goroutine and the Nacos config/naming callbacks while being read on
> the request path, with no lock, so a concurrent read/write can hit Go's fatal
> concurrent-map error and crash the worker. Add a `sync.RWMutex` and guard every access
> with the smallest surgical diff: `RLock` in the readers, `Lock` around the map-mutation
> regions in the writers, keep the blocking Nacos network calls outside the critical
> section, and initialize the maps in the constructor so the readers can drop their
> unsynchronized lazy-init. Add a colocated `-race` regression test that fails before the
> change and passes after. Keep behavior unchanged and match the module's existing style.

### AI Coding Summary

- **Key decisions:**
  - Used a single `sync.RWMutex` on the struct rather than per-map locks; all three maps are mutated together in the refresh paths, so one lock keeps the invariant simple and matches the module's existing RWMutex usage.
  - Kept `GetConfig`/`SelectInstances`/`GetCredential` outside the lock by building the tool entries into a local slice and applying them under one `Lock`, so the request path never blocks on Nacos I/O.
  - Made `deleteToolForService` lock-free and documented that callers must hold the write lock, since `RWMutex` is non-reentrant and every caller already holds it.
  - Initialized `toolsDescription`/`toolsRpcContext` in the constructor so their map headers are never reassigned, which let me remove the readers' unsynchronized lazy-init (itself one of the race sources, as it ran a full synchronous refresh on the request goroutine).
- **Major changes:** `sync.RWMutex` added to `NacosMcpRegistry`; `RLock` in `ListToolsDescription`/`GetToolRpcContext`; `Lock` around the map mutations in `refreshToolsListForServiceWithContent`, the config-deleted path, and the `refreshToolsListForGroup` delete block; maps initialized in `CreateNacosMcpRegistry`; new `nacos_test.go` regression test.
- **Limitations:** The regression test asserts race-freedom under `-race` (that is what the fix targets); it does not spin up a real Nacos server or Envoy. A read that arrives before the first background refresh now returns `(nil, false)` rather than force-refreshing synchronously, which is the intended behavior (a registered tool implies a prior refresh) and removes the request-path refresh that was itself unsafe.
