### PR TITLE
fix(ai-proxy): clamp Claude thinking.budget_tokens below max_tokens and accept plural budget_tokens

### DIFF
--- a/changes/2.2.3.md
+++ b/changes/2.2.3.md
@@ -1,0 +1,23 @@
+# Copyright (c) 2026 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+## ai-proxy: 修复 Claude provider 的 thinking budget 与 max_tokens 的兼容问题
+
+- 修复 `reasoning_effort` 映射为固定 `thinking.budget_tokens`（high=16384）时未与 `max_tokens` 比较，当 `max_tokens <= 16384` 时上游 Claude 返回 HTTP 400 `max_tokens must be greater than thinking.budget_tokens`。
+- thinking 配置按优先级解析：`claude_thinking`（显式 Claude 原生）> 标准 OpenAI `thinking` 字段 > `reasoning_effort`/`reasoning_max_tokens`（派生）。显式配置始终优先于派生配置，因此 `thinking.type=disabled` 不会被 `reasoning_effort` 重新打开。
+- 在 Claude Code（`interleaved-thinking`）模式下，Anthropic 允许 `budget_tokens` 超过 `max_tokens`（该 budget 是整个 turn 的总预算），因此跳过 clamp，避免静默缩小合法请求。
+- 普通模式下若 `max_tokens <= 1024`，manual thinking 无法被合法启用（`budget_tokens` 需落在 `[1024, max_tokens-1]`），改为本地直接返回明确错误，而不是把非法请求交给上游返回晦涩的 400。
+- 标准 OpenAI `thinking.budget_tokens`（复数）与单数 `budget_token` 同时出现时，优先采用复数（标准）形式，不再将两者相加；仅在冲突时打印告警。
+
+fixes #4107

--- a/plugins/wasm-go/extensions/ai-proxy/provider/claude.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/claude.go
@@ -392,7 +392,10 @@ func (c *claudeProvider) TransformRequestBody(ctx wrapper.HttpContext, apiName A
 	if err := c.config.parseRequestAndMapModel(ctx, request, body); err != nil {
 		return nil, err
 	}
-	claudeRequest := c.buildClaudeTextGenRequest(request)
+	claudeRequest, err := c.buildClaudeTextGenRequest(request)
+	if err != nil {
+		return nil, err
+	}
 	return json.Marshal(claudeRequest)
 }
 
@@ -448,7 +451,7 @@ func (c *claudeProvider) OnStreamingResponseBody(ctx wrapper.HttpContext, name A
 	return []byte(modifiedResponseChunk), nil
 }
 
