### PR TITLE
fix: support Higress service backends in HTTPRoute

### DIFF
--- a/pkg/ingress/kube/gateway/istio/conversion.go
+++ b/pkg/ingress/kube/gateway/istio/conversion.go
@@ -1176,14 +1176,8 @@ func buildDestination(ctx RouteContext, to k8s.BackendRef, ns string,
 			Host: hostname,
 			Port: &istio.PortSelector{Number: destPort},
 		}, ipCfg, invalidBackendErr
-	default:
-		return &istio.Destination{}, nil, &ConfigError{
-			Reason:  InvalidDestinationKind,
-			Message: fmt.Sprintf("referencing unsupported backendRef: group %q kind %q", ptr.OrEmpty(to.Group), ptr.OrEmpty(to.Kind)),
-		}
-	}
 	// Start - Added by Higress
-	if equal((*string)(to.Group), "networking.higress.io") && nilOrEqual((*string)(to.Kind), "Service") {
+	case config.GroupVersionKind{Group: "networking.higress.io", Kind: "Service"}:
 		var port *istio.PortSelector
 		if to.Port != nil {
 			port = &istio.PortSelector{Number: uint32(*to.Port)}
@@ -1192,8 +1186,13 @@ func buildDestination(ctx RouteContext, to k8s.BackendRef, ns string,
 			Host: string(to.Name),
 			Port: port,
 		}, nil, nil
-	}
 	// End - Added by Higress
+	default:
+		return &istio.Destination{}, nil, &ConfigError{
+			Reason:  InvalidDestinationKind,
+			Message: fmt.Sprintf("referencing unsupported backendRef: group %q kind %q", ptr.OrEmpty(to.Group), ptr.OrEmpty(to.Kind)),
+		}
+	}
 
 	// All types currently require a Port, so we do this for everything; consider making this per-type if we have future types
 	// that do not require port.
@@ -2734,14 +2733,6 @@ func isCatchAllMatch(m *istio.HTTPMatchRequest) bool {
 		m.Port == 0 &&
 		m.Authority == nil &&
 		m.SourceNamespace == ""
-}
-
-func equal(have *string, expected string) bool {
-	return have != nil && *have == expected
-}
-
-func nilOrEqual(have *string, expected string) bool {
-	return have == nil || *have == expected
 }
 
 func generateRouteName(obj config.Namer, routeType string) string {

--- a/pkg/ingress/kube/gateway/istio/conversion.go
+++ b/pkg/ingress/kube/gateway/istio/conversion.go
@@ -1148,14 +1148,8 @@ func buildDestination(ctx RouteContext, to k8s.BackendRef, ns string,
 			Host: hostname,
 			// Port: &istio.PortSelector{Number: uint32(*to.Port)},
 		}, ipCfg, invalidBackendErr
-	default:
-		return &istio.Destination{}, nil, &ConfigError{
-			Reason:  InvalidDestinationKind,
-			Message: fmt.Sprintf("referencing unsupported backendRef: group %q kind %q", ptr.OrEmpty(to.Group), ptr.OrEmpty(to.Kind)),
-		}
-	}
 	// Start - Added by Higress
-	if equal((*string)(to.Group), "networking.higress.io") && nilOrEqual((*string)(to.Kind), "Service") {
+	case config.GroupVersionKind{Group: "networking.higress.io", Kind: "Service"}:
 		var port *istio.PortSelector
 		if to.Port != nil {
 			port = &istio.PortSelector{Number: uint32(*to.Port)}
@@ -1164,8 +1158,13 @@ func buildDestination(ctx RouteContext, to k8s.BackendRef, ns string,
 			Host: string(to.Name),
 			Port: port,
 		}, nil, nil
-	}
 	// End - Added by Higress
+	default:
+		return &istio.Destination{}, nil, &ConfigError{
+			Reason:  InvalidDestinationKind,
+			Message: fmt.Sprintf("referencing unsupported backendRef: group %q kind %q", ptr.OrEmpty(to.Group), ptr.OrEmpty(to.Kind)),
+		}
+	}
 
 	// All types currently require a Port, so we do this for everything; consider making this per-type if we have future types
 	// that do not require port.
