### PR TITLE
fix: deduct AI quota for non-streaming responses

### DIFF
--- a/plugins/wasm-go/extensions/ai-quota/main.go
+++ b/plugins/wasm-go/extensions/ai-quota/main.go
@@ -21,7 +21,9 @@ import (
 )
 
 const (
-	pluginName = "ai-quota"
+	pluginName           = "ai-quota"
+	ctxKeyQuotaDeducted  = "quotaDeducted"
+	streamingContentType = "text/event-stream"
 )
 
 type ChatMode string
@@ -49,7 +51,9 @@ func init() {
 		wrapper.ParseConfig(parseConfig),
 		wrapper.ProcessRequestHeaders(onHttpRequestHeaders),
 		wrapper.ProcessRequestBody(onHttpRequestBody),
+		wrapper.ProcessResponseHeaders(onHttpResponseHeaders),
 		wrapper.ProcessStreamingResponseBody(onHttpStreamingResponseBody),
+		wrapper.ProcessResponseBody(onHttpResponseBody),
 	)
 }
 
@@ -236,13 +240,38 @@ func onHttpRequestBody(ctx wrapper.HttpContext, config QuotaConfig, body []byte)
 	return types.ActionContinue
 }
 
-func onHttpStreamingResponseBody(ctx wrapper.HttpContext, config QuotaConfig, data []byte, endOfStream bool) []byte {
+func onHttpResponseHeaders(ctx wrapper.HttpContext, _ QuotaConfig) types.Action {
 	chatMode, ok := ctx.GetContext("chatMode").(ChatMode)
-	if !ok {
-		return data
+	if !ok || chatMode != ChatModeCompletion {
+		ctx.DontReadResponseBody()
+		return types.ActionContinue
 	}
-	if chatMode == ChatModeNone || chatMode == ChatModeAdmin {
-		return data
+
+	contentType, _ := proxywasm.GetHttpResponseHeader("content-type")
+	if !strings.Contains(strings.ToLower(contentType), streamingContentType) {
+		ctx.BufferResponseBody()
+	}
+	return types.ActionContinue
+}
+
+func onHttpStreamingResponseBody(ctx wrapper.HttpContext, config QuotaConfig, data []byte, endOfStream bool) []byte {
+	processResponseUsage(ctx, config, data, endOfStream)
+	return data
+}
+
+func onHttpResponseBody(ctx wrapper.HttpContext, config QuotaConfig, data []byte) types.Action {
+	processResponseUsage(ctx, config, data, true)
+	return types.ActionContinue
+}
+
+func processResponseUsage(ctx wrapper.HttpContext, config QuotaConfig, data []byte, endOfStream bool) {
+	if deducted, _ := ctx.GetContext(ctxKeyQuotaDeducted).(bool); deducted {
+		return
+	}
+
+	chatMode, ok := ctx.GetContext("chatMode").(ChatMode)
+	if !ok || chatMode != ChatModeCompletion {
+		return
 	}
 	if usage := tokenusage.GetTokenUsage(ctx, data); usage.TotalToken > 0 {
 		ctx.SetContext(tokenusage.CtxKeyInputToken, usage.InputToken)
@@ -251,29 +280,26 @@ func onHttpStreamingResponseBody(ctx wrapper.HttpContext, config QuotaConfig, da
 
 	// chat completion mode
 	if !endOfStream {
-		return data
+		return
 	}
 
-	if ctx.GetContext(tokenusage.CtxKeyInputToken) == nil || ctx.GetContext(tokenusage.CtxKeyOutputToken) == nil || ctx.GetContext("consumer") == nil {
-		return data
+	inputToken, inputTokenOK := ctx.GetContext(tokenusage.CtxKeyInputToken).(int64)
+	outputToken, outputTokenOK := ctx.GetContext(tokenusage.CtxKeyOutputToken).(int64)
+	consumer, consumerOK := ctx.GetContext("consumer").(string)
+	if !inputTokenOK || !outputTokenOK || !consumerOK || consumer == "" {
+		return
 	}
 
-	inputToken, ok := ctx.GetContext(tokenusage.CtxKeyInputToken).(int64)
-	if !ok {
-		return data
-	}
-	outputToken, ok := ctx.GetContext(tokenusage.CtxKeyOutputToken).(int64)
-	if !ok {
-		return data
-	}
-	consumer, ok := ctx.GetContext("consumer").(string)
-	if !ok {
-		return data
-	}
 	totalToken := int(inputToken + outputToken)
 	log.Debugf("update consumer:%s, totalToken:%d", consumer, totalToken)
-	config.redisClient.DecrBy(config.RedisKeyPrefix+consumer, totalToken, nil)
-	return data
+
+	// Mark the request before dispatching so repeated end-of-stream callbacks cannot
+	// issue duplicate decrements. A synchronous dispatch failure is safe to retry.
+	ctx.SetContext(ctxKeyQuotaDeducted, true)
+	if err := config.redisClient.DecrBy(config.RedisKeyPrefix+consumer, totalToken, nil); err != nil {
+		ctx.SetContext(ctxKeyQuotaDeducted, false)
+		log.Errorf("failed to update consumer:%s quota: %v", consumer, err)
+	}
 }
 
 func deniedNoKeyAuthData() types.Action {

--- a/plugins/wasm-go/extensions/ai-quota/main_test.go
+++ b/plugins/wasm-go/extensions/ai-quota/main_test.go
@@ -16,11 +16,13 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 	"testing"
 
 	"github.com/higress-group/proxy-wasm-go-sdk/proxywasm/types"
 	"github.com/higress-group/wasm-go/pkg/test"
+	"github.com/higress-group/wasm-go/pkg/wrapper"
 	"github.com/stretchr/testify/require"
 )
 
@@ -65,6 +67,104 @@ var defaultPathSuffixesConfig = func() json.RawMessage {
 	})
 	return data
 }()
+
+type redisDecrement struct {
+	key   string
+	delta int
+}
+
+type recordingRedisClient struct {
+	wrapper.RedisClient
+	decrements []redisDecrement
+	err        error
+}
+
+func (c *recordingRedisClient) DecrBy(key string, delta int, _ wrapper.RedisResponseCallback) error {
+	c.decrements = append(c.decrements, redisDecrement{key: key, delta: delta})
+	return c.err
+}
+
+type recordingHTTPContext struct {
+	wrapper.HttpContext
+	context        map[string]interface{}
+	userAttributes map[string]interface{}
+	bufferedBody   bool
+	skippedBody    bool
+}
+
+func newRecordingHTTPContext(chatMode ChatMode, consumer string) *recordingHTTPContext {
+	ctx := &recordingHTTPContext{
+		context:        map[string]interface{}{"chatMode": chatMode},
+		userAttributes: map[string]interface{}{},
+	}
+	if consumer != "" {
+		ctx.context["consumer"] = consumer
+	}
+	return ctx
+}
+
+func (c *recordingHTTPContext) SetContext(key string, value interface{}) {
+	c.context[key] = value
+}
+
+func (c *recordingHTTPContext) GetContext(key string) interface{} {
+	return c.context[key]
+}
+
+func (c *recordingHTTPContext) SetUserAttribute(key string, value interface{}) {
+	c.userAttributes[key] = value
+}
+
+func (c *recordingHTTPContext) GetUserAttribute(key string) interface{} {
+	return c.userAttributes[key]
+}
+
+func (c *recordingHTTPContext) GetBoolContext(key string, defaultValue bool) bool {
+	value, ok := c.context[key].(bool)
+	if !ok {
+		return defaultValue
+	}
+	return value
+}
+
+func (c *recordingHTTPContext) GetStringContext(key, defaultValue string) string {
+	value, ok := c.context[key].(string)
+	if !ok {
+		return defaultValue
+	}
+	return value
+}
+
+func (c *recordingHTTPContext) GetByteSliceContext(key string, defaultValue []byte) []byte {
+	value, ok := c.context[key].([]byte)
+	if !ok {
+		return defaultValue
+	}
+	return value
+}
+
+func (c *recordingHTTPContext) BufferResponseBody() {
+	c.bufferedBody = true
+}
+
+func (c *recordingHTTPContext) DontReadResponseBody() {
+	c.skippedBody = true
+}
+
+func allowCompletionRequest(t *testing.T, host test.TestHost) {
+	t.Helper()
+
+	action := host.CallOnHttpRequestHeaders([][2]string{
+		{":authority", "example.com"},
+		{":path", "/v1/chat/completions"},
+		{":method", "POST"},
+		{"x-mse-consumer", "consumer1"},
+	})
+	require.Equal(t, types.HeaderStopAllIterationAndWatermark, action)
+
+	host.CallOnRedisCall(0, test.CreateRedisResp(1000))
+	require.Equal(t, types.ActionContinue, host.GetHttpStreamAction())
+}
 
 func TestParseConfig(t *testing.T) {
 	test.RunGoTest(t, func(t *testing.T) {
@@ -235,70 +335,178 @@ func TestOnHttpRequestBody(t *testing.T) {
 	})
 }
 
-func TestOnHttpStreamingResponseBody(t *testing.T) {
+func TestOnHttpResponseBody(t *testing.T) {
 	test.RunTest(t, func(t *testing.T) {
-		// 测试聊天完成模式的流式响应体处理
-		t.Run("chat completion mode", func(t *testing.T) {
+		t.Run("chunked non-streaming response is buffered before decrement", func(t *testing.T) {
 			host, status := test.NewTestHost(basicConfig)
 			defer host.Reset()
 			require.Equal(t, types.OnPluginStartStatusOK, status)
 
-			// 先设置请求头
-			host.CallOnHttpRequestHeaders([][2]string{
-				{":authority", "example.com"},
-				{":path", "/v1/chat/completions"},
-				{":method", "POST"},
-				{"x-mse-consumer", "consumer1"},
+			allowCompletionRequest(t, host)
+			action := host.CallOnHttpResponseHeaders([][2]string{
+				{":status", "200"},
+				{"content-type", "application/json"},
 			})
-
-			// 测试流式响应体处理
-			data := []byte(`{"choices": [{"delta": {"content": "Hello"}}]}`)
-			action := host.CallOnHttpStreamingResponseBody(data, false)
-
 			require.Equal(t, types.ActionContinue, action)
-			result := host.GetResponseBody()
-			// 非结束流应该返回原始数据
-			require.Equal(t, data, result)
 
-			// 测试结束流
-			action = host.CallOnHttpStreamingResponseBody(data, true)
-
+			firstChunk := []byte(`{"model":"gpt-4","choices":[],"usage":{"prompt_tokens":10,`)
+			lastChunk := []byte(`"completion_tokens":15,"total_tokens":25}}`)
+			action = host.CallOnHttpStreamingResponseBody(firstChunk, false)
+			require.Equal(t, types.ActionPause, action)
+			action = host.CallOnHttpStreamingResponseBody(lastChunk, true)
 			require.Equal(t, types.ActionContinue, action)
-			result = host.GetResponseBody()
-			// 结束流应该返回原始数据
-			require.Equal(t, data, result)
+			expectedBody := append(append([]byte{}, firstChunk...), lastChunk...)
+			require.Equal(t, expectedBody, host.GetResponseBody())
 
-			// 模拟Redis调用响应（减少配额）
-			resp := test.CreateRedisRespArray([]interface{}{30})
-			host.CallOnRedisCall(0, resp)
+			// Consume the pending response from the quota-decrement Redis callout.
+			host.CallOnRedisCall(0, test.CreateRedisResp(975))
 
 			host.CompleteHttp()
 		})
+	})
+}
 
-		// 测试非聊天完成模式的流式响应体处理
-		t.Run("non-chat completion mode", func(t *testing.T) {
+func TestOnHttpStreamingResponseBody(t *testing.T) {
+	test.RunTest(t, func(t *testing.T) {
+		t.Run("streaming response decrements only after end of stream", func(t *testing.T) {
 			host, status := test.NewTestHost(basicConfig)
 			defer host.Reset()
 			require.Equal(t, types.OnPluginStartStatusOK, status)
 
-			// 先设置请求头
-			host.CallOnHttpRequestHeaders([][2]string{
+			allowCompletionRequest(t, host)
+			action := host.CallOnHttpResponseHeaders([][2]string{
+				{":status", "200"},
+				{"content-type", "Text/Event-Stream; charset=utf-8"},
+			})
+			require.Equal(t, types.ActionContinue, action)
+
+			contentChunk := []byte("data: {\"model\":\"gpt-4\",\"choices\":[{\"delta\":{\"content\":\"hello\"}}]}\n\n")
+			usageChunk := []byte("data: {\"model\":\"gpt-4\",\"choices\":[],\"usage\":{\"prompt_tokens\":10,\"completion_tokens\":15,\"total_tokens\":25}}\n\n")
+			doneChunk := []byte("data: [DONE]\n\n")
+
+			action = host.CallOnHttpStreamingResponseBody(contentChunk, false)
+			require.Equal(t, types.ActionContinue, action)
+			require.Equal(t, contentChunk, host.GetResponseBody())
+			action = host.CallOnHttpStreamingResponseBody(usageChunk, false)
+			require.Equal(t, types.ActionContinue, action)
+			require.Equal(t, usageChunk, host.GetResponseBody())
+			action = host.CallOnHttpStreamingResponseBody(doneChunk, true)
+			require.Equal(t, types.ActionContinue, action)
+			require.Equal(t, doneChunk, host.GetResponseBody())
+
+			host.CallOnRedisCall(0, test.CreateRedisResp(975))
+			host.CompleteHttp()
+		})
+
+		t.Run("non-completion response body remains unchanged", func(t *testing.T) {
+			host, status := test.NewTestHost(basicConfig)
+			defer host.Reset()
+			require.Equal(t, types.OnPluginStartStatusOK, status)
+
+			action := host.CallOnHttpRequestHeaders([][2]string{
 				{":authority", "example.com"},
 				{":path", "/other/path"},
 				{":method", "GET"},
 				{"x-mse-consumer", "consumer1"},
 			})
-
-			// 测试流式响应体处理
-			data := []byte("response data")
-			action := host.CallOnHttpStreamingResponseBody(data, false)
-
-			// 非聊天完成模式应该返回原始数据
 			require.Equal(t, types.ActionContinue, action)
-			result := host.GetResponseBody()
-			require.Equal(t, data, result)
+			action = host.CallOnHttpResponseHeaders([][2]string{
+				{":status", "200"},
+				{"content-type", "application/json"},
+			})
+			require.Equal(t, types.ActionContinue, action)
+
+			data := []byte("response data")
+			action = host.CallOnHttpStreamingResponseBody(data, false)
+			require.Equal(t, types.ActionContinue, action)
+			require.Equal(t, data, host.GetResponseBody())
+			host.CompleteHttp()
 		})
 	})
+}
+
+func TestProcessResponseUsage(t *testing.T) {
+	test.RunGoTest(t, func(t *testing.T) {
+		host, status := test.NewTestHost(basicConfig)
+		defer host.Reset()
+		require.Equal(t, types.OnPluginStartStatusOK, status)
+
+		body := []byte(`{"model":"gpt-4","choices":[],"usage":{"prompt_tokens":10,"completion_tokens":15,"total_tokens":25}}`)
+
+		t.Run("dispatches one decrement for repeated callbacks", func(t *testing.T) {
+			redisClient := &recordingRedisClient{}
+			ctx := newRecordingHTTPContext(ChatModeCompletion, "consumer1")
+			config := QuotaConfig{RedisKeyPrefix: "chat_quota:", redisClient: redisClient}
+
+			processResponseUsage(ctx, config, body, true)
+			processResponseUsage(ctx, config, body, true)
+
+			require.Equal(t, []redisDecrement{{key: "chat_quota:consumer1", delta: 25}}, redisClient.decrements)
+			require.Equal(t, true, ctx.GetContext(ctxKeyQuotaDeducted))
+		})
+
+		t.Run("streaming usage waits for end of stream", func(t *testing.T) {
+			redisClient := &recordingRedisClient{}
+			ctx := newRecordingHTTPContext(ChatModeCompletion, "consumer1")
+			config := QuotaConfig{RedisKeyPrefix: "chat_quota:", redisClient: redisClient}
+
+			processResponseUsage(ctx, config, body, false)
+			require.Empty(t, redisClient.decrements)
+			processResponseUsage(ctx, config, []byte("data: [DONE]\n\n"), true)
+
+			require.Equal(t, []redisDecrement{{key: "chat_quota:consumer1", delta: 25}}, redisClient.decrements)
+		})
+
+		t.Run("synchronous dispatch failure can retry", func(t *testing.T) {
+			redisClient := &recordingRedisClient{err: errors.New("dispatch failed")}
+			ctx := newRecordingHTTPContext(ChatModeCompletion, "consumer1")
+			config := QuotaConfig{RedisKeyPrefix: "chat_quota:", redisClient: redisClient}
+
+			processResponseUsage(ctx, config, body, true)
+			require.Equal(t, []redisDecrement{{key: "chat_quota:consumer1", delta: 25}}, redisClient.decrements)
+			require.Equal(t, false, ctx.GetContext(ctxKeyQuotaDeducted))
+
+			redisClient.err = nil
+			processResponseUsage(ctx, config, body, true)
+			require.Equal(t, []redisDecrement{
+				{key: "chat_quota:consumer1", delta: 25},
+				{key: "chat_quota:consumer1", delta: 25},
+			}, redisClient.decrements)
+			require.Equal(t, true, ctx.GetContext(ctxKeyQuotaDeducted))
+		})
+
+		t.Run("does not decrement without usage", func(t *testing.T) {
+			redisClient := &recordingRedisClient{}
+			ctx := newRecordingHTTPContext(ChatModeCompletion, "consumer1")
+			config := QuotaConfig{RedisKeyPrefix: "chat_quota:", redisClient: redisClient}
+
+			processResponseUsage(ctx, config, []byte(`{"choices":[]}`), true)
+
+			require.Empty(t, redisClient.decrements)
+			require.Nil(t, ctx.GetContext(ctxKeyQuotaDeducted))
+		})
+
+		t.Run("does not decrement without consumer", func(t *testing.T) {
+			redisClient := &recordingRedisClient{}
+			ctx := newRecordingHTTPContext(ChatModeCompletion, "")
+			config := QuotaConfig{RedisKeyPrefix: "chat_quota:", redisClient: redisClient}
+
+			processResponseUsage(ctx, config, body, true)
+
+			require.Empty(t, redisClient.decrements)
+			require.Nil(t, ctx.GetContext(ctxKeyQuotaDeducted))
+		})
+	})
+}
+
+func TestOnHttpResponseHeadersSkipsNonCompletionBody(t *testing.T) {
+	ctx := newRecordingHTTPContext(ChatModeNone, "consumer1")
+
+	action := onHttpResponseHeaders(ctx, QuotaConfig{})
+
+	require.Equal(t, types.ActionContinue, action)
+	require.True(t, ctx.skippedBody)
+	require.False(t, ctx.bufferedBody)
 }
 
 func TestGetOperationMode(t *testing.T) {


### PR DESCRIPTION
## I. Summary

Fix AI quota under-accounting for non-streaming completion responses whose JSON
usage object is split across proxy body callbacks.

- Detect response content type at headers.
- Keep `text/event-stream` responses on the streaming path.
- Buffer non-SSE completion responses and parse the complete body once.
- Share one quota-update path between streaming and non-streaming callbacks.
- Prevent duplicate decrements from repeated end-of-stream callbacks while
  allowing retry after a synchronous Redis dispatch failure.
- Add Go and Wasm-host regression tests for both response modes and guard paths.

No configuration or migration change is required. Non-completion responses are
still skipped, and SSE response delivery remains streaming.

## II. Related issue

Fixes #3743.

## III. Change type

- [x] Bug fix
- [ ] Feature or enhancement
- [ ] Documentation or configuration only
- [x] Refactoring, tests, or maintenance

## IV. Agent participation and issue-spec gate

See the [agent-assisted contribution policy](https://github.com/higress-group/higress/blob/main/docs/developers/agent-assisted-contributions.md).
Materially agent-assisted PRs that miss the gate receive low review priority,
and timely maintainer review is not guaranteed; this author declaration is the
deterministic prioritization signal.
Choose exactly one participation declaration:

- [ ] **No agent participation:** This PR is human-only.
- [ ] **Trivial agent-use exception:** Agent use was limited to spelling,
      punctuation, whitespace, or formatting with no substantive choice or
      behavioral effect; the explanation is below.
- [ ] **Verified maintainer/administrator exception:** Material agent
      participation occurred, and authenticated `gh` verification confirmed
      a `role_name` of `maintain` or `admin` on `higress-group/higress`, and the
      verified login matches this PR's GitHub author; record the required
      evidence and rationale below.
- [x] **Material agent participation:** An AI or coding agent materially
      participated in analysis, design, implementation, testing, or PR
      preparation.

For material participation that does not use the verified maintainer/administrator
exception, check each timed obligation:

- [ ] **Before implementation began:** A Higress maintainer had approved the
      Proposal and Design Issues, and authorized implementation TASKs linked the
      work to the applicable SPECs.
- [ ] **Before verification began:** The Design contained a concrete
      Verification Plan.
- [ ] **Before requesting maintainer review or acceptance:** Applicable
      implementation and verification TASKs were `done` with exact commands,
      results, evidence links, and hashes.

Then choose exactly one overall gate status:

- [ ] Complete: all three timed obligations above were satisfied.
- [x] Noncompliant: one or more obligations were not satisfied; explain below.
- [ ] Verified exception: material agent participation used the
      verified-maintainer/administrator exception; provide the required evidence
      and rationale below.
- [ ] N/A because the PR is human-only or qualifies for the trivial exception.

**Gate-status explanation (or N/A):** This PR's implementation and initial
verification began on 2026-07-30. The current issue-spec gate was added later,
on 2026-08-08, so its timed pre-implementation and pre-verification obligations
were not met and cannot be represented as retroactively satisfied. The PR is
therefore declared noncompliant. Post-hoc reproducible verification evidence is
provided below for technical review, without claiming gate compliance.

**Trivial-exception explanation (or N/A):** N/A; agent participation was
material.

**Verified maintainer/administrator exception evidence (or N/A):** N/A; no
exception is claimed.

- This PR's number or URL: N/A
- Authenticated `gh` login: N/A
- Canonical-repository `role_name`: N/A
- Actual PR author from `gh pr view`: N/A
- Login/author match: N/A
- Token override attestation (`GH_TOKEN` and `GITHUB_TOKEN` were unset for every verification command; required: `yes`): N/A
- Bypass rationale: N/A
- Maintainer live validation (review URL or N/A until performed): N/A

**Approved Proposal Issue URL (or N/A with explanation):** N/A; no approved
Proposal existed before implementation. #3743 is the underlying bug report.

**Approved Design Issue URL (or N/A with explanation):** N/A; no approved Design
Issue existed before implementation.

**Maintainer approval link(s) (or N/A with explanation):** N/A; no gate approval
is claimed.

**Authorized implementation TASK link(s) (or N/A with explanation):** N/A; no
policy TASK existed before implementation.

**Verification Plan and verification TASK/evidence link(s) (or N/A with explanation):**
The timed pre-verification obligation was not satisfied. Post-hoc plan, harness,
raw logs/results, validation report, and integrity manifest are published in the
[immutable R3 evidence bundle](https://github.com/ai-yang/higress/tree/24e681864ba40d9b4d9012c15b4c0e19b9243590/review-evidence/r3/pr-4232).

## V. Testing and verification

**Test and deterministic rerun commands (or N/A with explanation):**

```text
# With the source roots, disposable caches, artifact directory, and pinned
# GO_IMAGE/GOPROXY exported as documented in the evidence README:
./review-evidence/r3/pr-4232/harness/go-verify.sh

# With BASELINE_WASM, FIXED_WASM, HIGRESS_GATEWAY_IMAGE, and REDIS_IMAGE set:
./review-evidence/r3/pr-4232/harness/run-runtime.sh

cd review-evidence/r3/pr-4232
./harness/verify-evidence.py
sha256sum --check SHA256SUMS
```

Recorded checks: `go test -mod=readonly ./...`; race tests with `-count=20`;
`go vet`; WASI c-shared build; uncached Wasm-host tests; fixed coverage; and
three identical real Envoy/Redis rounds per variant. All passed.

**Environment and configuration (or N/A with explanation):** Linux x86_64;
Docker/Compose 26.0.0/2.25.0; Go 1.24.4; Envoy 1.36.4 from the pinned Higress
gateway image; Redis 7.4. Envoy uses one worker. The upstream sends the same
120-byte `application/json` body in two 60-byte chunks separated by 350 ms.
Redis begins at quota 100 for every independent round.

**Exact tested revision, version, image tag/digest, manifests, and values (or N/A with explanation):**
Baseline/main `409b3ed2644a977776391eae78ed6cb11e99d3d3`; fixed
`d03df0204427d5b77d3f2e54e54ced8754d3db80` whose parent is that exact baseline.
Pinned image references, IDs, full Envoy config, Compose fixture, values, build
flags, and tool versions are in
[`environment.json`](https://github.com/ai-yang/higress/blob/24e681864ba40d9b4d9012c15b4c0e19b9243590/review-evidence/r3/pr-4232/environment.json).

**Baseline reproduction evidence for bug fixes (or N/A with explanation):**
With identical inputs, baseline returned 3/3 exact 200 responses but Redis stayed
`100 -> 100` in all three rounds, reproducing complete quota under-deduction.
See the [baseline results and logs](https://github.com/ai-yang/higress/tree/24e681864ba40d9b4d9012c15b4c0e19b9243590/review-evidence/r3/pr-4232/results/baseline).

**Fixed-version verification evidence for bug fixes (or N/A with explanation):**
Fixed returned 3/3 exact 200 responses and Redis changed `100 -> 82` in all
three rounds. The verifier confirms three completed 2xx requests and exactly
three 18-token quota updates. See
[`results/summary.json`](https://github.com/ai-yang/higress/blob/24e681864ba40d9b4d9012c15b4c0e19b9243590/review-evidence/r3/pr-4232/results/summary.json)
and the [validation report](https://github.com/ai-yang/higress/blob/24e681864ba40d9b4d9012c15b4c0e19b9243590/review-evidence/r3/pr-4232/validation-report.md).

**Wasm source revision and SHA-256 (or N/A with explanation):** Baseline source
`409b3ed2644a977776391eae78ed6cb11e99d3d3`, artifact
`97697b83b41045406ca9c994361306efb4a3e3e5f13180477d842f02332f3742`;
fixed source `d03df0204427d5b77d3f2e54e54ced8754d3db80`, artifact
`fe1f284383d14e2d5441517d6d8127f5d4d8b3e4aefde038304348bdb75db6f0`.
Artifacts were built with the same pinned image and
`GOOS=wasip1 GOARCH=wasm -trimpath -buildmode=c-shared -buildvcs=false`.

## VI. Special notes for reviewers

- Review focus: response-mode detection, buffering only non-SSE completion
  bodies, and the request-scoped deduplication marker.
- Buffering cost is proportional to a non-streaming completion response body;
  SSE remains unbuffered and non-completion bodies are not read by this plugin.
- As before, `DecrBy` has no response callback here, so asynchronous Redis-side
  execution failures are not observed or retried. This PR only restores retry
  after synchronous dispatch failure and does not broaden that behavior.
- Rebase equivalence is recorded by `range-diff` (`c7f41a0d = d03df020`), and
  the fixed commit remains DCO signed.

## VII. AI coding disclosure

**Tool(s) used (or N/A):** OpenAI Codex.

### Prompts or instructions

Analyze issue #3743 against the ai-quota plugin; implement non-streaming quota
deduction without regressing SSE; add direct and Wasm-host tests; isolate the
change; rebase it onto current `main`; inspect project feedback; and produce a
pinned, repeatable baseline/fixed Envoy+Redis validation bundle with sanitized
logs, machine results, and SHA256 checksums.

### AI-assisted work summary

The agent traced the bug to fragment-wise parsing through the streaming-only
response hook, helped implement response-mode-aware handling and a common
deduplicated update path, expanded regression tests, rebased the single commit,
and built the public R3 evidence harness. Human review retained responsibility
for the change and its publication. The evidence explicitly records the
noncompliant gate status because the work predates the current timed policy.