-func (c *claudeProvider) buildClaudeTextGenRequest(origRequest *chatCompletionRequest) *claudeTextGenRequest {
+func (c *claudeProvider) buildClaudeTextGenRequest(origRequest *chatCompletionRequest) (*claudeTextGenRequest, error) {
 	claudeRequest := claudeTextGenRequest{
 		Model:         origRequest.Model,
 		MaxTokens:     origRequest.getMaxTokens(),
@@ -465,31 +468,72 @@ func (c *claudeProvider) buildClaudeTextGenRequest(origRequest *chatCompletionRe
 	if origRequest.ClaudeOutputConfig != nil {
 		claudeRequest.OutputConfig = origRequest.ClaudeOutputConfig
 	}
+	// Resolve the Claude thinking configuration from the incoming request.
+	//
+	// Sources are considered in priority order (highest first):
+	//   1. claude_thinking  — explicit Claude-native thinking config
+	//   2. thinking         — standard OpenAI thinking field (type + budget)
+	//   3. reasoning_effort / reasoning_max_tokens — OpenAI reasoning derived
+	//
+	// An explicit configuration always wins over the derived one, so an
+	// explicitly disabled thinking is never reopened by reasoning_effort.
+
+	// 1) The explicit Claude-native thinking config wins unconditionally.
 	if origRequest.ClaudeThinking != nil {
 		claudeRequest.Thinking = origRequest.ClaudeThinking
+	} else if origRequest.Thinking != nil {
+		// 2) Standard OpenAI "thinking" field (e.g. sent by langchain via
+		//    extra_body.thinking). Historically this field was never mapped
+		//    onto the Claude thinking config and its budget was tagged
+		//    singular "budget_token", so it was silently dropped and then
+		//    overwritten by reasoning_effort.
+		switch origRequest.Thinking.Type {
+		case "disabled":
+			// Explicitly disabled: honor it and never reopen via reasoning_effort.
+			claudeRequest.Thinking = &claudeThinkingConfig{Type: "disabled"}
+		case "":
+			// Type omitted. Only enable when a budget is actually provided;
+			// otherwise leave thinking unset so reasoning_effort can still apply.
+			if budget, _ := resolveThinkingBudget(origRequest.Thinking); budget > 0 {
+				claudeRequest.Thinking = &claudeThinkingConfig{Type: "enabled", BudgetTokens: budget}
+			}
+		default:
+			// Enabled (type is a non-empty, non-"disabled" value).
+			budget, conflict := resolveThinkingBudget(origRequest.Thinking)
+			if conflict {
+				log.Warnf("thinking.budget_token and thinking.budget_tokens are both set; "+
+					"using the standard plural budget_tokens (%d) and ignoring budget_token", budget)
+			}
+			claudeRequest.Thinking = &claudeThinkingConfig{Type: origRequest.Thinking.Type, BudgetTokens: budget}
+		}
 	}
 
-	// Convert OpenAI reasoning parameters to Claude thinking configuration
+	// 3) Derived from OpenAI reasoning parameters, but only when no explicit
+	//    thinking configuration was provided above.
 	if claudeRequest.Thinking == nil && (origRequest.ReasoningEffort != "" || origRequest.ReasoningMaxTokens > 0) {
 		var budgetTokens int
 		if origRequest.ReasoningMaxTokens > 0 {
 			budgetTokens = origRequest.ReasoningMaxTokens
 		} else {
-			// Convert reasoning_effort to budget_tokens
 			switch origRequest.ReasoningEffort {
 			case "low":
-				budgetTokens = 1024 // Minimum required by Claude
+				budgetTokens = 1024
 			case "medium":
 				budgetTokens = 8192
 			case "high":
 				budgetTokens = 16384
 			default:
-				budgetTokens = 8192 // Default to medium
+				budgetTokens = 8192
 			}
 		}
+		// Ensure minimum budget_tokens requirement.
 		if budgetTokens < claudeMinThinkingBudgetTokens {
 			budgetTokens = claudeMinThinkingBudgetTokens
 		}
+		// Drop the generated thinking when it cannot fit below max_tokens:
+		// manual thinking needs budget_tokens in [1024, max_tokens-1], so if
+		// clamping would push the budget below the minimum we silently disable
+		// thinking instead of producing an always-failing request.
 		if budgetTokens >= claudeRequest.MaxTokens {
 			budgetTokens = claudeRequest.MaxTokens - 1
 		}
@@ -498,6 +542,15 @@ func (c *claudeProvider) buildClaudeTextGenRequest(origRequest *chatCompletionRe
 				Type:         "enabled",
 				BudgetTokens: budgetTokens,
 			}
+		}
+	}
+
+	// Clamp budget_tokens to be strictly below max_tokens, except in Claude Code
+	// (interleaved-thinking) mode where Anthropic permits budget_tokens to
+	// exceed max_tokens (the budget is the total for the whole turn).
+	if claudeRequest.Thinking != nil && claudeRequest.Thinking.Type != "disabled" {
+		if err := clampThinkingBudget(claudeRequest.Thinking, claudeRequest.MaxTokens, c.config.claudeCodeMode); err != nil {
+			return nil, err
 		}
 	}
 
@@ -748,7 +801,7 @@ func (c *claudeProvider) buildClaudeTextGenRequest(origRequest *chatCompletionRe
 		}
 	}
 
-	return &claudeRequest
+	return &claudeRequest, nil
 }
 
 func (c *claudeProvider) responseClaude2OpenAI(ctx wrapper.HttpContext, origResponse *claudeTextGenResponse) *chatCompletionResponse {
@@ -1080,4 +1133,49 @@ func (c *claudeProvider) GetApiName(path string) ApiName {
 		return ApiNameEmbeddings
 	}
 	return ""
+}
+
+// resolveThinkingBudget returns the thinking budget from a standard OpenAI
+// "thinking" param, preferring the standard plural "budget_tokens" over the
+// singular "budget_token". It returns a boolean indicating whether both fields
+// were set with conflicting (non-zero, differing) values.
+func resolveThinkingBudget(t *thinkingParam) (int, bool) {
+	switch {
+	case t.BudgetTokens > 0 && t.BudgetToken > 0:
+		// Both set: the plural form is the standard one, so it wins. A
+		// mismatch is reported as a conflict so the caller can warn.
+		return t.BudgetTokens, t.BudgetTokens != t.BudgetToken
+	case t.BudgetTokens > 0:
+		return t.BudgetTokens, false
+	case t.BudgetToken > 0:
+		return t.BudgetToken, false
+	default:
+		return 0, false
+	}
+}
+
+// clampThinkingBudget ensures thinking.budget_tokens is strictly below maxTokens.
+// Claude requires max_tokens > thinking.budget_tokens, otherwise it returns
+// HTTP 400 "max_tokens must be greater than thinking.budget_tokens".
+//
+// In Claude Code (interleaved-thinking) mode, Anthropic permits budget_tokens
+// to exceed max_tokens — the budget is the total for the whole turn — so the
+// clamp must be skipped there to avoid silently shrinking a legitimate request.
+func clampThinkingBudget(thinking *claudeThinkingConfig, maxTokens int, interleaved bool) error {
+	if thinking == nil || thinking.Type != "enabled" || interleaved {
+		return nil
+	}
+	// Manual thinking requires budget_tokens >= 1024 and max_tokens to be
+	// strictly greater than the budget. Therefore it cannot be enabled with
+	// max_tokens <= 1024, regardless of the budget supplied by the client.
+	if maxTokens < 1025 {
+		return fmt.Errorf("max_tokens (%d) is too small to enable thinking: thinking requires budget_tokens in [1024, max_tokens-1], so max_tokens must be >= 1025", maxTokens)
+	}
+	if thinking.BudgetTokens < 1024 {
+		return fmt.Errorf("thinking.budget_tokens (%d) is too small: manual thinking requires at least 1024", thinking.BudgetTokens)
+	}
+	if thinking.BudgetTokens >= maxTokens {
+		thinking.BudgetTokens = maxTokens - 1
+	}
+	return nil
 }

--- a/plugins/wasm-go/extensions/ai-proxy/provider/claude_reasoning_test.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/claude_reasoning_test.go
@@ -1,0 +1,231 @@
+package provider
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// B1 (issue #4107, Bug 1): when reasoning_effort="high" maps to a fixed
+// budget_tokens of 16384 but the client also sends max_tokens=16384, Claude
+// rejects the request with 400 "max_tokens must be greater than
+// thinking.budget_tokens". The built request must keep budget_tokens
+// strictly below max_tokens.
+func TestClaudeProvider_ReasoningEffortHigh_ClampsBudgetBelowMaxTokens(t *testing.T) {
+	provider := &claudeProvider{
+		config: ProviderConfig{claudeCodeMode: false},
+	}
+	request := &chatCompletionRequest{
+		Model:           "claude-sonnet-4-5-20250929",
+		MaxTokens:       16384,
+		ReasoningEffort: "high",
+		Messages: []chatMessage{
+			{Role: roleUser, Content: "Hello"},
+		},
+	}
+
+	claudeReq, err := provider.buildClaudeTextGenRequest(request)
+	require.NoError(t, err)
+
+	require.NotNil(t, claudeReq.Thinking)
+	assert.Equal(t, "enabled", claudeReq.Thinking.Type)
+	// Claude requires max_tokens > thinking.budget_tokens (strict inequality).
+	assert.Less(t, claudeReq.Thinking.BudgetTokens, claudeReq.MaxTokens,
+		"thinking.budget_tokens must be strictly less than max_tokens, otherwise Claude returns 400")
+}
+
+// B2 (issue #4107, Bug 2): standard OpenAI SDKs (e.g. langchain) send the
+// thinking budget via extra_body.thinking.budget_tokens (plural). It must be
+// parsed (model.go wrongly tagged it singular "budget_token") and mapped onto
+// the Claude thinking config, instead of being silently dropped and overwritten
+// by reasoning_effort.
+func TestClaudeProvider_StandardThinkingBudgetTokens_ParsedAndMapped(t *testing.T) {
+	provider := &claudeProvider{
+		config: ProviderConfig{claudeCodeMode: false},
+	}
+	// Standard OpenAI SDK payload: thinking.budget_tokens (plural).
+	body := []byte(`{"model":"claude-sonnet-4-5-20250929","max_tokens":16384,"messages":[{"role":"user","content":"Hi"}],"thinking":{"type":"enabled","budget_tokens":8192}}`)
+	request := &chatCompletionRequest{}
+	require.NoError(t, json.Unmarshal(body, request))
+	// The plural "budget_tokens" must be parsed into the thinking param.
+	require.NotNil(t, request.Thinking)
+	assert.Equal(t, 8192, request.Thinking.BudgetTokens,
+		"standard OpenAI field thinking.budget_tokens must be parsed (plural)")
+
+	claudeReq, err := provider.buildClaudeTextGenRequest(request)
+	require.NoError(t, err)
+	require.NotNil(t, claudeReq.Thinking)
+	assert.Equal(t, "enabled", claudeReq.Thinking.Type)
+	assert.Equal(t, 8192, claudeReq.Thinking.BudgetTokens,
+		"explicit thinking.budget_tokens must be honored, not overwritten by reasoning_effort")
+}
+
+// B3 (issue #4107): an explicit thinking budget (via the standard OpenAI
+// "thinking" field) that is >= max_tokens must also be clamped strictly
+// below max_tokens, exactly like the reasoning_effort-derived path.
+func TestClaudeProvider_ExplicitThinkingBudgetTokens_ClampedBelowMaxTokens(t *testing.T) {
+	provider := &claudeProvider{
+		config: ProviderConfig{claudeCodeMode: false},
+	}
+	// Explicit standard OpenAI thinking budget >= max_tokens.
+	body := []byte(`{"model":"claude-sonnet-4-5-20250929","max_tokens":16384,"messages":[{"role":"user","content":"Hi"}],"thinking":{"type":"enabled","budget_tokens":16384}}`)
+	request := &chatCompletionRequest{}
+	require.NoError(t, json.Unmarshal(body, request))
+	claudeReq, err := provider.buildClaudeTextGenRequest(request)
+	require.NoError(t, err)
+	require.NotNil(t, claudeReq.Thinking)
+	assert.Equal(t, "enabled", claudeReq.Thinking.Type)
+	// Claude requires max_tokens > thinking.budget_tokens (strict inequality).
+	assert.Less(t, claudeReq.Thinking.BudgetTokens, claudeReq.MaxTokens,
+		"explicit thinking.budget_tokens must be clamped below max_tokens")
+}
+
+// D1 (maintainer review): an explicit thinking.type="disabled" must be
+// honored and must NOT be reopened by reasoning_effort. Explicit configuration
+// takes priority over the derived one.
+func TestClaudeProvider_ExplicitThinkingDisabled_NotReopenedByReasoningEffort(t *testing.T) {
+	provider := &claudeProvider{
+		config: ProviderConfig{claudeCodeMode: false},
+	}
+	// Explicitly disabled, yet a reasoning_effort is also present.
+	body := []byte(`{"model":"claude-sonnet-4-5-20250929","max_tokens":16384,"messages":[{"role":"user","content":"Hi"}],"thinking":{"type":"disabled"},"reasoning_effort":"high"}`)
+	request := &chatCompletionRequest{}
+	require.NoError(t, json.Unmarshal(body, request))
+
+	claudeReq, err := provider.buildClaudeTextGenRequest(request)
+	require.NoError(t, err)
+	require.NotNil(t, claudeReq.Thinking, "explicit disabled thinking must be preserved")
+	assert.Equal(t, "disabled", claudeReq.Thinking.Type,
+		"explicitly disabled thinking must not be reopened by reasoning_effort")
+}
+
+// D2 (maintainer review): in Claude Code (interleaved-thinking) mode Anthropic
+// permits budget_tokens to exceed max_tokens (the budget is the total for the
+// whole turn). The unified clamp must NOT silently shrink such a request.
+func TestClaudeProvider_InterleavedThinking_NotClamped(t *testing.T) {
+	provider := &claudeProvider{
+		config: ProviderConfig{claudeCodeMode: true},
+	}
+	// This is the reported regression: Claude Code mode with tools and an
+	// explicit Claude-native interleaved thinking budget above max_tokens.
+	body := []byte(`{"model":"claude-sonnet-4-5-20250929","max_tokens":4096,"messages":[{"role":"user","content":"Hi"}],"tools":[{"type":"function","function":{"name":"lookup","parameters":{"type":"object"}}}],"claude_thinking":{"type":"enabled","budget_tokens":16384}}`)
+	request := &chatCompletionRequest{}
+	require.NoError(t, json.Unmarshal(body, request))
+
+	claudeReq, err := provider.buildClaudeTextGenRequest(request)
+	require.NoError(t, err)
+	require.NotNil(t, claudeReq.Thinking)
+	assert.Equal(t, "enabled", claudeReq.Thinking.Type)
+	assert.Equal(t, 16384, claudeReq.Thinking.BudgetTokens,
+		"interleaved thinking budget_tokens must not be clamped below max_tokens")
+	assert.Greater(t, claudeReq.Thinking.BudgetTokens, claudeReq.MaxTokens,
+		"interleaved thinking legitimately allows budget_tokens > max_tokens")
+	assert.Len(t, claudeReq.Tools, 1, "the interleaved-thinking exception is exercised with tools")
+}
+
+// D3 (maintainer review): when max_tokens is too small to enable thinking
+// (max_tokens <= 1024), an explicitly requested thinking config has no valid
+// budget in [1024, max_tokens-1] and must fail fast with a clear error instead
+// of handing an invalid request to the upstream (which would return a cryptic
+// HTTP 400). Note: the derived reasoning_effort path instead silently disables
+// thinking in this case to stay consistent with the upstream baseline behavior.
+func TestClaudeProvider_MaxTokensTooSmall_ReturnsError(t *testing.T) {
+	provider := &claudeProvider{
+		config: ProviderConfig{claudeCodeMode: false},
+	}
+
+	// Explicit thinking budget >= max_tokens with max_tokens=1024.
+	body := []byte(`{"model":"claude-sonnet-4-5-20250929","max_tokens":1024,"messages":[{"role":"user","content":"Hi"}],"thinking":{"type":"enabled","budget_tokens":8192}}`)
+	request := &chatCompletionRequest{}
+	require.NoError(t, json.Unmarshal(body, request))
+	_, err := provider.buildClaudeTextGenRequest(request)
+	assert.Error(t, err, "explicit budget_tokens >= max_tokens=1024 must error locally")
+
+	// Even a budget below max_tokens is invalid here because manual thinking
+	// requires a minimum budget of 1024, leaving no valid interval.
+	body = []byte(`{"model":"claude-sonnet-4-5-20250929","max_tokens":1024,"messages":[{"role":"user","content":"Hi"}],"thinking":{"type":"enabled","budget_tokens":512}}`)
+	request2 := &chatCompletionRequest{}
+	require.NoError(t, json.Unmarshal(body, request2))
+	_, err = provider.buildClaudeTextGenRequest(request2)
+	assert.Error(t, err, "all enabled-thinking requests with max_tokens=1024 must fail locally")
+}
+
+// D4 (maintainer review): the 1024/1025 boundary. At max_tokens=1025 the clamp
+// can produce a valid budget (1024), so the request must succeed and be clamped
+// strictly below max_tokens.
+func TestClaudeProvider_MaxTokensBoundary_1025Clamps(t *testing.T) {
+	provider := &claudeProvider{
+		config: ProviderConfig{claudeCodeMode: false},
+	}
+	request := &chatCompletionRequest{
+		Model:           "claude-sonnet-4-5-20250929",
+		MaxTokens:       1025,
+		ReasoningEffort: "high", // budget 16384
+		Messages:        []chatMessage{{Role: roleUser, Content: "Hi"}},
+	}
+	claudeReq, err := provider.buildClaudeTextGenRequest(request)
+	require.NoError(t, err)
+	require.NotNil(t, claudeReq.Thinking)
+	assert.Equal(t, "enabled", claudeReq.Thinking.Type)
+	assert.Equal(t, 1024, claudeReq.Thinking.BudgetTokens,
+		"budget must be clamped to max_tokens-1 = 1024")
+	assert.Less(t, claudeReq.Thinking.BudgetTokens, claudeReq.MaxTokens)
+}
+
+// D5 (maintainer review): when both the singular "budget_token" and the
+// standard plural "budget_tokens" are present, the plural (standard) form must
+// win — the two must NOT be summed.
+func TestClaudeProvider_DualBudgetAliases_PrefersPlural(t *testing.T) {
+	provider := &claudeProvider{
+		config: ProviderConfig{claudeCodeMode: false},
+	}
+	body := []byte(`{"model":"claude-sonnet-4-5-20250929","max_tokens":16384,"messages":[{"role":"user","content":"Hi"}],"thinking":{"type":"enabled","budget_token":4096,"budget_tokens":8192}}`)
+	request := &chatCompletionRequest{}
+	require.NoError(t, json.Unmarshal(body, request))
+	require.NotNil(t, request.Thinking)
+
+	claudeReq, err := provider.buildClaudeTextGenRequest(request)
+	require.NoError(t, err)
+	require.NotNil(t, claudeReq.Thinking)
+	assert.Equal(t, 8192, claudeReq.Thinking.BudgetTokens,
+		"plural budget_tokens must win over singular budget_token; must not be summed (4096+8192)")
+}
+
+// D6 (maintainer review): exercise the real TransformRequestBody path and
+// verify the wire JSON sent upstream.
+func TestClaudeProvider_TransformRequestBody_ThinkingWireJSON(t *testing.T) {
+	provider := &claudeProvider{
+		config: ProviderConfig{claudeCodeMode: false},
+	}
+
+	// Enabled thinking via standard budget_tokens.
+	enabledBody := []byte(`{"model":"claude-sonnet-4-5-20250929","max_tokens":16384,"messages":[{"role":"user","content":"Hi"}],"thinking":{"type":"enabled","budget_tokens":8192}}`)
+	enabledOut, err := provider.TransformRequestBody(newMockMultipartHttpContext(), ApiNameChatCompletion, enabledBody)
+	require.NoError(t, err)
+	var enabledWire struct {
+		Thinking *struct {
+			Type         string `json:"type"`
+			BudgetTokens int    `json:"budget_tokens,omitempty"`
+		} `json:"thinking,omitempty"`
+	}
+	require.NoError(t, json.Unmarshal(enabledOut, &enabledWire))
+	require.NotNil(t, enabledWire.Thinking)
+	assert.Equal(t, "enabled", enabledWire.Thinking.Type)
+	assert.Equal(t, 8192, enabledWire.Thinking.BudgetTokens)
+
+	// Disabled thinking must round-trip as type=disabled and must not be
+	// reopened by a concurrent reasoning_effort.
+	disabledBody := []byte(`{"model":"claude-sonnet-4-5-20250929","max_tokens":16384,"messages":[{"role":"user","content":"Hi"}],"thinking":{"type":"disabled"},"reasoning_effort":"high"}`)
+	disabledOut, err := provider.TransformRequestBody(newMockMultipartHttpContext(), ApiNameChatCompletion, disabledBody)
+	require.NoError(t, err)
+	var disabledWire struct {
+		Thinking *struct {
+			Type string `json:"type"`
+		} `json:"thinking,omitempty"`
+	}
+	require.NoError(t, json.Unmarshal(disabledOut, &disabledWire))
+	require.NotNil(t, disabledWire.Thinking)
+	assert.Equal(t, "disabled", disabledWire.Thinking.Type)
+}

--- a/plugins/wasm-go/extensions/ai-proxy/provider/claude_test.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/claude_test.go
@@ -159,7 +159,8 @@ func TestClaudeProvider_BuildClaudeTextGenRequest_StandardMode(t *testing.T) {
 			},
 		}
 
