### PR TITLE
fix(ai-proxy): detect Baidu embeddings API paths

### DIFF
--- a/plugins/wasm-go/extensions/ai-proxy/provider/baidu.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/baidu.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 
 	"github.com/alibaba/higress/plugins/wasm-go/extensions/ai-proxy/util"
-	"github.com/higress-group/wasm-go/pkg/wrapper"
 	"github.com/higress-group/proxy-wasm-go-sdk/proxywasm/types"
+	"github.com/higress-group/wasm-go/pkg/wrapper"
 )
 
 // baiduProvider is the provider for baidu service.
@@ -72,6 +72,9 @@ func (g *baiduProvider) TransformRequestHeaders(ctx wrapper.HttpContext, apiName
 func (g *baiduProvider) GetApiName(path string) ApiName {
 	if strings.Contains(path, baiduChatCompletionPath) {
 		return ApiNameChatCompletion
+	}
+	if strings.Contains(path, baiduEmbeddings) {
+		return ApiNameEmbeddings
 	}
 	return ""
 }

--- a/plugins/wasm-go/extensions/ai-proxy/provider/baidu_test.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/baidu_test.go
@@ -1,0 +1,44 @@
+package provider
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBaiduProviderGetApiName(t *testing.T) {
+	provider := &baiduProvider{}
+
+	tests := []struct {
+		name string
+		path string
+		want ApiName
+	}{
+		{
+			name: "chat completions",
+			path: baiduChatCompletionPath,
+			want: ApiNameChatCompletion,
+		},
+		{
+			name: "embeddings",
+			path: baiduEmbeddings,
+			want: ApiNameEmbeddings,
+		},
+		{
+			name: "embeddings with route prefix",
+			path: "/gateway" + baiduEmbeddings,
+			want: ApiNameEmbeddings,
+		},
+		{
+			name: "unknown",
+			path: "/v2/unknown",
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, provider.GetApiName(tt.path))
+		})
+	}
+}


### PR DESCRIPTION
## What changed

- recognize Baidu Qianfan's `/v2/embeddings` endpoint in `GetApiName`
- add regression coverage for chat, embeddings, prefixed embeddings, and unknown paths

## Why

Baidu Qianfan includes embeddings in its default capabilities, but original-protocol requests are classified by the provider-specific `GetApiName` hook. That hook only recognized chat completions, leaving direct `/v2/embeddings` requests with an empty API name.

## Validation

- `go test ./provider`
- `git diff --check`
