### PR TITLE
bugfix: replace FixedQueue with time-based SlidingWindow in ai-load-balancer endpoint_metrics

### DIFF
--- a/plugins/wasm-go/extensions/ai-load-balancer/endpoint_metrics/lb_policy.go
+++ b/plugins/wasm-go/extensions/ai-load-balancer/endpoint_metrics/lb_policy.go
@@ -13,13 +13,13 @@ import (
 )
 
 const (
-	FixedQueueSize = 100
+	FixedQueueSize = 100 // default max entries in the sliding window
 )
 
 type MetricsEndpointLoadBalancer struct {
 	metricPolicy     string
 	targetMetric     string
-	endpointRequests *utils.FixedQueue[string]
+	endpointRequests *utils.SlidingWindow[string]
 	maxRate          float64
 }
 
@@ -38,7 +38,21 @@ func NewMetricsEndpointLoadBalancer(json gjson.Result) (MetricsEndpointLoadBalan
 	} else {
 		lb.maxRate = 1.0
 	}
-	lb.endpointRequests = utils.NewFixedQueue[string](FixedQueueSize)
+	windowSize := FixedQueueSize
+	if json.Get("window_size").Exists() {
+		windowSize = int(json.Get("window_size").Int())
+		if windowSize <= 0 {
+			windowSize = FixedQueueSize
+		}
+	}
+	windowSeconds := 60
+	if json.Get("window_seconds").Exists() {
+		windowSeconds = int(json.Get("window_seconds").Int())
+		if windowSeconds <= 0 {
+			windowSeconds = 60
+		}
+	}
+	lb.endpointRequests = utils.NewSlidingWindow[string](windowSize, windowSeconds)
 	return lb, nil
 }
 
@@ -86,19 +100,17 @@ func (lb MetricsEndpointLoadBalancer) HandleHttpRequestBody(ctx wrapper.HttpCont
 			otherHosts = append(otherHosts, k)
 		}
 	}