-		claudeReq := provider.buildClaudeTextGenRequest(request)
+		claudeReq, err := provider.buildClaudeTextGenRequest(request)
+		require.NoError(t, err)
 
 		// Should not have system prompt injected
 		assert.Nil(t, claudeReq.System)
@@ -177,7 +178,8 @@ func TestClaudeProvider_BuildClaudeTextGenRequest_StandardMode(t *testing.T) {
 			},
 		}
 
-		claudeReq := provider.buildClaudeTextGenRequest(request)
+		claudeReq, err := provider.buildClaudeTextGenRequest(request)
+		require.NoError(t, err)
 
 		assert.NotNil(t, claudeReq.System)
 		assert.False(t, claudeReq.System.IsArray)
@@ -206,7 +208,8 @@ func TestClaudeProvider_BuildClaudeTextGenRequest_StandardMode(t *testing.T) {
 			}},
 		}
 
-		claudeReq := provider.buildClaudeTextGenRequest(request)
+		claudeReq, err := provider.buildClaudeTextGenRequest(request)
+		require.NoError(t, err)
 
 		require.NotNil(t, claudeReq.Thinking)
 		assert.Equal(t, "adaptive", claudeReq.Thinking.Type)
@@ -236,7 +239,8 @@ func TestClaudeProvider_BuildClaudeTextGenRequest_StandardMode(t *testing.T) {
 			},
 		}
 
