### PR TITLE
fix(ai-proxy): detect hunyuan embeddings API paths

### DIFF
--- a/plugins/wasm-go/extensions/ai-proxy/provider/hunyuan.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/hunyuan.go
@@ -594,5 +594,8 @@ func GetTC3Authorizationcode(secretId string, secretKey string, timestamp int64,
 }
 
 func (m *hunyuanProvider) GetApiName(path string) ApiName {
+	if strings.Contains(path, PathOpenAIEmbeddings) {
+		return ApiNameEmbeddings
+	}
 	return ApiNameChatCompletion
 }

--- a/plugins/wasm-go/extensions/ai-proxy/provider/hunyuan_test.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/hunyuan_test.go
@@ -1,0 +1,44 @@
+package provider
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHunyuanProviderGetApiName(t *testing.T) {
+	provider := &hunyuanProvider{}
+
+	tests := []struct {
+		name string
+		path string
+		want ApiName
+	}{
+		{
+			name: "chat completions",
+			path: PathOpenAIChatCompletions,
+			want: ApiNameChatCompletion,
+		},
+		{
+			name: "embeddings",
+			path: PathOpenAIEmbeddings,
+			want: ApiNameEmbeddings,
+		},
+		{
+			name: "embeddings with route prefix",
+			path: "/gateway" + PathOpenAIEmbeddings,
+			want: ApiNameEmbeddings,
+		},
+		{
+			name: "unknown path defaults to chat completion",
+			path: "/v1/unknown",
+			want: ApiNameChatCompletion,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, provider.GetApiName(tt.path))
+		})
+	}
+}


### PR DESCRIPTION
## Problem

hunyuanProvider.GetApiName() unconditionally returned ApiNameChatCompletion regardless of the request path. Since DefaultCapabilities() declares support for ApiNameEmbeddings, embeddings requests (/v1/embeddings) were silently misprocessed as chat completions — signed with the wrong TC-Action (ChatCompletions) and sent to Tencent Cloud with an incompatible payload.

## Fix

Add path detection for the embeddings endpoint before falling back to the chat completion default.

## Testing

Added hunyuan_test.go with unit tests covering:
- Chat completions path detection
- Embeddings path detection
- Embeddings with route prefix
- Unknown path defaults to chat completion