-	if lb.endpointRequests.Size() != 0 {
-		count := 0.0
-		lb.endpointRequests.ForEach(func(i int, item string) {
-			if item == finalAddress {
-				count += 1
-			}
+	windowSize := lb.endpointRequests.Size()
+	if windowSize != 0 {
+		count := lb.endpointRequests.CountInWindow(func(item string) bool {
+			return item == finalAddress
 		})
-		currentRate = count / float64(lb.endpointRequests.Size())
+		currentRate = float64(count) / float64(windowSize)
 	}
 	if currentRate > lb.maxRate && len(otherHosts) > 0 {
 		finalAddress = otherHosts[rand.Intn(len(otherHosts))]
 	}
-	lb.endpointRequests.Enqueue(finalAddress)
+	lb.endpointRequests.Push(finalAddress)
 	log.Debugf("pod %s is selected", finalAddress)
 	proxywasm.SetUpstreamOverrideHost([]byte(finalAddress))
 	return types.ActionContinue

--- a/plugins/wasm-go/extensions/ai-load-balancer/utils/sliding_window.go
+++ b/plugins/wasm-go/extensions/ai-load-balancer/utils/sliding_window.go
@@ -1,0 +1,101 @@
+package utils
+
+import (
+	"time"
+)
+
+// TimedEntry holds a value with its insertion timestamp.
+type TimedEntry[T any] struct {
+	Value     T
+	Timestamp int64 // UnixMilli
+}
+
+// SlidingWindow implements a time-based sliding window.
+// Unlike FixedQueue which keeps the last N items regardless of time,
+// SlidingWindow purges entries older than the configured window duration,
+// providing accurate rate calculation for bursty or low-QPS traffic.
+type SlidingWindow[T any] struct {
+	entries []TimedEntry[T]
+	maxSize int   // hard cap to prevent unbounded memory growth
+	window  int64 // window duration in milliseconds
+}
+
+// NewSlidingWindow creates a SlidingWindow with the given size cap and
+// window duration (in seconds).
+func NewSlidingWindow[T any](maxSize int, windowSeconds int) *SlidingWindow[T] {
+	if maxSize <= 0 {
+		maxSize = 100
+	}
+	if windowSeconds <= 0 {
+		windowSeconds = 60
+	}
+	return &SlidingWindow[T]{
+		entries: make([]TimedEntry[T], 0, maxSize),
+		maxSize: maxSize,
+		window:  int64(windowSeconds) * 1000,
+	}
+}
+
+// Push adds a value with the current timestamp, then purges expired entries.
+func (w *SlidingWindow[T]) Push(value T) {
+	now := time.Now().UnixMilli()
+	w.entries = append(w.entries, TimedEntry[T]{Value: value, Timestamp: now})
+	w.purge(now)
+	// Enforce hard cap: if still over maxSize after purge (high QPS burst),
+	// remove oldest entries.
+	if len(w.entries) > w.maxSize {
+		excess := len(w.entries) - w.maxSize
+		w.entries = w.entries[excess:]
+	}
+}
+
+// purge removes entries older than the window duration.
+func (w *SlidingWindow[T]) purge(now int64) {
+	cutoff := now - w.window
+	idx := 0
+	for idx < len(w.entries) && w.entries[idx].Timestamp < cutoff {
+		idx++
+	}
+	if idx > 0 {
+		w.entries = w.entries[idx:]
+	}
+}
+
+// CountInWindow returns how many entries in the current window match the predicate.
+func (w *SlidingWindow[T]) CountInWindow(match func(item T) bool) int {
+	now := time.Now().UnixMilli()
+	w.purge(now)
+	count := 0
+	for _, e := range w.entries {
+		if match(e.Value) {
+			count++
+		}
+	}
+	return count
+}
+
+// Size returns the number of entries currently in the window.
+func (w *SlidingWindow[T]) Size() int {
+	now := time.Now().UnixMilli()
+	w.purge(now)
+	return len(w.entries)
+}
+
+// Clear removes all entries.
+func (w *SlidingWindow[T]) Clear() {
+	w.entries = w.entries[:0]
+}
+
+// IsEmpty returns true if the window has no entries.
+func (w *SlidingWindow[T]) IsEmpty() bool {
+	return w.Size() == 0
+}
+
+// ForEach iterates over all in-window entries.
+func (w *SlidingWindow[T]) ForEach(fn func(index int, item T)) {
+	now := time.Now().UnixMilli()
+	w.purge(now)
+	for i, e := range w.entries {
+		fn(i, e.Value)
+	}
+}

--- a/plugins/wasm-go/extensions/ai-load-balancer/utils/sliding_window_test.go
+++ b/plugins/wasm-go/extensions/ai-load-balancer/utils/sliding_window_test.go
@@ -1,0 +1,123 @@
+package utils
+
+import (
+	"testing"
+	"time"
+)
+
+func TestSlidingWindow_PushAndSize(t *testing.T) {
+	w := NewSlidingWindow[string](10, 60)
+	if w.Size() != 0 {
+		t.Fatalf("expected size 0, got %d", w.Size())
+	}
+	w.Push("a")
+	w.Push("b")
+	w.Push("a")
+	if w.Size() != 3 {
+		t.Fatalf("expected size 3, got %d", w.Size())
+	}
+}
+
+func TestSlidingWindow_CountInWindow(t *testing.T) {
+	w := NewSlidingWindow[string](100, 60)
+	w.Push("pod-a")
+	w.Push("pod-b")
+	w.Push("pod-a")
+	w.Push("pod-a")
+	w.Push("pod-b")
+
+	countA := w.CountInWindow(func(item string) bool { return item == "pod-a" })
+	if countA != 3 {
+		t.Fatalf("expected 3 for pod-a, got %d", countA)
+	}
+	countB := w.CountInWindow(func(item string) bool { return item == "pod-b" })
+	if countB != 2 {
+		t.Fatalf("expected 2 for pod-b, got %d", countB)
+	}
+}
+
+func TestSlidingWindow_PurgeExpired(t *testing.T) {
+	w := NewSlidingWindow[string](100, 1) // 1 second window
+	w.Push("old-entry")
+	// Wait for the entry to expire
+	time.Sleep(1100 * time.Millisecond)
+	w.Push("new-entry")
+	size := w.Size()
+	if size != 1 {
+		t.Fatalf("expected size 1 after purge, got %d", size)
+	}
+	countOld := w.CountInWindow(func(item string) bool { return item == "old-entry" })
+	if countOld != 0 {
+		t.Fatalf("expected 0 for old-entry after purge, got %d", countOld)
+	}
+	countNew := w.CountInWindow(func(item string) bool { return item == "new-entry" })
+	if countNew != 1 {
+		t.Fatalf("expected 1 for new-entry, got %d", countNew)
+	}
+}
+
+func TestSlidingWindow_MaxSizeCap(t *testing.T) {
+	w := NewSlidingWindow[int](3, 60)
+	w.Push(1)
+	w.Push(2)
+	w.Push(3)
+	w.Push(4) // should evict 1
+	if w.Size() != 3 {
+		t.Fatalf("expected size 3 after cap, got %d", w.Size())
+	}
+	// Verify oldest entry (1) is gone
+	count1 := w.CountInWindow(func(item int) bool { return item == 1 })
+	if count1 != 0 {
+		t.Fatalf("expected 0 for evicted entry 1, got %d", count1)
+	}
+	count4 := w.CountInWindow(func(item int) bool { return item == 4 })
+	if count4 != 1 {
+		t.Fatalf("expected 1 for entry 4, got %d", count4)
+	}
+}
+
+func TestSlidingWindow_IsEmpty(t *testing.T) {
+	w := NewSlidingWindow[string](10, 60)
+	if !w.IsEmpty() {
+		t.Fatal("expected empty window")
+	}
+	w.Push("x")
+	if w.IsEmpty() {
+		t.Fatal("expected non-empty window")
+	}
+}
+
+func TestSlidingWindow_Clear(t *testing.T) {
+	w := NewSlidingWindow[string](10, 60)
+	w.Push("a")
+	w.Push("b")
+	w.Clear()
+	if w.Size() != 0 {
+		t.Fatalf("expected size 0 after clear, got %d", w.Size())
+	}
+}
+
+func TestSlidingWindow_Defaults(t *testing.T) {
+	w := NewSlidingWindow[string](0, 0)
+	w.Push("test")
+	if w.Size() != 1 {
+		t.Fatalf("expected size 1, got %d", w.Size())
+	}
+}
+
+func TestSlidingWindow_ForEach(t *testing.T) {
+	w := NewSlidingWindow[string](10, 60)
+	w.Push("a")
+	w.Push("b")
+	w.Push("c")
+	seen := []string{}
+	w.ForEach(func(_ int, item string) {
+		seen = append(seen, item)
+	})
+	if len(seen) != 3 {
+		t.Fatalf("expected 3 items, got %d", len(seen))
+	}
+	if seen[0] != "a" || seen[1] != "b" || seen[2] != "c" {
+		t.Fatalf("unexpected order: %v", seen)
+	}
+}


### PR DESCRIPTION
## I. What does this PR do

Replaces the `FixedQueue[string]` in the `endpoint_metrics` load balancer with a time-based `SlidingWindow` to fix the rate-limiting degeneration reported in #3407.

### Root Cause

The `endpoint_metrics` strategy used a `FixedQueue[string]` (capacity 100) to track recent request targets for rate limiting. This had two critical problems:

1. **No time awareness**: The queue kept the last 100 requests regardless of when they occurred. Under low QPS, entries from minutes or hours ago inflated the rate calculation, making it meaningless.

2. **Degeneration to random**: When `rate_limit < 1.0`, once the queue filled up, the ratio of any pod's count stayed frozen because old entries couldn't be removed by time. The system oscillated between 'always pick A' and 'random pick', with the net effect being equivalent to random selection — losing the benefit of metrics-based scheduling entirely.

As confirmed by @johnlanni in #3407 (comment): this is a real deficiency that needs a sliding window.

### Fix

**New `SlidingWindow` data structure** (`utils/sliding_window.go`):
- Records `time.Now().UnixMilli()` with each entry (already proven safe in WASM by `cluster_metrics` and `global_least_request` which use the same API)
- Purges entries older than the configured window duration on every `Push` and `CountInWindow` call
- Provides `CountInWindow(match func(T) bool) int` for accurate rate calculation
- Hard `maxSize` cap to prevent unbounded memory under high-QPS bursts

**Modified `endpoint_metrics/lb_policy.go`**:
- `endpointRequests` field changed from `*FixedQueue[string]` to `*SlidingWindow[string]`
- Rate calculation uses `CountInWindow` instead of iterating the full queue
- `Enqueue` replaced with `Push` (which also purges expired entries)

**New config options** (backward compatible):
- `window_size`: max entries in the sliding window (default 100, same as old `FixedQueueSize`)
- `window_seconds`: time window duration in seconds (default 60)

### Impact

- **Backward compatible**: Without new config, defaults to 100 entries / 60 seconds, providing better behavior than the old FixedQueue without requiring config changes
- **No impact on other strategies**: `cluster_metrics` and `global_least_request` have their own rate-limiting logic and are not affected
- **WASM safe**: `time.Now().UnixMilli()` is already used in `cluster_metrics/lb_policy.go` and `global_least_request/lb_policy.go`

## II. Fixes Issue

Partially addresses #3407 (sub-problem 1: sliding window fix for endpoint_metrics)

## III. Test cases

Added 8 unit tests in `utils/sliding_window_test.go`:
- `TestSlidingWindow_PushAndSize`: basic push and size
- `TestSlidingWindow_CountInWindow`: count matching entries
- `TestSlidingWindow_PurgeExpired`: entries expired after window duration are purged
- `TestSlidingWindow_MaxSizeCap`: hard cap enforced under burst
- `TestSlidingWindow_IsEmpty`: empty check
- `TestSlidingWindow_Clear`: clear all entries
- `TestSlidingWindow_Defaults`: zero-value defaults (maxSize=100, window=60s)
- `TestSlidingWindow_ForEach`: iteration order preserved

All 8 tests pass.

## IV. How to verify

- `cd plugins/wasm-go/extensions/ai-load-balancer && go test ./utils/ -v` — 8 tests pass
- `GOOS=wasip1 GOARCH=wasm go build ./...` — compiles successfully

## V. Special notes for reviewers

- @johnlanni confirmed in #3407 that the sliding window is the correct fix
- The `SlidingWindow` is generic (`SlidingWindow[T any]`) and reusable for other strategies if needed
- Sub-problem 3 (cluster_metrics route_not_found documentation) will be addressed in a separate PR
- The `FixedQueue` is NOT removed — it may still be used by other code; only `endpoint_metrics` is migrated

## VI. AI Coding Tool Usage Checklist

- [x] Used AI coding tools: Yes (AI-assisted code analysis and implementation)
- [ ] New standalone plugin scenario: N/A (bug fix in existing code)
- [x] Regular modification scenario: AI analyzed the endpoint_metrics rate-limiting logic and designed the SlidingWindow replacement