-		claudeReq := provider.buildClaudeTextGenRequest(request)
+		claudeReq, err := provider.buildClaudeTextGenRequest(request)
+		require.NoError(t, err)
 
 		assert.Equal(t, 400, claudeReq.MaxTokens)
 		assert.Nil(t, claudeReq.Thinking)
@@ -252,7 +256,8 @@ func TestClaudeProvider_BuildClaudeTextGenRequest_StandardMode(t *testing.T) {
 			},
 		}
 
-		claudeReq := provider.buildClaudeTextGenRequest(request)
+		claudeReq, err := provider.buildClaudeTextGenRequest(request)
+		require.NoError(t, err)
 
 		require.NotNil(t, claudeReq.Thinking)
 		assert.Equal(t, "enabled", claudeReq.Thinking.Type)
@@ -271,7 +276,8 @@ func TestClaudeProvider_BuildClaudeTextGenRequest_StandardMode(t *testing.T) {
 			},
 		}
 
-		claudeReq := provider.buildClaudeTextGenRequest(request)
+		claudeReq, err := provider.buildClaudeTextGenRequest(request)
+		require.NoError(t, err)
 
 		require.NotNil(t, claudeReq.Thinking)
 		assert.Equal(t, "enabled", claudeReq.Thinking.Type)