@@ -2696,14 +2695,6 @@ func isCatchAllMatch(m *istio.HTTPMatchRequest) bool {
 		m.Port == 0 &&
 		m.Authority == nil &&
 		m.SourceNamespace == ""
-}
-
-func equal(have *string, expected string) bool {
-	return have != nil && *have == expected
-}
-
-func nilOrEqual(have *string, expected string) bool {
-	return have == nil || *have == expected
 }
 
 func generateRouteName(obj config.Namer, routeType string) string {

--- a/pkg/ingress/kube/gateway/istio/conversion_test.go
+++ b/pkg/ingress/kube/gateway/istio/conversion_test.go
@@ -1575,6 +1575,119 @@ func TestGatewayReferenceAllowedParentHostnameParsing(t *testing.T) {
 	}
 }
 
+func TestBuildDestinationHigressServiceBackend(t *testing.T) {
+	group := k8s.Group("networking.higress.io")
+	serviceKind := k8s.Kind("Service")
+	unsupportedKind := k8s.Kind("McpBridge")
+	port := k8s.PortNumber(80)
+
+	tests := []struct {
+		name       string
+		backendRef k8s.BackendRef
+		wantPort   *uint32
+		wantReason ConfigErrorReason
+	}{
+		{
+			name: "explicit service kind and port",
+			backendRef: k8s.BackendRef{BackendObjectReference: k8s.BackendObjectReference{
+				Group: &group,
+				Kind:  &serviceKind,
+				Name:  "llm-inclouder.internal.static",
+				Port:  &port,
+			}},
+			wantPort: ptr.Of(uint32(80)),
+		},
+		{
+			name: "default service kind without port",
+			backendRef: k8s.BackendRef{BackendObjectReference: k8s.BackendObjectReference{
+				Group: &group,
+				Name:  "llm-inclouder.internal.static",
+			}},
+		},
+		{
+			name: "unsupported kind",
+			backendRef: k8s.BackendRef{BackendObjectReference: k8s.BackendObjectReference{
+				Group: &group,
+				Kind:  &unsupportedKind,
+				Name:  "default",
+			}},
+			wantReason: InvalidDestinationKind,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			destination, inferencePool, configErr := buildDestination(
+				RouteContext{}, tt.backendRef, "default", false, gvk.HTTPRoute,
+			)
+			if tt.wantReason != "" {
+				if configErr == nil || configErr.Reason != tt.wantReason {
+					t.Fatalf("buildDestination() error = %v, want reason %q", configErr, tt.wantReason)
+				}
+				return
+			}
+			if configErr != nil {
+				t.Fatalf("buildDestination() unexpected error: %v", configErr)
+			}
+			if inferencePool != nil {
+				t.Fatalf("buildDestination() inference pool config = %v, want nil", inferencePool)
+			}
+			if destination.Host != string(tt.backendRef.Name) {
+				t.Fatalf("buildDestination() host = %q, want %q", destination.Host, tt.backendRef.Name)
+			}
+			if tt.wantPort == nil {
+				if destination.Port != nil {
+					t.Fatalf("buildDestination() port = %v, want nil", destination.Port)
+				}
+			} else if destination.Port == nil || destination.Port.Number != *tt.wantPort {
+				t.Fatalf("buildDestination() port = %v, want %d", destination.Port, *tt.wantPort)
+			}
+		})
+	}
+}
+
+func TestConvertHTTPRouteWithHigressServiceBackend(t *testing.T) {
+	group := k8s.Group("networking.higress.io")
+	kind := k8s.Kind("Service")
+	port := k8s.PortNumber(80)
+	rule := k8s.HTTPRouteRule{BackendRefs: []k8s.HTTPBackendRef{{
+		BackendRef: k8s.BackendRef{BackendObjectReference: k8s.BackendObjectReference{
+			Group: &group,
+			Kind:  &kind,
+			Name:  "llm-inclouder.internal.static",
+			Port:  &port,
+		}},
+	}}}
+	obj := &k8s.HTTPRoute{ObjectMeta: metav1.ObjectMeta{
+		Name:      "ai-route-test",
+		Namespace: "higress-system",
+	}}
+
+	route, inferencePool, configErr := convertHTTPRoute(RouteContext{}, rule, obj, 0, false)
+	if configErr != nil {
+		t.Fatalf("convertHTTPRoute() unexpected error: %v", configErr)
+	}
+	if inferencePool != nil {
+		t.Fatalf("convertHTTPRoute() inference pool config = %v, want nil", inferencePool)
+	}
+	if route == nil {
+		t.Fatal("convertHTTPRoute() route is nil")
+	}
+	if len(route.Route) != 1 {
+		t.Fatalf("convertHTTPRoute() destinations = %d, want 1", len(route.Route))
+	}
+	destination := route.Route[0].Destination
+	if destination == nil {
+		t.Fatal("convertHTTPRoute() destination is nil")
+	}
+	if destination.Host != "llm-inclouder.internal.static" {
+		t.Fatalf("convertHTTPRoute() host = %q, want %q", destination.Host, "llm-inclouder.internal.static")
+	}
+	if destination.Port == nil || destination.Port.Number != 80 {
+		t.Fatalf("convertHTTPRoute() port = %v, want 80", destination.Port)
+	}
+}
+
 func TestRouteParentReferenceHostnameIntersection(t *testing.T) {
 	tests := []struct {
 		name         string

--- a/pkg/ingress/kube/gateway/istio/conversion_test.go
+++ b/pkg/ingress/kube/gateway/istio/conversion_test.go
@@ -1522,6 +1522,119 @@ func TestGatewayReferenceAllowedParentHostnameParsing(t *testing.T) {
 	}
 }
 
+func TestBuildDestinationHigressServiceBackend(t *testing.T) {
+	group := k8s.Group("networking.higress.io")
+	serviceKind := k8s.Kind("Service")
+	unsupportedKind := k8s.Kind("McpBridge")
+	port := k8s.PortNumber(80)
+
+	tests := []struct {
+		name       string
+		backendRef k8s.BackendRef
+		wantPort   *uint32
+		wantReason ConfigErrorReason
+	}{
+		{
+			name: "explicit service kind and port",
+			backendRef: k8s.BackendRef{BackendObjectReference: k8s.BackendObjectReference{
+				Group: &group,
+				Kind:  &serviceKind,
+				Name:  "llm-inclouder.internal.static",
+				Port:  &port,
+			}},
+			wantPort: ptr.Of(uint32(80)),
+		},
+		{
+			name: "default service kind without port",
+			backendRef: k8s.BackendRef{BackendObjectReference: k8s.BackendObjectReference{
+				Group: &group,
+				Name:  "llm-inclouder.internal.static",
+			}},
+		},
+		{
+			name: "unsupported kind",
+			backendRef: k8s.BackendRef{BackendObjectReference: k8s.BackendObjectReference{
+				Group: &group,
+				Kind:  &unsupportedKind,
+				Name:  "default",
+			}},
+			wantReason: InvalidDestinationKind,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			destination, inferencePool, configErr := buildDestination(
+				RouteContext{}, tt.backendRef, "default", false, gvk.HTTPRoute,
+			)
+			if tt.wantReason != "" {
+				if configErr == nil || configErr.Reason != tt.wantReason {
+					t.Fatalf("buildDestination() error = %v, want reason %q", configErr, tt.wantReason)
+				}
+				return
+			}
+			if configErr != nil {
+				t.Fatalf("buildDestination() unexpected error: %v", configErr)
+			}
+			if inferencePool != nil {
+				t.Fatalf("buildDestination() inference pool config = %v, want nil", inferencePool)
+			}
+			if destination.Host != string(tt.backendRef.Name) {
+				t.Fatalf("buildDestination() host = %q, want %q", destination.Host, tt.backendRef.Name)
+			}
+			if tt.wantPort == nil {
+				if destination.Port != nil {
+					t.Fatalf("buildDestination() port = %v, want nil", destination.Port)
+				}
+			} else if destination.Port == nil || destination.Port.Number != *tt.wantPort {
+				t.Fatalf("buildDestination() port = %v, want %d", destination.Port, *tt.wantPort)
+			}
+		})
+	}
+}
+
+func TestConvertHTTPRouteWithHigressServiceBackend(t *testing.T) {
+	group := k8s.Group("networking.higress.io")
+	kind := k8s.Kind("Service")
+	port := k8s.PortNumber(80)
+	rule := k8s.HTTPRouteRule{BackendRefs: []k8s.HTTPBackendRef{{
+		BackendRef: k8s.BackendRef{BackendObjectReference: k8s.BackendObjectReference{
+			Group: &group,
+			Kind:  &kind,
+			Name:  "llm-inclouder.internal.static",
+			Port:  &port,
+		}},
+	}}}
+	obj := &k8sbeta.HTTPRoute{ObjectMeta: metav1.ObjectMeta{
+		Name:      "ai-route-test",
+		Namespace: "higress-system",
+	}}
+
+	route, inferencePool, configErr := convertHTTPRoute(RouteContext{}, rule, obj, 0, false)
+	if configErr != nil {
+		t.Fatalf("convertHTTPRoute() unexpected error: %v", configErr)
+	}
+	if inferencePool != nil {
+		t.Fatalf("convertHTTPRoute() inference pool config = %v, want nil", inferencePool)
+	}
+	if route == nil {
+		t.Fatal("convertHTTPRoute() route is nil")
+	}
+	if len(route.Route) != 1 {
+		t.Fatalf("convertHTTPRoute() destinations = %d, want 1", len(route.Route))
+	}
+	destination := route.Route[0].Destination
+	if destination == nil {
+		t.Fatal("convertHTTPRoute() destination is nil")
+	}
+	if destination.Host != "llm-inclouder.internal.static" {
+		t.Fatalf("convertHTTPRoute() host = %q, want %q", destination.Host, "llm-inclouder.internal.static")
+	}
+	if destination.Port == nil || destination.Port.Number != 80 {
+		t.Fatalf("convertHTTPRoute() port = %v, want 80", destination.Port)
+	}
+}
+
 func TestRouteParentReferenceHostnameIntersection(t *testing.T) {
 	tests := []struct {
 		name         string


### PR DESCRIPTION
## I. Summary

Fix HTTPRoute conversion for `backendRefs` with group `networking.higress.io` and kind `Service`:

- dispatch the Higress service kind inside `buildDestination` before the unsupported-kind fallback;
- preserve the registry service name and optional port in the generated Istio destination;
- keep the existing ReferenceGrant check and Kubernetes `Service` behavior unchanged;
- remove helpers made unreachable/unnecessary by the switch case;
- add focused destination tests and a full HTTPRoute conversion regression test.

No migration is required. Existing Kubernetes Service backends are unchanged; this only makes the documented Higress registry-service backend path reachable.

## II. Related issue

Fixes #4185.

## III. Change type

- [x] Bug fix
- [ ] Feature or enhancement
- [ ] Documentation or configuration only
- [x] Refactoring, tests, or maintenance

## IV. Agent participation and issue-spec gate

See the [agent-assisted contribution policy](https://github.com/higress-group/higress/blob/main/docs/developers/agent-assisted-contributions.md).

- [ ] **No agent participation:** This PR is human-only.
- [ ] **Trivial agent-use exception:** Agent use was limited to spelling, punctuation, whitespace, or formatting with no substantive choice or behavioral effect.
- [ ] **Verified maintainer/administrator exception:** Material agent participation occurred and the author qualifies for the verified exception.
- [x] **Material agent participation:** An AI/coding agent materially participated in analysis, implementation, testing, rebase adaptation, and PR preparation.

Timed obligations:

- [ ] **Before implementation began:** A Higress maintainer had approved Proposal and Design Issues and authorized implementation TASKs.
- [ ] **Before verification began:** The Design contained a concrete Verification Plan.
- [ ] **Before requesting maintainer review or acceptance:** Applicable implementation and verification TASKs were `done` with exact evidence.

Overall gate status:

- [ ] Complete
- [x] Noncompliant
- [ ] Verified exception
- [ ] N/A

**Gate-status explanation (or N/A):** This PR and its implementation began on 2026-07-30, before the issue-spec gate was added on 2026-08-08 by #4353. The required “before implementation” and “before verification” approvals therefore cannot be satisfied retroactively. I am explicitly marking the PR noncompliant rather than claiming a retroactive exception. Post-hoc R3 verification is supplied below to make technical review reproducible; it does not change the gate status or request review priority.

**Trivial-exception explanation (or N/A):** N/A — material participation is declared.

**Verified maintainer/administrator exception evidence (or N/A):** N/A — no verified maintainer/administrator exception is claimed.

**Approved Proposal Issue URL (or N/A with explanation):** N/A — work began before #4353 and had no pre-implementation Proposal approval.

**Approved Design Issue URL (or N/A with explanation):** N/A — work began before #4353 and had no pre-implementation Design approval.

**Maintainer approval link(s) (or N/A with explanation):** N/A — no gate approval is claimed.

**Authorized implementation TASK link(s) (or N/A with explanation):** N/A — no pre-implementation TASK authorization existed.

**Verification Plan and verification TASK/evidence link(s) (or N/A with explanation):** Formal pre-verification Design/TASK: N/A for the pre-policy work. Post-hoc reproducible R3 harness, plan, raw results, logs, assertions, cleanup proof, and checksums: [immutable evidence bundle](https://github.com/ai-yang/higress/tree/dba4b1b84841389f68a3373eb128c62fd1a4f63d/review-evidence/r3/pr-4231).

## V. Testing and verification

**Test and deterministic rerun commands (or N/A with explanation):**

```text
./review-evidence/r3/pr-4231/harness/go-verify.sh
./review-evidence/r3/pr-4231/harness/cluster-setup.sh
./review-evidence/r3/pr-4231/harness/run-requests.sh baseline
./review-evidence/r3/pr-4231/harness/capture-variant.sh baseline
./review-evidence/r3/pr-4231/harness/upgrade-fixed.sh
./review-evidence/r3/pr-4231/harness/run-requests.sh fixed
./review-evidence/r3/pr-4231/harness/capture-variant.sh fixed
./review-evidence/r3/pr-4231/harness/verify-evidence.py
sha256sum -c review-evidence/r3/pr-4231/SHA256SUMS
./review-evidence/r3/pr-4231/harness/cleanup.sh
```

Exact prerequisites, environment variables, build commands, and ordering are in the [R3 README](https://github.com/ai-yang/higress/blob/dba4b1b84841389f68a3373eb128c62fd1a4f63d/review-evidence/r3/pr-4231/README.md). Go verification passed: focused tests, full package tests, focused `-race -count=20`, and package `go vet`; see the [complete successful log](https://github.com/ai-yang/higress/blob/dba4b1b84841389f68a3373eb128c62fd1a4f63d/review-evidence/r3/pr-4231/logs/go-verify.log).

**Environment and configuration (or N/A with explanation):** Linux/amd64; Go 1.26.7 in a pinned container; kind v0.17.0; Kubernetes/kubectl v1.34.0; Gateway API v1.6.0 standard channel; Helm v3.14.4; Higress chart/app v2.2.4; single-node IPv4 kind cluster with host HTTP port 18080. Tool hashes, submodule SHAs, build flags, and image references are in [environment.json](https://github.com/ai-yang/higress/blob/dba4b1b84841389f68a3373eb128c62fd1a4f63d/review-evidence/r3/pr-4231/environment.json).

**Exact tested revision, version, image tag/digest, manifests, and values (or N/A with explanation):** Baseline source `409b3ed2644a977776391eae78ed6cb11e99d3d3`; fixed source/head `7cc8cde4bb8b268e1e5fa98219790b392e1d98d3`. Running binaries reported those exact SHAs. The same pinned gateway, pilot, echo, kind-node images, chart, runtime fixture, and requests were used. The rendered Helm diff contains only the controller tag change: [render diff](https://github.com/ai-yang/higress/blob/dba4b1b84841389f68a3373eb128c62fd1a4f63d/review-evidence/r3/pr-4231/logs/helm-rendered-controller.diff). Exact [manifests and values](https://github.com/ai-yang/higress/tree/dba4b1b84841389f68a3373eb128c62fd1a4f63d/review-evidence/r3/pr-4231/manifests), binary SHA256 values, image IDs/digests, and tool hashes are published in the bundle.

**Baseline reproduction evidence for bug fixes (or N/A with explanation):** With a valid `default` McpBridge registry, Envoy already had `outbound|5678||pr4231-echo.dns` with a healthy endpoint and the gateway could directly reach the backend with HTTP 200. Nevertheless the baseline HTTPRoute was `ResolvedRefs=False / InvalidKind`, its generated route targeted `UnknownService`, and the identical request returned HTTP 500 in 3/3 runs with `cluster_not_found`. See [baseline HTTPRoute](https://github.com/ai-yang/higress/blob/dba4b1b84841389f68a3373eb128c62fd1a4f63d/review-evidence/r3/pr-4231/logs/baseline/httproute.yaml), [Envoy clusters/routes](https://github.com/ai-yang/higress/tree/dba4b1b84841389f68a3373eb128c62fd1a4f63d/review-evidence/r3/pr-4231/logs/baseline), and [raw responses](https://github.com/ai-yang/higress/tree/dba4b1b84841389f68a3373eb128c62fd1a4f63d/review-evidence/r3/pr-4231/results/baseline).

**Fixed-version verification evidence for bug fixes (or N/A with explanation):** After changing only the controller image, the HTTPRoute became `ResolvedRefs=True`, the Envoy route targeted `outbound|5678||pr4231-echo.dns`, and 3/3 requests returned HTTP 200 with exact body `pr4231-backend-ok\n` and `via_upstream` access-log details. The machine assertion passed. See [summary.json](https://github.com/ai-yang/higress/blob/dba4b1b84841389f68a3373eb128c62fd1a4f63d/review-evidence/r3/pr-4231/results/summary.json), [validation report](https://github.com/ai-yang/higress/blob/dba4b1b84841389f68a3373eb128c62fd1a4f63d/review-evidence/r3/pr-4231/validation-report.md), [fixed logs](https://github.com/ai-yang/higress/tree/dba4b1b84841389f68a3373eb128c62fd1a4f63d/review-evidence/r3/pr-4231/logs/fixed), [fixed responses](https://github.com/ai-yang/higress/tree/dba4b1b84841389f68a3373eb128c62fd1a4f63d/review-evidence/r3/pr-4231/results/fixed), and [SHA256SUMS](https://github.com/ai-yang/higress/blob/dba4b1b84841389f68a3373eb128c62fd1a4f63d/review-evidence/r3/pr-4231/SHA256SUMS).

**Wasm source revision and SHA-256 (or N/A with explanation):** N/A — this PR does not change or build a Wasm plugin.

## VI. Special notes for reviewers

- Review focus: `buildDestination` dispatch order and preservation of group/kind, ReferenceGrant, and optional-port semantics.
- Runtime coverage uses the reported DNS-registry naming path. It does not claim exhaustive coverage of every registry type, TLS listener, or cross-namespace combination.
- The initial exploratory fixture used a non-default McpBridge name and was rejected before final evidence collection. The published fixture follows the repository's existing DNS-registry e2e convention (`higress-system/default`); all published red/green results use that valid fixture.
- Cleanup proof confirms the test kind cluster/container was removed and mapped ports were closed.

## VII. AI coding disclosure

**Tool(s) used (or N/A):** OpenAI Codex.

### Prompts or instructions

Analyze #4185 against current Higress main; identify and fix the HTTPRoute conversion bug without changing Kubernetes Service behavior; add focused and end-to-end conversion regression tests; rebase onto current main; run unit, full-package, race, vet, and real kind red/green verification; publish sanitized reproducible evidence with hashes; and update this PR transparently under the current contribution policy.

### AI-assisted work summary

The agent identified that the Higress-specific backend handling was placed after a switch whose default returned `InvalidDestinationKind`, making that branch unreachable. The implementation moves it into the switch, retains optional-port and ReferenceGrant behavior, adapts the test to Gateway API v1 after rebase, and removes unused helpers. Post-hoc verification used exact baseline/fixed controller builds in the same kind cluster, rejected an invalid exploratory fixture, established a healthy registry/backend control, reproduced 3/3 baseline failures, verified 3/3 fixed successes, ran machine assertions and SHA256 checks, and cleaned the runtime. The formal issue-spec gate remains explicitly noncompliant because the work predates the policy.
