### PR TITLE
fix(ai-cache): add empty value check in uploadEmbeddingAndAnswer

### DIFF
--- a/plugins/wasm-go/extensions/ai-cache/core.go
+++ b/plugins/wasm-go/extensions/ai-cache/core.go
@@ -237,6 +237,12 @@ func uploadEmbeddingAndAnswer(ctx wrapper.HttpContext, c config.PluginConfig, ke
 		return
 	}
 
+	// Check if the cached value is empty, skip uploading embedding if so
+	if strings.TrimSpace(value) == "" {
+		log.Warnf("[%s] [uploadEmbeddingAndAnswer] cached value for key %s is empty, skip uploading embedding", PLUGIN_NAME, key)
+		return
+	}
+
 	// Attempt to upload answer embedding first
 	if ansEmbUploader, ok := activeVectorProvider.(vector.AnswerAndEmbeddingUploader); ok {
 		log.Infof("[%s] uploading answer embedding for key: %s", PLUGIN_NAME, key)


### PR DESCRIPTION
## Summary

Add empty value check in uploadEmbeddingAndAnswer before uploading embedding to vector database, consistent with cacheResponse behavior.

## Problem

In the ai-cache plugin, cacheResponse checks if the value is empty before writing to the cache database, but uploadEmbeddingAndAnswer does not perform the same check before uploading to the vector database. This inconsistency can lead to empty values being written to the vector database.

## Fix

Added empty value check in uploadEmbeddingAndAnswer:

    if strings.TrimSpace(value) == "" {
        log.Warnf("[%s] [uploadEmbeddingAndAnswer] cached value for key %s is empty, skip uploading embedding", PLUGIN_NAME, key)
        return
    }

## Testing

- [x] Code compiles
- [x] Follows existing code style

## Related

Fixes comment on PR #3962: https://github.com/higress-group/higress/pull/3962#issuecomment-4852450100