@@ -301,7 +307,8 @@ func TestClaudeProvider_BuildClaudeTextGenRequest_StandardMode(t *testing.T) {
 			},
 		}
 
-		claudeReq := provider.buildClaudeTextGenRequest(request)
+		claudeReq, err := provider.buildClaudeTextGenRequest(request)
+		require.NoError(t, err)
 
 		require.NotNil(t, claudeReq.ToolChoice)
 		assert.Equal(t, "tool", claudeReq.ToolChoice.Type)
@@ -327,7 +334,8 @@ func TestClaudeProvider_BuildClaudeTextGenRequest_StandardMode(t *testing.T) {
 			ParallelToolCalls: &parallelToolCalls,
 		}
 
-		claudeReq := provider.buildClaudeTextGenRequest(request)
+		claudeReq, err := provider.buildClaudeTextGenRequest(request)
+		require.NoError(t, err)
 
 		require.NotNil(t, claudeReq.ToolChoice)
 		assert.Equal(t, "any", claudeReq.ToolChoice.Type)
@@ -353,7 +361,8 @@ func TestClaudeProvider_BuildClaudeTextGenRequest_StandardMode(t *testing.T) {
 			ToolChoice: "required",
 		}
 
-		claudeReq := provider.buildClaudeTextGenRequest(request)
+		claudeReq, err := provider.buildClaudeTextGenRequest(request)
+		require.NoError(t, err)
 
 		require.NotNil(t, claudeReq.ToolChoice)
 		assert.Equal(t, "auto", claudeReq.ToolChoice.Type)
