### PR TITLE
fix(ai-proxy): preserve Bedrock cache read/write token categories

### DIFF
--- a/plugins/wasm-go/extensions/ai-proxy/provider/bedrock.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/bedrock.go
@@ -1280,12 +1280,12 @@ func appendCachePointToBedrockMessage(request *bedrockTextGenRequest, messageInd
 }
 
 func buildPromptTokensDetails(cacheReadInputTokens int, cacheWriteInputTokens int) *promptTokensDetails {
-	totalCachedTokens := cacheReadInputTokens + cacheWriteInputTokens
-	if totalCachedTokens <= 0 {
+	if cacheReadInputTokens <= 0 && cacheWriteInputTokens <= 0 {
 		return nil
 	}
 	return &promptTokensDetails{
-		CachedTokens: totalCachedTokens,
+		CachedTokens:     cacheReadInputTokens,
+		CacheWriteTokens: cacheWriteInputTokens,
 	}
 }
 

--- a/plugins/wasm-go/extensions/ai-proxy/provider/claude_to_openai.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/claude_to_openai.go
@@ -378,6 +378,7 @@ func (c *ClaudeToOpenAIConverter) ConvertOpenAIResponseToClaude(ctx wrapper.Http
 		}
 		if openaiResponse.Usage.PromptTokensDetails != nil {
 			claudeResponse.Usage.CacheReadInputTokens = openaiResponse.Usage.PromptTokensDetails.CachedTokens
+			claudeResponse.Usage.CacheCreationInputTokens = openaiResponse.Usage.PromptTokensDetails.CacheWriteTokens
 		}
 	}
 
@@ -990,6 +991,7 @@ func (c *ClaudeToOpenAIConverter) buildClaudeStreamResponse(ctx wrapper.HttpCont
 		}
 		if openaiResponse.Usage.PromptTokensDetails != nil {
 			usage.CacheReadInputTokens = openaiResponse.Usage.PromptTokensDetails.CachedTokens
+			usage.CacheCreationInputTokens = openaiResponse.Usage.PromptTokensDetails.CacheWriteTokens
 		}
 
 		// Send message_delta with both stop_reason and usage (Claude protocol requirement)