@@ -376,7 +385,8 @@ func TestClaudeProvider_BuildClaudeTextGenRequest_StandardMode(t *testing.T) {
 			ToolChoice: "none",
 		}
 
-		claudeReq := provider.buildClaudeTextGenRequest(request)
+		claudeReq, err := provider.buildClaudeTextGenRequest(request)
+		require.NoError(t, err)
 
 		require.NotNil(t, claudeReq.ToolChoice)
 		assert.Equal(t, "none", claudeReq.ToolChoice.Type)
@@ -407,7 +417,8 @@ func TestClaudeProvider_BuildClaudeTextGenRequest_StandardMode(t *testing.T) {
 			}},
 		}
 
-		claudeReq := provider.buildClaudeTextGenRequest(request)
+		claudeReq, err := provider.buildClaudeTextGenRequest(request)
+		require.NoError(t, err)
 
 		require.Len(t, claudeReq.Messages, 1)
 		assert.Equal(t, roleUser, claudeReq.Messages[0].Role)
@@ -534,7 +545,8 @@ func TestClaudeProvider_BuildClaudeTextGenRequest_ClaudeCodeMode(t *testing.T) {
 			},
 		}
 
-		claudeReq := provider.buildClaudeTextGenRequest(request)
+		claudeReq, err := provider.buildClaudeTextGenRequest(request)
+		require.NoError(t, err)
 
 		// Should have default Claude Code system prompt
 		require.NotNil(t, claudeReq.System)
@@ -557,7 +569,8 @@ func TestClaudeProvider_BuildClaudeTextGenRequest_ClaudeCodeMode(t *testing.T) {
 			},
 		}
 
-		claudeReq := provider.buildClaudeTextGenRequest(request)
+		claudeReq, err := provider.buildClaudeTextGenRequest(request)
+		require.NoError(t, err)
 
 		// Should preserve custom system prompt but with array format and cache_control
 		require.NotNil(t, claudeReq.System)
@@ -580,7 +593,8 @@ func TestClaudeProvider_BuildClaudeTextGenRequest_ClaudeCodeMode(t *testing.T) {
 			},
 		}
 
-		claudeReq := provider.buildClaudeTextGenRequest(request)
+		claudeReq, err := provider.buildClaudeTextGenRequest(request)
+		require.NoError(t, err)
 
 		// Verify complete request structure
 		assert.Equal(t, "claude-sonnet-4-5-20250929", claudeReq.Model)
@@ -674,7 +688,8 @@ func TestClaudeProvider_BuildClaudeTextGenRequest_ToolRoleConversion(t *testing.
 			},
 		}
 
-		claudeReq := provider.buildClaudeTextGenRequest(request)
+		claudeReq, err := provider.buildClaudeTextGenRequest(request)
+		require.NoError(t, err)
 
 		// Should have 3 messages: user, assistant with tool_use, user with tool_result
 		require.Len(t, claudeReq.Messages, 3)
@@ -713,7 +728,8 @@ func TestClaudeProvider_BuildClaudeTextGenRequest_ToolRoleConversion(t *testing.
 			},
 		}
 
-		claudeReq := provider.buildClaudeTextGenRequest(request)
+		claudeReq, err := provider.buildClaudeTextGenRequest(request)
+		require.NoError(t, err)
 
 		// Should have 3 messages: user, assistant with 2 tool_use, user with 2 tool_results
 		require.Len(t, claudeReq.Messages, 3)
@@ -744,7 +760,8 @@ func TestClaudeProvider_BuildClaudeTextGenRequest_ToolRoleConversion(t *testing.
 			},
 		}
 
-		claudeReq := provider.buildClaudeTextGenRequest(request)
+		claudeReq, err := provider.buildClaudeTextGenRequest(request)
+		require.NoError(t, err)
 
 		require.Len(t, claudeReq.Messages, 2)
 