--- a/plugins/wasm-go/extensions/ai-proxy/provider/model.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/model.go
@@ -193,8 +193,9 @@ type usage struct {
 }
 
 type promptTokensDetails struct {
-	AudioTokens  int `json:"audio_tokens,omitempty"`
-	CachedTokens int `json:"cached_tokens,omitempty"`
+	AudioTokens      int `json:"audio_tokens,omitempty"`
+	CachedTokens     int `json:"cached_tokens,omitempty"`
+	CacheWriteTokens int `json:"cache_write_tokens,omitempty"`
 }
 
 type completionTokensDetails struct {

--- a/plugins/wasm-go/extensions/ai-proxy/test/bedrock.go
+++ b/plugins/wasm-go/extensions/ai-proxy/test/bedrock.go
@@ -1841,9 +1841,10 @@ func RunBedrockOnHttpResponseBodyTests(t *testing.T) {
 			usageMap := usage.(map[string]interface{})
 			promptTokensDetails, hasPromptTokensDetails := usageMap["prompt_tokens_details"].(map[string]interface{})
 			require.True(t, hasPromptTokensDetails, "prompt_tokens_details should exist when cacheReadInputTokens is present")
-			require.Equal(t, float64(18), promptTokensDetails["cached_tokens"], "cached_tokens should sum cacheReadInputTokens and cacheWriteInputTokens")
-			_, hasCacheWriteTokens := promptTokensDetails["cache_write_tokens"]
-			require.False(t, hasCacheWriteTokens, "cache_write_tokens should not exist in OpenAI-compatible usage")
+			require.Equal(t, float64(6), promptTokensDetails["cached_tokens"], "cached_tokens should reflect cacheReadInputTokens only")
+			cacheWriteTokens, hasCacheWriteTokens := promptTokensDetails["cache_write_tokens"]
+			require.True(t, hasCacheWriteTokens, "cache_write_tokens should exist when cacheWriteInputTokens is present")
+			require.Equal(t, float64(12), cacheWriteTokens, "cache_write_tokens should reflect cacheWriteInputTokens")
 		})
 
 		t.Run("bedrock response body with zero cache read tokens should omit prompt_tokens_details", func(t *testing.T) {
@@ -1914,7 +1915,7 @@ func RunBedrockOnHttpResponseBodyTests(t *testing.T) {
 			require.False(t, hasPromptTokensDetails, "prompt_tokens_details should be omitted when cacheReadInputTokens is zero")
 		})
 
-		t.Run("bedrock response body with only cache write tokens should map to cached_tokens", func(t *testing.T) {
+		t.Run("bedrock response body with only cache write tokens should map to cache_write_tokens", func(t *testing.T) {
 			host, status := test.NewTestHost(bedrockApiTokenConfig)
 			defer host.Reset()
 			require.Equal(t, types.OnPluginStartStatusOK, status)
@@ -1979,9 +1980,11 @@ func RunBedrockOnHttpResponseBodyTests(t *testing.T) {
 			usageMap := responseMap["usage"].(map[string]interface{})
 			promptTokensDetails, hasPromptTokensDetails := usageMap["prompt_tokens_details"].(map[string]interface{})
 			require.True(t, hasPromptTokensDetails, "prompt_tokens_details should exist when cacheWriteInputTokens is present")
-			require.Equal(t, float64(9), promptTokensDetails["cached_tokens"], "cached_tokens should map from cacheWriteInputTokens when cacheReadInputTokens is zero")
-			_, hasCacheWriteTokens := promptTokensDetails["cache_write_tokens"]
-			require.False(t, hasCacheWriteTokens, "cache_write_tokens should not exist in OpenAI-compatible usage")
+			cacheWriteTokens, hasCacheWriteTokens := promptTokensDetails["cache_write_tokens"]
+			require.True(t, hasCacheWriteTokens, "cache_write_tokens should exist when cacheWriteInputTokens is present")
+			require.Equal(t, float64(9), cacheWriteTokens, "cache_write_tokens should reflect cacheWriteInputTokens")
+			_, hasCachedTokens := promptTokensDetails["cached_tokens"]
+			require.False(t, hasCachedTokens, "cached_tokens should be omitted when cacheReadInputTokens is zero")
 		})
 
 		t.Run("bedrock anthropic messages response body should pass through", func(t *testing.T) {
@@ -2203,7 +2206,7 @@ func RunBedrockOnStreamingResponseBodyTests(t *testing.T) {
 			}
 		})
 
-		t.Run("bedrock streaming usage should map cached_tokens", func(t *testing.T) {
+		t.Run("bedrock streaming usage should preserve cache read/write categories", func(t *testing.T) {
 			host, status := test.NewTestHost(bedrockApiTokenConfig)
 			defer host.Reset()
 			require.Equal(t, types.OnPluginStartStatusOK, status)
@@ -2266,9 +2269,10 @@ func RunBedrockOnStreamingResponseBodyTests(t *testing.T) {
 			require.NoError(t, err)
 			usageMap := responseMap["usage"].(map[string]interface{})
 			promptTokensDetails := usageMap["prompt_tokens_details"].(map[string]interface{})
-			require.Equal(t, float64(10), promptTokensDetails["cached_tokens"], "cached_tokens should sum cacheReadInputTokens and cacheWriteInputTokens in streaming usage event")
-			_, hasCacheWriteTokens := promptTokensDetails["cache_write_tokens"]
-			require.False(t, hasCacheWriteTokens, "cache_write_tokens should not exist in OpenAI-compatible streaming usage")
+			require.Equal(t, float64(7), promptTokensDetails["cached_tokens"], "cached_tokens should reflect cacheReadInputTokens only in streaming usage event")
+			cacheWriteTokens, hasCacheWriteTokens := promptTokensDetails["cache_write_tokens"]
+			require.True(t, hasCacheWriteTokens, "cache_write_tokens should exist when cacheWriteInputTokens is present in streaming usage")
+			require.Equal(t, float64(3), cacheWriteTokens, "cache_write_tokens should reflect cacheWriteInputTokens in streaming usage event")
 		})
 
 		t.Run("bedrock streaming text chunk then usage chunk format is stable", func(t *testing.T) {


### PR DESCRIPTION
## Ⅰ. Describe what this PR does

Fixes #4169

The Bedrock provider combined `cacheReadInputTokens` and `cacheWriteInputTokens` into a single `prompt_tokens_details.cached_tokens` value, losing the distinction between cache reads and cache writes. When the response was later converted to the Claude protocol, all combined cache tokens were reported as `cache_read_input_tokens` and `cache_creation_input_tokens` was omitted.

## Ⅱ. Changes

1. **`provider/model.go`** — add `cache_write_tokens` field to `promptTokensDetails`.
2. **`provider/bedrock.go`** — `buildPromptTokensDetails` now maps `cacheReadInputTokens` → `cached_tokens` and `cacheWriteInputTokens` → `cache_write_tokens` separately, instead of summing them. `prompt_tokens_details` is still omitted when both are zero.
3. **`provider/claude_to_openai.go`** — map `cache_write_tokens` back to `cache_creation_input_tokens` in both the non-streaming and streaming Claude conversion paths.
4. **`test/bedrock.go`** — updated the Bedrock usage tests to assert the two categories are preserved separately.

## Ⅲ. Behavior

For Bedrock usage:
```json
{ "inputTokens": 100, "outputTokens": 20, "cacheReadInputTokens": 7, "cacheWriteInputTokens": 3 }
```

**Before:** `prompt_tokens_details: { cached_tokens: 10 }` → Claude: `cache_read_input_tokens: 10`, no `cache_creation_input_tokens`.

**After:** `prompt_tokens_details: { cached_tokens: 7, cache_write_tokens: 3 }` → Claude: `cache_read_input_tokens: 7, cache_creation_input_tokens: 3`.

Both streaming and non-streaming paths are covered.