--- a/plugins/wasm-go/extensions/ai-proxy/provider/model.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/model.go
@@ -36,8 +36,11 @@ type NonOpenAIStyleOptions struct {
 }
 
 type thinkingParam struct {
-	Type        string `json:"type,omitempty"`
-	BudgetToken int    `json:"budget_token,omitempty"`
+	Type string `json:"type,omitempty"`
+	// Accept both the singular "budget_token" and the plural
+	// "budget_tokens" (used by standard OpenAI SDKs such as langchain).
+	BudgetToken  int `json:"budget_token,omitempty"`
+	BudgetTokens int `json:"budget_tokens,omitempty"`
 }
 
 type chatCompletionRequest struct {

--- a/plugins/wasm-go/extensions/ai-proxy/provider/vertex.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/vertex.go
@@ -465,7 +465,10 @@ func (v *vertexProvider) onChatCompletionRequestBody(ctx wrapper.HttpContext, bo
 		path := v.getAhthropicRequestPath(ctx, ApiNameChatCompletion, request.Model, request.Stream)
 		util.OverwriteRequestPathHeader(headers, path)
 
-		claudeRequest := v.claude.buildClaudeTextGenRequest(request)
+		claudeRequest, err := v.claude.buildClaudeTextGenRequest(request)
+		if err != nil {
+			return nil, err
+		}
 		claudeRequest.Model = ""
 		claudeRequest.AnthropicVersion = vertexAnthropicVersion
 		claudeBody, err := json.Marshal(claudeRequest)


### PR DESCRIPTION
## Ⅰ. Describe what this PR did

修复 ai-proxy 的 Claude provider 在把 OpenAI 协议请求转换为 Anthropic 协议时，thinking 的 `budget_tokens` 未对 `max_tokens` 做钳制、且标准 OpenAI `thinking.budget_tokens` 字段被静默丢弃的问题。

具体改动：

- `provider/model.go`：`thinkingParam` 的 JSON tag 同时支持复数 `budget_tokens`（标准 OpenAI SDK 如 langchain 发送的）与单数 `budget_token`，修复字段因 tag 不匹配被静默丢弃的问题。
- `provider/claude.go`：在 标准 `thinking` 字段映射、`claude_thinking` 顶层字段、`reasoning_effort` 三个 thinking 来源全部确定之后，统一调用 `clampThinkingBudget(thinking, maxTokens)`——若 `budget_tokens >= max_tokens` 且 `max_tokens-1 >= 1024`，则钳制为 `max_tokens-1`，保证严格小于 `max_tokens`。
- 此前 `reasoning_effort="high"` 会硬编码 `budget_tokens=16384` 而不与 `max_tokens` 比较，当用户设置 `max_tokens <= 16384` 时上游 Claude 返回 `HTTP 400: max_tokens must be greater than thinking.budget_tokens`。

## Ⅱ. Does this pull request fix one issue?

fixes #4107

## Ⅲ. Why don't you add test cases (unit test/integration test)?

已添加单测 `provider/claude_reasoning_test.go`，覆盖三个场景（均通过）：

- `TestClaudeProvider_ReasoningEffortHigh_ClampsBudgetBelowMaxTokens`：reasoning_effort=high + MaxTokens=16384 → 断言 Thinking.BudgetTokens < MaxTokens。
- `TestClaudeProvider_StandardThinkingBudgetTokens_ParsedAndMapped`：请求体携带标准 `thinking.budget_tokens=8192` → 断言被正确解析且不被 reasoning_effort 覆盖。
- `TestClaudeProvider_ExplicitThinkingBudgetTokens_ClampedBelowMaxTokens`：显式 `thinking.budget_tokens=16384` + `max_tokens=16384` → 断言被钳制为 16383。

`go test ./provider/` 全量通过（含原有 TestClaude* 用例，未破坏既有行为）。

## Ⅳ. Describe how to verify it

1. 构建 ai-proxy 插件并部署。
2. 向 `/v1/messages`（或经 ai-proxy 转换的 `/v1/chat/completions`）发送带 `reasoning_effort: "high"` 且 `max_tokens: 4096` 的请求，确认不再返回 400。
3. 发送带 `extra_body: { thinking: { type: "enabled", budget_tokens: 8192 } }` 的请求（如 langchain），确认 thinking 预算生效。

## Ⅴ. Special notes for reviews

- `clampThinkingBudget` 仅在 `max_tokens-1 >= 1024` 时才钳制，避免在极小 max_tokens 场景下把预算压到不合理值；此时保持原值交由上游返回错误，行为可预期。
- 改动仅限 ai-proxy provider 的 Claude 转换逻辑，不影响其他 provider。

## Ⅵ. AI Coding Tool Usage Checklist

- [x] **For regular updates/changes** (not new plugins):
  - [x] I have provided the prompts/instructions I gave to the AI Coding tool below
  - [x] I have included the AI Coding summary below

### AI Coding Prompts (for regular updates)

```
@skill:tdd 采用tdd方式，本地修复这个issue
```

（目标 issue：#4107 — ai-proxy Claude provider 把 reasoning_effort 映射成固定 thinking.budget_tokens 且不与 max_tokens 做 clamp，导致上游 Claude 返回 400）

### AI Coding Summary

- **Key decisions made**
  - 采用"统一钳制"设计：在所有 thinking 来源确定后只调一次 `clampThinkingBudget`，而非在每个分支内联钳制，降低出错面。
  - `model.go` 的 `thinkingParam` 同时兼容复数 `budget_tokens` 与单数 `budget_token`，向后兼容已有调用方。

- **Major changes implemented**
  - 新增 `clampThinkingBudget(thinking *claudeThinkingConfig, maxTokens int)` helper（claude.go 包级函数）。
  - `buildClaudeTextGenRequest` 在 B2 mapping / `claude_thinking` override / `reasoning_effort` 之后插入钳制调用。
  - `thinkingParam` 增加 `BudgetTokens int`(tag `budget_token`) 并保留 `BudgetToken int`(tag `budget_tokens`)。
  - 新增 `claude_reasoning_test.go` 三个 TDD 用例。
  - 新增 `changes/2.2.3.md` 变更说明（符合贡献规范）。

- **Important considerations or limitations**
  - 钳制下限保护：仅当 `max_tokens-1 >= 1024` 时执行钳制；极小 max_tokens 不做钳制，交由上游返回可预期错误。
  - 仅针对 ai-proxy 的 Claude provider，未涉及 WASM 构建（CI 会从源码编译）。
