### PR TITLE
fix(ai-statistics): frame SSE events before token/error parsing (#4146)

### DIFF
--- a/plugins/wasm-go/extensions/ai-statistics/main.go
+++ b/plugins/wasm-go/extensions/ai-statistics/main.go
@@ -59,6 +59,10 @@ const (
 	RequestPath                = "request_path"
 	SkipProcessing             = "skip_processing"
 
+	// ctxKeySseFramer stores the request-scoped SSE event framer (see
+	// sse_framer.go) in HttpContext for the lifetime of a streaming response.
+	ctxKeySseFramer = "sseFramer"
+
 	// Session ID related
 	SessionID = "session_id"
 
@@ -795,10 +799,24 @@ func onHttpResponseHeaders(ctx wrapper.HttpContext, config AIStatisticsConfig) t
 	return types.ActionContinue
 }
 
-func onHttpStreamingBody(ctx wrapper.HttpContext, config AIStatisticsConfig, data []byte, endOfStream bool) []byte {
+func onHttpStreamingBody(ctx wrapper.HttpContext, config AIStatisticsConfig, data []byte, endOfStream bool) (ret []byte) {
+	// Fail-open boundary (Design #4249): the named return is pre-set to the
+	// original data and all observability logic below runs under a local
+	// recovery boundary, so a panic in the framer or any consumer produces one
+	// error log line and the upstream response bytes still pass through
+	// unchanged. The wrapper-level recover cannot be relied on for this
+	// contract: it recovers at OnHttpResponseBody scope and would skip
+	// proxywasm.ReplaceHttpResponseBody entirely.
+	ret = data
+	defer func() {
+		if r := recover(); r != nil {
+			log.Errorf("ai-statistics: onHttpStreamingBody recovered from observability panic, passing response chunk through unchanged: %v", r)
+		}
+	}()
+
 	// Check if processing should be skipped
 	if ctx.GetBoolContext(SkipProcessing, false) {
-		return data
+		return ret
 	}
 
 	// Buffer stream body for record log & span attributes
@@ -822,18 +840,11 @@ func onHttpStreamingBody(ctx wrapper.HttpContext, config AIStatisticsConfig, dat
 		ctx.SetUserAttribute(ChatID, chatID.String())
 	}
 
-	// Track streaming errors across chunks — SSE failures often appear as
-	// data: {"error":{...}} before data: [DONE], so the last chunk alone is
-	// insufficient for error detection.
-	if !ctx.GetBoolContext("hasStreamError", false) && isErrorResponse(data) {
-		ctx.SetContext("hasStreamError", true)
-	}
-
 	// Get requestStartTime from http context
 	requestStartTime, ok := ctx.GetContext(StatisticsRequestStartTime).(int64)
 	if !ok {
 		log.Error("failed to get requestStartTime from http context")
-		return data
+		return ret
 	}
 
 	// If this is the first chunk, record first token duration metric and span attribute
@@ -843,29 +854,41 @@ func onHttpStreamingBody(ctx wrapper.HttpContext, config AIStatisticsConfig, dat
 		ctx.SetUserAttribute(LLMFirstTokenDuration, firstTokenTime-requestStartTime)
 	}
 
-	// Set information about this request
-	if !config.disableOpenaiUsage {
-		if usage := tokenusage.GetTokenUsage(ctx, data); usage.TotalToken > 0 {
-			// Set span attributes for ARMS.
-			setSpanAttribute(ArmsTotalToken, usage.TotalToken)
-			setSpanAttribute(ArmsModelName, usage.Model)
-			setSpanAttribute(ArmsInputToken, usage.InputToken)
-			setSpanAttribute(ArmsOutputToken, usage.OutputToken)
-
-			// Set token details to context for later use in attributes
-			if len(usage.InputTokenDetails) > 0 {
-				ctx.SetContext(tokenusage.CtxKeyInputTokenDetails, usage.InputTokenDetails)
-			}
-			if len(usage.OutputTokenDetails) > 0 {
-				ctx.SetContext(tokenusage.CtxKeyOutputTokenDetails, usage.OutputTokenDetails)
-			}
-
-			// Write once
-			_ = ctx.WriteUserAttributeToLogWithKey(wrapper.AILogKey)
+	// Frame the raw callback bytes into complete SSE events: one callback is an
+	// arbitrary byte chunk, not a complete event. Token usage and stream-error
+	// detection consume the reassembled complete events, so values split across
+	// host callbacks are recovered exactly as if delivered intact. ChatID
+	// extraction stays on raw data, and tool-call extraction / full-body
+	// JSONPath stay on the end-of-stream accumulated-body path below.
+	framer, ok := ctx.GetContext(ctxKeySseFramer).(*sseFramer)
+	if !ok || framer == nil {
+		framer = &sseFramer{}
+		ctx.SetContext(ctxKeySseFramer, framer)
+	}
+	for _, event := range framer.frameCallback(data) {
+		// Set information about this request
+		if !config.disableOpenaiUsage {
+			processTokenUsageEvent(ctx, event)
+		}
+		// Track streaming errors across events — SSE failures often appear as
+		// data: {"error":{...}} before data: [DONE], so the last chunk alone is
+		// insufficient for error detection. writeMetric consumes this flag once
+		// at end of stream, so one request yields exactly one failure increment
+		// regardless of how many error events matched.
+		if !ctx.GetBoolContext("hasStreamError", false) && isErrorResponse(event) {
+			ctx.SetContext("hasStreamError", true)
 		}
 	}
+
 	// If the end of the stream is reached, record metrics/logs/spans.
 	if endOfStream {
+		// An unterminated tail is not recoverable and is discarded here. If the
+		// incomplete suffix ever overflowed the cap, the framer entered RESYNC
+		// and counted it; summarize the diagnostic once per request.
+		if overflowCount := framer.drain(); overflowCount > 0 {
+			log.Debugf("ai-statistics: sse framer discarded %d oversized incomplete event(s) during this request", overflowCount)
+		}
+
 		responseEndTime := time.Now().UnixMilli()
 		ctx.SetUserAttribute(LLMServiceDuration, responseEndTime-requestStartTime)
 
@@ -890,7 +913,97 @@ func onHttpStreamingBody(ctx wrapper.HttpContext, config AIStatisticsConfig, dat
 		}
 		writeMetric(ctx, config, bodyForMetric)
 	}
-	return data
+	return ret
+}
+
+// getTokenUsage is an indirection over tokenusage.GetTokenUsage so integration
+// tests can inject an observability-side panic and pin the fail-open contract
+// (Design #4249 T-19). It is never reassigned in production.
+var getTokenUsage = tokenusage.GetTokenUsage
+
+// inputTokenDetailsProbePaths and outputTokenDetailsProbePaths mirror exactly
+// the paths tokenusage.ExtractInputTokenDetails / ExtractOutputTokenDetails
+// read (github.com/higress-group/wasm-go/pkg/tokenusage). They are used to
+// detect field PRESENCE in a framed event so the token-details policy can
+// distinguish "absent" (retain the previously recorded map) from "present"
+// (replace the whole map with the event's value). Keep in sync with
+// tokenusage: a details-path addition there must be mirrored here, which fails
+// loudly in review (Design #4249).
+var inputTokenDetailsProbePaths = []string{
+	tokenusage.UsageInputTokensDetailsPathOpenAIChatCompletions,
+	tokenusage.UsageInputTokensDetailsPathOpenAIResponses,
+	tokenusage.UsageInputTokensDetailsPathDoubao,
+	tokenusage.UsageInputTokensDetailsPathGemini,
+	tokenusage.UsageMetadataCachedContentTokenCountPathGemini,
+	tokenusage.UsageMetadataToolUsePromptTokenCountPathGemini,
+	tokenusage.UsageCacheCreationInputTokensPathAnthropicMessages,
+	tokenusage.UsageCacheReadInputTokensPathAnthropicMessages,
+}
+
+var outputTokenDetailsProbePaths = []string{
+	tokenusage.UsageOutputTokensDetailsPathOpenAIChatCompletions,
+	tokenusage.UsageOutputTokensDetailsPathOpenAIResponses,
+	tokenusage.UsageOutputTokensDetailsPathDoubao,
+	tokenusage.UsageOutputTokensDetailsPathGemini,
+	tokenusage.UsageMetadataThoughtsTokenCountPathGemini,
+	tokenusage.UsageGeneratedImagesPathDoubao,
+}
+
+// processTokenUsageEvent records token usage from one complete framed SSE
+// event. Scalar merge semantics stay entirely inside tokenusage.GetTokenUsage
+// (an event's explicit value wins; otherwise the stored attribute is reused;
+// values are never summed across events). The token-details policy of Design
+// #4249 is applied around the call: replace the details map when the event
+// carries the corresponding details field, retain the previously recorded map
+// when it does not, never sum, and keep the context layer and the
+// user-attribute layer synchronized. tokenusage creates fresh details maps per
+// call and writes them to the user-attribute layer unconditionally, so without
+// this policy a usage-bearing event that omits details would wipe previously
+// recorded details with an empty map.
+func processTokenUsageEvent(ctx wrapper.HttpContext, event []byte) {
+	// Snapshot the previously recorded details maps BEFORE the call. The
+	// context layer is the source of truth: ai-statistics only ever writes it
+	// with effective (non-nil) maps.
+	prevInputDetails, _ := ctx.GetContext(tokenusage.CtxKeyInputTokenDetails).(map[string]int64)
+	prevOutputDetails, _ := ctx.GetContext(tokenusage.CtxKeyOutputTokenDetails).(map[string]int64)
+
+	usage := getTokenUsage(ctx, event)
+
+	inputDetails := prevInputDetails
+	if wrapper.GetValueFromBody(event, inputTokenDetailsProbePaths) != nil {
+		inputDetails = usage.InputTokenDetails
+	}
+	outputDetails := prevOutputDetails
+	if wrapper.GetValueFromBody(event, outputTokenDetailsProbePaths) != nil {
+		outputDetails = usage.OutputTokenDetails
+	}
+	// Write the effective maps to BOTH layers, undoing tokenusage's
+	// unconditional empty-map user-attribute write when the event omitted the
+	// details. A nil effective map (no details ever seen) skips both writes so
+	// intact-event behavior stays byte-equivalent to before: tokenusage's empty
+	// map remains in the user-attribute layer and the context layer stays
+	// unset.
+	if inputDetails != nil {
+		ctx.SetContext(tokenusage.CtxKeyInputTokenDetails, inputDetails)
+		ctx.SetUserAttribute(tokenusage.CtxKeyInputTokenDetails, inputDetails)
+	}
+	if outputDetails != nil {
+		ctx.SetContext(tokenusage.CtxKeyOutputTokenDetails, outputDetails)
+		ctx.SetUserAttribute(tokenusage.CtxKeyOutputTokenDetails, outputDetails)
+	}
+
+	if usage.TotalToken > 0 {
+		// Set span attributes for ARMS. Repeated writes across multiple usage
+		// events are per-key last-write-wins, so the final complete usage event
+		// determines the span (Design #4249 output consistency).
+		setSpanAttribute(ArmsTotalToken, usage.TotalToken)
+		setSpanAttribute(ArmsModelName, usage.Model)
+		setSpanAttribute(ArmsInputToken, usage.InputToken)
+		setSpanAttribute(ArmsOutputToken, usage.OutputToken)
+
+		// Write once
+		_ = ctx.WriteUserAttributeToLogWithKey(wrapper.AILogKey)
+	}
 }
 
 func onHttpResponseBody(ctx wrapper.HttpContext, config AIStatisticsConfig, body []byte) types.Action {

--- a/plugins/wasm-go/extensions/ai-statistics/main_test.go
+++ b/plugins/wasm-go/extensions/ai-statistics/main_test.go
@@ -16,11 +16,15 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/higress-group/proxy-wasm-go-sdk/proxywasm/types"
 	"github.com/higress-group/wasm-go/pkg/test"
+	"github.com/higress-group/wasm-go/pkg/tokenusage"
 	"github.com/higress-group/wasm-go/pkg/wrapper"
 	"github.com/stretchr/testify/require"
 )
@@ -747,6 +751,13 @@ func TestMetrics(t *testing.T) {
 			// 添加延迟，确保有足够的时间间隔来计算 llm_service_duration
 			time.Sleep(10 * time.Millisecond)
 
+			// 2.5 处理响应头（非流式 JSON，走缓冲响应体路径）
+			action := host.CallOnHttpResponseHeaders([][2]string{
+				{":status", "200"},
+				{"content-type", "application/json"},
+			})
+			require.Equal(t, types.ActionContinue, action)
+
 			// 3. 处理响应体
 			responseBody := []byte(`{
 				"choices": [{"message": {"content": "Hello, how can I help you?"}}],
@@ -832,8 +843,8 @@ func TestMetrics(t *testing.T) {
 			// 应该返回 ActionContinue
 			require.Equal(t, types.ActionContinue, action)
 
-			// 4. 处理流式响应体 - 添加 usage 信息
-			firstChunk := []byte(`data: {"choices":[{"message":{"content":"Hello"}}],"model":"gpt-4","usage":{"prompt_tokens":5,"completion_tokens":3,"total_tokens":8}}`)
+			// 4. 处理流式响应体 - 添加 usage 信息（SSE 事件以 \n\n 结尾）
+			firstChunk := []byte("data: {\"choices\":[{\"message\":{\"content\":\"Hello\"}}],\"model\":\"gpt-4\",\"usage\":{\"prompt_tokens\":5,\"completion_tokens\":3,\"total_tokens\":8}}\n\n")
 			action = host.CallOnHttpStreamingResponseBody(firstChunk, false)
 
 			// 应该返回原始数据
@@ -842,8 +853,8 @@ func TestMetrics(t *testing.T) {
 			result := host.GetResponseBody()
 			require.Equal(t, firstChunk, result)
 
-			// 5. 处理最后一个流式块 - 添加 usage 信息
-			lastChunk := []byte(`data: {"choices":[{"message":{"content":"How can I help you?"}}],"model":"gpt-4","usage":{"prompt_tokens":5,"completion_tokens":8,"total_tokens":13}}`)
+			// 5. 处理最后一个流式块 - 添加 usage 信息（SSE 事件以 \n\n 结尾）
+			lastChunk := []byte("data: {\"choices\":[{\"message\":{\"content\":\"How can I help you?\"}}],\"model\":\"gpt-4\",\"usage\":{\"prompt_tokens\":5,\"completion_tokens\":8,\"total_tokens\":13}}\n\n")
 			action = host.CallOnHttpStreamingResponseBody(lastChunk, true)
 
 			// 应该返回原始数据
@@ -1035,8 +1046,8 @@ func TestCompleteFlow(t *testing.T) {
 			// 应该返回 ActionContinue
 			require.Equal(t, types.ActionContinue, action)
 
-			// 4. 处理流式响应体 - 添加 usage 信息
-			firstChunk := []byte(`data: {"choices":[{"message":{"content":"Hello"}}],"model":"gpt-4","usage":{"prompt_tokens":5,"completion_tokens":3,"total_tokens":8}}`)
+			// 4. 处理流式响应体 - 添加 usage 信息（SSE 事件以 \n\n 结尾）
+			firstChunk := []byte("data: {\"choices\":[{\"message\":{\"content\":\"Hello\"}}],\"model\":\"gpt-4\",\"usage\":{\"prompt_tokens\":5,\"completion_tokens\":3,\"total_tokens\":8}}\n\n")
 			action = host.CallOnHttpStreamingResponseBody(firstChunk, false)
 
 			// 应该返回原始数据
@@ -1045,8 +1056,8 @@ func TestCompleteFlow(t *testing.T) {
 			result := host.GetResponseBody()
 			require.Equal(t, firstChunk, result)
 
-			// 5. 处理最后一个流式块 - 添加 usage 信息
-			lastChunk := []byte(`data: {"choices":[{"message":{"content":"How can I help you?"}}],"model":"gpt-4","usage":{"prompt_tokens":5,"completion_tokens":8,"total_tokens":13}}`)
+			// 5. 处理最后一个流式块 - 添加 usage 信息（SSE 事件以 \n\n 结尾）
+			lastChunk := []byte("data: {\"choices\":[{\"message\":{\"content\":\"How can I help you?\"}}],\"model\":\"gpt-4\",\"usage\":{\"prompt_tokens\":5,\"completion_tokens\":8,\"total_tokens\":13}}\n\n")
 			action = host.CallOnHttpStreamingResponseBody(lastChunk, true)
 
 			// 应该返回原始数据
@@ -2367,13 +2378,14 @@ func TestStreamingFailureCountMetric(t *testing.T) {
 			})
 
 			// Simulate SSE stream: error appears in middle chunk, last chunk is [DONE]
-			chunk1 := []byte(`data: {"choices":[{"delta":{"content":"Hello"}}]}`)
+			// (events are terminated with the SSE delimiter \n\n).
+			chunk1 := []byte("data: {\"choices\":[{\"delta\":{\"content\":\"Hello\"}}]}\n\n")
 			host.CallOnHttpStreamingResponseBody(chunk1, false)
 
-			chunk2 := []byte(`data: {"error":{"type":"api_error","message":"Something went wrong"}}`)
+			chunk2 := []byte("data: {\"error\":{\"type\":\"api_error\",\"message\":\"Something went wrong\"}}\n\n")
 			host.CallOnHttpStreamingResponseBody(chunk2, false)
 
-			chunk3 := []byte(`data: [DONE]`)
+			chunk3 := []byte("data: [DONE]\n\n")
 			host.CallOnHttpStreamingResponseBody(chunk3, true)
 
 			host.CompleteHttp()
@@ -2383,6 +2395,764 @@ func TestStreamingFailureCountMetric(t *testing.T) {
 			failureValue, err := host.GetCounterMetric(failureMetric)
 			require.NoError(t, err)
 			require.Equal(t, uint64(1), failureValue)
+		})
+	})
+}
+
+// ==================== SSE framer integration tests (Design #4249) ====================
+//
+// These tests drive onHttpStreamingBody through the proxy-wasm test host with
+// controlled byte boundaries and pin the consumer-level rows of the Design
+// test matrix: token usage and stream-error detection consume reassembled
+// complete SSE events from the request-scoped framer, so split and intact
+// delivery are observably equivalent, and original response bytes pass through
+// unchanged on every callback. Scanner-level rows (T-05..T-08, T-13..T-15,
+// T-22, T-23, T-25, T-26 byte-boundary details) are covered in
+// sse_framer_test.go; the tests below assert the end-to-end outcomes.
+
+// setupStreamingHost starts a request scoped to a streaming (SSE) response:
+// request headers + body (model gpt-4) + text/event-stream response headers,
+// with route api-v1 / cluster cluster-1 / consumer user1 for metric labels.
+// The caller must defer host.Reset().
+func setupStreamingHost(t *testing.T, config json.RawMessage) test.TestHost {
+	t.Helper()
+	host, status := test.NewTestHost(config)
+	require.Equal(t, types.OnPluginStartStatusOK, status)
+
+	host.SetRouteName("api-v1")
+	host.SetClusterName("cluster-1")
+
+	action := host.CallOnHttpRequestHeaders([][2]string{
+		{":authority", "example.com"},
+		{":path", "/v1/chat/completions"},
+		{":method", "POST"},
+		{"x-mse-consumer", "user1"},
+	})
+	require.Equal(t, types.ActionContinue, action)
+
+	action = host.CallOnHttpRequestBody([]byte(`{"model": "gpt-4", "messages": [{"role": "user", "content": "Hello"}]}`))
+	require.Equal(t, types.ActionContinue, action)
+
+	action = host.CallOnHttpResponseHeaders([][2]string{
+		{":status", "200"},
+		{"content-type", "text/event-stream"},
+	})
+	require.Equal(t, types.ActionContinue, action)
+	return host
+}
+
+// sseEvent wraps a payload in one complete SSE event with an LF delimiter.
+func sseEvent(payload string) []byte {
+	return []byte("data: " + payload + "\n\n")
+}
+
+// concatStreamBytes concatenates byte slices into a fresh slice.
+func concatStreamBytes(parts ...[]byte) []byte {
+	var out []byte
+	for _, p := range parts {
+		out = append(out, p...)
+	}
+	return out
+}
+
+// deliverStreamChunk feeds one host callback and asserts the fail-open
+// passthrough contract: the plugin must return the original bytes unchanged.
+func deliverStreamChunk(t *testing.T, host test.TestHost, chunk []byte, endOfStream bool) {
+	t.Helper()
+	action := host.CallOnHttpStreamingResponseBody(chunk, endOfStream)
+	require.Equal(t, types.ActionContinue, action)
+	require.Equal(t, chunk, host.GetResponseBody(), "original response bytes must pass through unchanged")
+}
+
+// deliverStreamChunks feeds each chunk as one host callback, with endOfStream
+// set on the last chunk, asserting passthrough on every callback.
+func deliverStreamChunks(t *testing.T, host test.TestHost, chunks ...[]byte) {
+	t.Helper()
+	for i, chunk := range chunks {
+		deliverStreamChunk(t, host, chunk, i == len(chunks)-1)
+	}
+}
+
+// aiLogInt64 reads a numeric attribute from the parsed ai_log property.
+func aiLogInt64(attrs map[string]interface{}, key string) (int64, bool) {
+	v, ok := attrs[key]
+	if !ok {
+		return 0, false
+	}
+	f, ok := v.(float64)
+	if !ok {
+		return 0, false
+	}
+	return int64(f), true
+}
+
+// assertTokenAttrs asserts the final recorded token usage in ai_log.
+func assertTokenAttrs(t *testing.T, attrs map[string]interface{}, input, output, total int64) {
+	t.Helper()
+	in, ok := aiLogInt64(attrs, tokenusage.CtxKeyInputToken)
+	require.True(t, ok, "input_token missing from ai_log")
+	require.Equal(t, input, in)
+	out, ok := aiLogInt64(attrs, tokenusage.CtxKeyOutputToken)
+	require.True(t, ok, "output_token missing from ai_log")
+	require.Equal(t, output, out)
+	tot, ok := aiLogInt64(attrs, tokenusage.CtxKeyTotalToken)
+	require.True(t, ok, "total_token missing from ai_log")
+	require.Equal(t, total, tot)
+}
+
+// assertNoTokenAttrs asserts no token usage was recorded (zero-fabrication).
+func assertNoTokenAttrs(t *testing.T, attrs map[string]interface{}) {
+	t.Helper()
+	for _, key := range []string{tokenusage.CtxKeyInputToken, tokenusage.CtxKeyOutputToken, tokenusage.CtxKeyTotalToken} {
+		_, ok := aiLogInt64(attrs, key)
+		require.False(t, ok, "%s must not be fabricated", key)
+	}
+}
+
+// getSpanValue reads an ARMS span property written by setSpanAttribute.
+func getSpanValue(host test.TestHost, key string) (string, bool) {
+	raw, err := host.GetProperty([]string{wrapper.TraceSpanTagPrefix + key})
+	if err != nil || len(raw) == 0 {
+		return "", false
+	}
+	return string(raw), true
+}
+
+// streamingMetricName builds the counter name for the standard test flow.
+func streamingMetricName(model, metric string) string {
+	return fmt.Sprintf("route.api-v1.upstream.cluster-1.model.%s.consumer.user1.metric.%s", model, metric)
+}
+
+// assertTokenMetrics asserts the recorded token counter metrics.
+func assertTokenMetrics(t *testing.T, host test.TestHost, model string, input, output, total uint64) {
+	t.Helper()
+	for metric, want := range map[string]uint64{
+		tokenusage.CtxKeyInputToken:  input,
+		tokenusage.CtxKeyOutputToken: output,
+		tokenusage.CtxKeyTotalToken:  total,
+	} {
+		got, err := host.GetCounterMetric(streamingMetricName(model, metric))
+		require.NoError(t, err)
+		require.Equal(t, want, got, "metric %s", metric)
+	}
+}
+
+// TestStreamingIntactUsageEventParity covers T-01: a single intact usage event
+// in one callback recovers the upstream values, and the ai_log content is
+// byte-equivalent to the pre-change behavior (dynamic duration fields aside).
+func TestStreamingIntactUsageEventParity(t *testing.T) {
+	test.RunTest(t, func(t *testing.T) {
+		t.Run("intact usage event", func(t *testing.T) {
+			host := setupStreamingHost(t, emptyAttributesConfig)
+			defer host.Reset()
+
+			contentEvent := sseEvent(`{"id":"chatcmpl-parity","choices":[{"delta":{"content":"Hello"}}],"model":"gpt-4"}`)
+			usageEvent := sseEvent(`{"choices":[],"model":"gpt-4","usage":{"prompt_tokens":5,"completion_tokens":8,"total_tokens":13}}`)
+			deliverStreamChunks(t, host, contentEvent, usageEvent)
+
+			attrs := getAILogAttributes(t, host)
+			// Durations are time-based; assert presence and exclude them from
+			// the exact-content comparison.
+			_, ok := aiLogInt64(attrs, LLMFirstTokenDuration)
+			require.True(t, ok, "llm_first_token_duration missing")
+			_, ok = aiLogInt64(attrs, LLMServiceDuration)
+			require.True(t, ok, "llm_service_duration missing")
+			delete(attrs, LLMFirstTokenDuration)
+			delete(attrs, LLMServiceDuration)
+
+			// Byte-equivalence with pre-change behavior: the framed complete
+			// event is exactly the bytes the raw-chunk path used to see, and an
+			// event without details leaves empty detail maps in the log.
+			require.Equal(t, map[string]interface{}{
+				"api":                  "-",
+				"chat_round":           float64(1),
+				"response_type":        "stream",
+				"chat_id":              "chatcmpl-parity",
+				"model":                "gpt-4",
+				"input_token":          float64(5),
+				"output_token":         float64(8),
+				"total_token":          float64(13),
+				"input_token_details":  map[string]interface{}{},
+				"output_token_details": map[string]interface{}{},
+			}, attrs)
+
+			spanTotal, ok := getSpanValue(host, ArmsTotalToken)
+			require.True(t, ok)
+			require.Equal(t, "13", spanTotal)
+			spanInput, ok := getSpanValue(host, ArmsInputToken)
+			require.True(t, ok)
+			require.Equal(t, "5", spanInput)
+			spanOutput, ok := getSpanValue(host, ArmsOutputToken)
+			require.True(t, ok)
+			require.Equal(t, "8", spanOutput)
+			spanModel, ok := getSpanValue(host, ArmsModelName)
+			require.True(t, ok)
+			require.Equal(t, "gpt-4", spanModel)
+
+			assertTokenMetrics(t, host, "gpt-4", 5, 8, 13)
+			host.CompleteHttp()
+		})
+	})
+}
+
+// TestStreamingSplitUsageEventRecovery covers T-02, T-03, T-17 and T-23: a
+// usage event split across host callbacks at arbitrary byte boundaries is
+// reassembled by the framer and recovers exactly the same tokens as intact
+// delivery, including with shouldBufferStreamingBody disabled (the config used
+// here buffers nothing) and with one-byte callbacks.
+func TestStreamingSplitUsageEventRecovery(t *testing.T) {
+	test.RunTest(t, func(t *testing.T) {
+		payload := `{"id":"chatcmpl-split","object":"chat.completion.chunk","created":1710000000,"model":"gpt-4","choices":[{"index":0,"delta":{}}],"usage":{"prompt_tokens":11,"completion_tokens":22,"total_tokens":33}}`
+		event := sseEvent(payload)
+		require.Greater(t, len(event), 141, "pinned split offsets must be inside the event")
+
+		// assertRecovered runs one full request over the given chunks and
+		// asserts the recovered final usage matches the intact-delivery values.
+		assertRecovered := func(t *testing.T, chunks ...[]byte) {
+			host := setupStreamingHost(t, emptyAttributesConfig)
+			defer host.Reset()
+			deliverStreamChunks(t, host, chunks...)
+			attrs := getAILogAttributes(t, host)
+			assertTokenAttrs(t, attrs, 11, 22, 33)
+			require.Equal(t, "gpt-4", attrs["model"])
+			host.CompleteHttp()
+		}
+
+		// T-02: splits inside the JSON body at the Design-pinned offsets.
+		for _, off := range []int{50, 100, 120, 130, 140} {
+			t.Run(fmt.Sprintf("split_at_offset_%d", off), func(t *testing.T) {
+				assertRecovered(t, event[:off], event[off:])
+			})
+		}
+
+		// T-03: a split inside the "data:" prefix reassembles by byte shape.
+		t.Run("split_inside_data_prefix", func(t *testing.T) {
+			assertRecovered(t, event[:2], event[2:])
+		})
+
+		// T-23: one event delivered across many 1-byte callbacks is emitted on
+		// the completing callback and recovers the same tokens.
+		t.Run("one_byte_per_callback", func(t *testing.T) {
+			chunks := make([][]byte, 0, len(event))
+			for i := 0; i < len(event); i++ {
+				chunks = append(chunks, event[i:i+1])
+			}
+			assertRecovered(t, chunks...)
+		})
+
+		// T-17: with shouldBufferStreamingBody == false (emptyAttributesConfig
+		// configures no streaming-body attribute), token recovery still works
+		// via the framer's bounded tail, end to end down to the metrics.
+		t.Run("buffering_disabled_still_recovers_usage", func(t *testing.T) {
+			host := setupStreamingHost(t, emptyAttributesConfig)
+			defer host.Reset()
+
+			deliverStreamChunks(t, host, event[:100], event[100:])
+			attrs := getAILogAttributes(t, host)
+			assertTokenAttrs(t, attrs, 11, 22, 33)
+			assertTokenMetrics(t, host, "gpt-4", 11, 22, 33)
+			host.CompleteHttp()
+		})
+	})
+}
+
+// TestStreamingDelimiterSplitRecovery covers T-04 and T-05 at integration
+// level: LF and CRLF delimiters split across callbacks (at every byte
+// boundary) are recognized only once complete, and the event recovers the same
+// tokens as intact delivery. (Exact emission counts per split point are
+// asserted in sse_framer_test.go.)
+func TestStreamingDelimiterSplitRecovery(t *testing.T) {
+	test.RunTest(t, func(t *testing.T) {
+		payload := `{"choices":[],"model":"gpt-4","usage":{"prompt_tokens":3,"completion_tokens":4,"total_tokens":7}}`
+
+		// T-04: an LF delimiter split across callbacks emits the event only
+		// after the second \n arrives; usage is recovered mid-stream, before
+		// end-of-stream.
+		t.Run("lf_delimiter_split", func(t *testing.T) {
+			host := setupStreamingHost(t, emptyAttributesConfig)
+			defer host.Reset()
+
+			deliverStreamChunk(t, host, []byte("data: "+payload+"\n"), false)
+			attrs := getAILogAttributes(t, host)
+			assertNoTokenAttrs(t, attrs)
+
+			deliverStreamChunk(t, host, []byte("\n"), false)
+			attrs = getAILogAttributes(t, host)
+			assertTokenAttrs(t, attrs, 3, 4, 7)
+
+			deliverStreamChunks(t, host, sseEvent("[DONE]"))
+			host.CompleteHttp()
+		})
+
+		// T-05: a CRLF delimiter split at every byte boundary recovers the
+		// event; intact CRLF and mixed delimiter forms behave the same.
+		crlfEvent := []byte("data: " + payload + "\r\n\r\n")
+		n := len(crlfEvent)
+		cases := []struct {
+			name  string
+			part1 []byte
+			part2 []byte
+		}{
+			{"crlf_intact", crlfEvent, nil},
+			{"cr_then_lf_crlf", crlfEvent[:n-3], crlfEvent[n-3:]}, // "\r" | "\n\r\n"
+			{"crlf_then_crlf", crlfEvent[:n-2], crlfEvent[n-2:]},  // "\r\n" | "\r\n"
+			{"crlf_cr_then_lf", crlfEvent[:n-1], crlfEvent[n-1:]}, // "\r\n\r" | "\n"
+		}
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				host := setupStreamingHost(t, emptyAttributesConfig)
+				defer host.Reset()
+				if tc.part2 == nil {
+					deliverStreamChunks(t, host, tc.part1)
+				} else {
+					deliverStreamChunks(t, host, tc.part1, tc.part2)
+				}
+				attrs := getAILogAttributes(t, host)
+				assertTokenAttrs(t, attrs, 3, 4, 7)
+				host.CompleteHttp()
+			})
+		}
+
+		// Mixed delimiter forms terminate an event exactly like pure LF.
+		for _, delim := range []string{"\n\r\n", "\r\n\n"} {
+			t.Run(fmt.Sprintf("mixed_delimiter_%q", delim), func(t *testing.T) {
+				host := setupStreamingHost(t, emptyAttributesConfig)
+				defer host.Reset()
+				deliverStreamChunks(t, host, []byte("data: "+payload+delim))
+				attrs := getAILogAttributes(t, host)
+				assertTokenAttrs(t, attrs, 3, 4, 7)
+				host.CompleteHttp()
+			})
+		}
+	})
+}
+
+// TestStreamingMultipleUsageEvents covers T-09 and the T-20 consistency rows:
+// with several usage events the final complete event wins (values are never
+// summed), repeated span-property writes overwrite to the final value, and
+// ai_log / span / metrics all reflect the same final usage state.
+func TestStreamingMultipleUsageEvents(t *testing.T) {
+	test.RunTest(t, func(t *testing.T) {
+		first := sseEvent(`{"model":"gpt-4","usage":{"prompt_tokens":5,"completion_tokens":3,"total_tokens":8}}`)
+		final := sseEvent(`{"model":"gpt-4","usage":{"prompt_tokens":5,"completion_tokens":8,"total_tokens":13}}`)
+
+		assertFinalState := func(t *testing.T, host test.TestHost) {
+			attrs := getAILogAttributes(t, host)
+			assertTokenAttrs(t, attrs, 5, 8, 13)
+			spanTotal, ok := getSpanValue(host, ArmsTotalToken)
+			require.True(t, ok)
+			require.Equal(t, "13", spanTotal, "span property must hold the last event's value")
+			assertTokenMetrics(t, host, "gpt-4", 5, 8, 13)
+		}
+
+		t.Run("separate_callbacks", func(t *testing.T) {
+			host := setupStreamingHost(t, emptyAttributesConfig)
+			defer host.Reset()
+
+			deliverStreamChunk(t, host, first, false)
+			attrs := getAILogAttributes(t, host)
+			assertTokenAttrs(t, attrs, 5, 3, 8)
+			spanTotal, ok := getSpanValue(host, ArmsTotalToken)
+			require.True(t, ok)
+			require.Equal(t, "8", spanTotal)
+
+			deliverStreamChunks(t, host, final)
+			assertFinalState(t, host)
+			host.CompleteHttp()
+		})
+
+		t.Run("both_events_in_one_callback", func(t *testing.T) {
+			host := setupStreamingHost(t, emptyAttributesConfig)
+			defer host.Reset()
+			deliverStreamChunks(t, host, concatStreamBytes(first, final))
+			assertFinalState(t, host)
+			host.CompleteHttp()
+		})
+
+		t.Run("second_event_split_across_callbacks", func(t *testing.T) {
+			host := setupStreamingHost(t, emptyAttributesConfig)
+			defer host.Reset()
+			stream := concatStreamBytes(first, final)
+			split := len(first) + len(final)/2
+			deliverStreamChunks(t, host, stream[:split], stream[split:])
+			assertFinalState(t, host)
+			host.CompleteHttp()
+		})
+
+		// A final event silent on total never regresses the recorded total to
+		// 0: tokenusage computes it from the effective components (5+8).
+		t.Run("final_event_without_explicit_total", func(t *testing.T) {
+			host := setupStreamingHost(t, emptyAttributesConfig)
+			defer host.Reset()
+			partial := sseEvent(`{"model":"gpt-4","usage":{"prompt_tokens":5,"completion_tokens":8}}`)
+			deliverStreamChunks(t, host, first, partial)
+			attrs := getAILogAttributes(t, host)
+			assertTokenAttrs(t, attrs, 5, 8, 13)
+			host.CompleteHttp()
+		})
+	})
+}
+
+// TestStreamingTokenDetailsPolicy covers T-10 (and the details part of T-20):
+// details present in event N and absent in usage-bearing event N+1 are
+// retained in both the context layer (EOS builtin attributes) and the
+// user-attribute layer (per-callback ai_log write); details present in N+1
+// replace the whole map and are never summed.
+func TestStreamingTokenDetailsPolicy(t *testing.T) {
+	test.RunTest(t, func(t *testing.T) {
+		t.Run("details_retained_when_later_event_omits_them", func(t *testing.T) {
+			host := setupStreamingHost(t, tokenDetailsConfig)
+			defer host.Reset()
+
+			withDetails := sseEvent(`{"model":"gpt-4o","usage":{"prompt_tokens":10,"completion_tokens":5,"total_tokens":15,"prompt_tokens_details":{"cached_tokens":4},"completion_tokens_details":{"reasoning_tokens":2}}}`)
+			withoutDetails := sseEvent(`{"model":"gpt-4o","usage":{"prompt_tokens":10,"completion_tokens":7,"total_tokens":17}}`)
+
+			deliverStreamChunk(t, host, withDetails, false)
+			attrs := getAILogAttributes(t, host)
+			require.Equal(t, map[string]interface{}{"cached_tokens": float64(4)}, attrs["input_token_details"])
+			require.Equal(t, map[string]interface{}{"reasoning_tokens": float64(2)}, attrs["output_token_details"])
+
+			// The usage-bearing event without details must not wipe the
+			// recorded details: the user-attribute layer (this per-callback
+			// ai_log write) retains the previous maps.
+			deliverStreamChunk(t, host, withoutDetails, false)
+			attrs = getAILogAttributes(t, host)
+			assertTokenAttrs(t, attrs, 10, 7, 17)
+			require.Equal(t, map[string]interface{}{"cached_tokens": float64(4)}, attrs["input_token_details"],
+				"user-attribute layer must retain previous details")
+			require.Equal(t, map[string]interface{}{"reasoning_tokens": float64(2)}, attrs["output_token_details"],
+				"user-attribute layer must retain previous details")
+
+			deliverStreamChunks(t, host, sseEvent("[DONE]"))
+			// At EOS the builtin attributes read the context layer, which must
+			// hold the same retained maps (layers synchronized), rendered as
+			// their JSON string form.
+			attrs = getAILogAttributes(t, host)
+			assertTokenAttrs(t, attrs, 10, 7, 17)
+			require.Equal(t, `{"cached_tokens":4}`, attrs["input_token_details"])
+			require.Equal(t, `{"reasoning_tokens":2}`, attrs["output_token_details"])
+			cached, ok := aiLogInt64(attrs, BuiltinCachedTokens)
+			require.True(t, ok)
+			require.Equal(t, int64(4), cached)
+			reasoning, ok := aiLogInt64(attrs, BuiltinReasoningTokens)
+			require.True(t, ok)
+			require.Equal(t, int64(2), reasoning)
+
+			// Output consistency (T-20): span and metrics reflect the same
+			// final usage as the log attributes.
+			spanTotal, ok := getSpanValue(host, ArmsTotalToken)
+			require.True(t, ok)
+			require.Equal(t, "17", spanTotal)
+			assertTokenMetrics(t, host, "gpt-4o", 10, 7, 17)
+			host.CompleteHttp()
+		})
+
+		t.Run("details_replaced_when_later_event_carries_them", func(t *testing.T) {
+			host := setupStreamingHost(t, tokenDetailsConfig)
+			defer host.Reset()
+
+			first := sseEvent(`{"model":"gpt-4o","usage":{"prompt_tokens":10,"completion_tokens":5,"total_tokens":15,"prompt_tokens_details":{"cached_tokens":4},"completion_tokens_details":{"reasoning_tokens":2}}}`)
+			// Output details present (replace), input details absent (retain).
+			second := sseEvent(`{"model":"gpt-4o","usage":{"prompt_tokens":10,"completion_tokens":7,"total_tokens":17,"completion_tokens_details":{"reasoning_tokens":6}}}`)
+			deliverStreamChunks(t, host, first, second)
+
+			attrs := getAILogAttributes(t, host)
+			assertTokenAttrs(t, attrs, 10, 7, 17)
+			require.Equal(t, `{"cached_tokens":4}`, attrs["input_token_details"], "absent input details must be retained")
+			require.Equal(t, `{"reasoning_tokens":6}`, attrs["output_token_details"], "present output details must replace the whole map")
+			reasoning, ok := aiLogInt64(attrs, BuiltinReasoningTokens)
+			require.True(t, ok)
+			require.Equal(t, int64(6), reasoning, "details are replaced, never summed")
+			host.CompleteHttp()
+		})
+
+		t.Run("details_never_summed_across_events", func(t *testing.T) {
+			host := setupStreamingHost(t, tokenDetailsConfig)
+			defer host.Reset()
+
+			first := sseEvent(`{"model":"gpt-4o","usage":{"prompt_tokens":10,"completion_tokens":5,"total_tokens":15,"prompt_tokens_details":{"cached_tokens":4}}}`)
+			second := sseEvent(`{"model":"gpt-4o","usage":{"prompt_tokens":10,"completion_tokens":7,"total_tokens":17,"prompt_tokens_details":{"cached_tokens":9}}}`)
+			deliverStreamChunks(t, host, first, second)
+
+			attrs := getAILogAttributes(t, host)
+			require.Equal(t, `{"cached_tokens":9}`, attrs["input_token_details"], "details maps replace; values are never summed")
+			cached, ok := aiLogInt64(attrs, BuiltinCachedTokens)
+			require.True(t, ok)
+			require.Equal(t, int64(9), cached)
+			host.CompleteHttp()
+		})
+	})
+}
+
+// TestStreamingSplitErrorEvent covers T-11: an SSE error event split across
+// callbacks is reassembled and detected exactly as an intact one, and one
+// request produces exactly one llm_failure_count increment regardless of how
+// many error events matched. The config used here buffers nothing, so the
+// increment can only come from the framed-event hasStreamError flag (the EOS
+// bodyForMetric fallback sees only the final [DONE] chunk).
+func TestStreamingSplitErrorEvent(t *testing.T) {
+	test.RunTest(t, func(t *testing.T) {
+		failureMetric := streamingMetricName("gpt-4", LLMFailureCount)
+		contentEvent := sseEvent(`{"choices":[{"delta":{"content":"Hello"}}]}`)
+		errorPayload := `{"error":{"type":"api_error","message":"Something went wrong"}}`
+		doneEvent := sseEvent("[DONE]")
+
+		assertOneFailure := func(t *testing.T, chunks ...[]byte) {
+			host := setupStreamingHost(t, emptyAttributesConfig)
+			defer host.Reset()
+			deliverStreamChunks(t, host, chunks...)
+			value, err := host.GetCounterMetric(failureMetric)
+			require.NoError(t, err)
+			require.Equal(t, uint64(1), value, "exactly one request-level failure increment")
+			host.CompleteHttp()
+		}
+
+		t.Run("intact_error_event", func(t *testing.T) {
+			assertOneFailure(t, contentEvent, sseEvent(errorPayload), doneEvent)
+		})
+
+		t.Run("split_error_event_is_equivalent", func(t *testing.T) {
+			event := sseEvent(errorPayload)
+			assertOneFailure(t, contentEvent, event[:12], event[12:len(event)-2], event[len(event)-2:], doneEvent)
+		})
+
+		t.Run("two_error_events_still_one_increment", func(t *testing.T) {
+			assertOneFailure(t, sseEvent(errorPayload), sseEvent(errorPayload), doneEvent)
+		})
+	})
+}
+
+// TestStreamingNoUpstreamUsage covers T-12 and T-18: when the upstream never
+// emits usage (including an abrupt end of stream mid-event, the #4145 shape),
+// recorded tokens remain zero and nothing is fabricated.
+func TestStreamingNoUpstreamUsage(t *testing.T) {
+	test.RunTest(t, func(t *testing.T) {
+		assertZeroTokens := func(t *testing.T, host test.TestHost) {
+			attrs := getAILogAttributes(t, host)
+			assertNoTokenAttrs(t, attrs)
+			_, err := host.GetCounterMetric(streamingMetricName("gpt-4", tokenusage.CtxKeyTotalToken))
+			require.Error(t, err, "no token metric may be recorded without upstream usage")
+			_, err = host.GetCounterMetric(streamingMetricName("gpt-4", LLMFailureCount))
+			require.Error(t, err, "no failure may be recorded for a clean stream")
+		}
+
+		t.Run("no_usage_events", func(t *testing.T) {
+			host := setupStreamingHost(t, emptyAttributesConfig)
+			defer host.Reset()
+			deliverStreamChunks(t, host,
+				sseEvent(`{"choices":[{"delta":{"content":"Hello"}}],"model":"gpt-4"}`),
+				sseEvent(`{"choices":[{"delta":{"content":" world"}}],"model":"gpt-4"}`),
+				sseEvent("[DONE]"))
+			assertZeroTokens(t, host)
+			host.CompleteHttp()
+		})
+
+		// #4145 shape: the stream ends abruptly with an incomplete tail; the
+		// tail is discarded at EOS and no usage is fabricated.
+		t.Run("abrupt_end_of_stream_mid_event", func(t *testing.T) {
+			host := setupStreamingHost(t, emptyAttributesConfig)
+			defer host.Reset()
+			deliverStreamChunks(t, host,
+				sseEvent(`{"choices":[{"delta":{"content":"Hello"}}],"model":"gpt-4"}`),
+				[]byte(`data: {"choices":[{"delta":{"content":"Hel`))
+			assertZeroTokens(t, host)
+			host.CompleteHttp()
+		})
+	})
+}
+
+// TestStreamingToolCallsSplit covers T-16: tool-call extraction stays on the
+// end-of-stream accumulated-body path, so tool_calls content split across
+// callbacks yields exactly the intact-delivery result and arguments are not
+// double-appended.
+func TestStreamingToolCallsSplit(t *testing.T) {
+	test.RunTest(t, func(t *testing.T) {
+		events := [][]byte{
+			sseEvent(`{"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_abc123","type":"function","function":{"name":"get_weather","arguments":""}}]}}]}`),
+			sseEvent(`{"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\"locat"}}]}}]}`),
+			sseEvent(`{"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"ion\": \"Bei"}}]}}]}`),
+			sseEvent(`{"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"jing\"}"}}]}}]}`),
+			sseEvent(`{"choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}`),
+		}
+
+		readToolCalls := func(t *testing.T, chunks ...[]byte) interface{} {
+			host := setupStreamingHost(t, builtinAttributesConfig)
+			defer host.Reset()
+			deliverStreamChunks(t, host, chunks...)
+			attrs := getAILogAttributes(t, host)
+			host.CompleteHttp()
+			return attrs["tool_calls"]
+		}
+
+		t.Run("split_delivery_matches_intact_delivery", func(t *testing.T) {
+			intact := readToolCalls(t, events...)
+
+			// Re-chunk the identical byte stream into 13-byte pieces that cut
+			// across event boundaries, JSON tokens and the data: prefixes.
+			stream := concatStreamBytes(events...)
+			var pieces [][]byte
+			for i := 0; i < len(stream); i += 13 {
+				end := i + 13
+				if end > len(stream) {
+					end = len(stream)
+				}
+				pieces = append(pieces, stream[i:end])
+			}
+			split := readToolCalls(t, pieces...)
+
+			require.Equal(t, intact, split, "tool_calls must equal intact delivery")
+			calls, ok := split.([]interface{})
+			require.True(t, ok)
+			require.Len(t, calls, 1)
+			call := calls[0].(map[string]interface{})
+			require.Equal(t, "call_abc123", call["id"])
+			require.Equal(t, "function", call["type"])
+			fn := call["function"].(map[string]interface{})
+			require.Equal(t, "get_weather", fn["name"])
+			require.Equal(t, `{"location": "Beijing"}`, fn["arguments"],
+				"arguments must be assembled exactly once, not double-appended")
+		})
+	})
+}
+
+// TestStreamingEOSIncompleteTail covers T-24: an unterminated event at
+// end-of-stream is discarded; no usage is fabricated for the partial event
+// and previously recorded values are preserved.
+func TestStreamingEOSIncompleteTail(t *testing.T) {
+	test.RunTest(t, func(t *testing.T) {
+		usageEvent := sseEvent(`{"model":"gpt-4","usage":{"prompt_tokens":5,"completion_tokens":8,"total_tokens":13}}`)
+		partialUsage := []byte(`data: {"model":"gpt-4","usage":{"prompt_tokens":99,"completion_tokens":99,"total_tokens":198}}`)
+
+		t.Run("partial_final_event_discarded", func(t *testing.T) {
+			host := setupStreamingHost(t, emptyAttributesConfig)
+			defer host.Reset()
+			deliverStreamChunks(t, host, usageEvent, partialUsage)
+			attrs := getAILogAttributes(t, host)
+			assertTokenAttrs(t, attrs, 5, 8, 13)
+			assertTokenMetrics(t, host, "gpt-4", 5, 8, 13)
+			host.CompleteHttp()
+		})
+
+		t.Run("complete_event_then_partial_tail_same_callback", func(t *testing.T) {
+			host := setupStreamingHost(t, emptyAttributesConfig)
+			defer host.Reset()
+			deliverStreamChunks(t, host, concatStreamBytes(usageEvent, partialUsage))
+			attrs := getAILogAttributes(t, host)
+			assertTokenAttrs(t, attrs, 5, 8, 13)
+			host.CompleteHttp()
+		})
+	})
+}
+
+// TestStreamingFailOpenOnPanic covers T-19: a panic in an observability
+// consumer is contained by the local recovery boundary in onHttpStreamingBody
+// and the original response bytes pass through unchanged. Wrapper-level
+// recovery is disabled via WASM_DISABLE_PANIC_RECOVERY so only the local
+// boundary can contain the panic in go mode; in wasm mode the injected
+// override has no effect and the passthrough assertions still hold.
+func TestStreamingFailOpenOnPanic(t *testing.T) {
+	test.RunTest(t, func(t *testing.T) {
+		t.Run("injected_consumer_panic_returns_original_data", func(t *testing.T) {
+			host := setupStreamingHost(t, emptyAttributesConfig)
+			defer host.Reset()
+
+			os.Setenv("WASM_DISABLE_PANIC_RECOVERY", "true")
+			defer os.Unsetenv("WASM_DISABLE_PANIC_RECOVERY")
+
+			orig := getTokenUsage
+			getTokenUsage = func(ctx wrapper.HttpContext, body []byte) tokenusage.TokenUsage {
+				panic("injected consumer panic")
+			}
+			defer func() { getTokenUsage = orig }()
+
+			usageChunk := sseEvent(`{"model":"gpt-4","usage":{"prompt_tokens":5,"completion_tokens":3,"total_tokens":8}}`)
+			deliverStreamChunk(t, host, usageChunk, false)
+
+			// The request-scoped framer state is not corrupted by the panic: a
+			// later event is still processed and the EOS path completes.
+			getTokenUsage = orig
+			finalChunk := sseEvent(`{"model":"gpt-4","usage":{"prompt_tokens":5,"completion_tokens":8,"total_tokens":13}}`)
+			deliverStreamChunks(t, host, finalChunk)
+			attrs := getAILogAttributes(t, host)
+			assertTokenAttrs(t, attrs, 5, 8, 13)
+			host.CompleteHttp()
+		})
+	})
+}
+
+// TestStreamingFramerResyncIntegration drives the RESYNC paths end to end:
+// T-13 (complete events emitted before an oversized suffix in the same
+// callback are still delivered), T-14 (after an overflow the framer resumes
+// within the callback that carries the next delimiter), T-25/T-26 (the exact
+// 1 MiB boundary), and exercises drain() with a non-zero overflow count at EOS
+// (T-21; the exact count is asserted in sse_framer_test.go).
+func TestStreamingFramerResyncIntegration(t *testing.T) {
+	test.RunTest(t, func(t *testing.T) {
+		// paddedUsageEvent builds a usage event larger than 1 MiB whose padding
+		// contains no line endings (so no delimiter appears inside it).
+		paddedUsageEvent := func(prompt, completion, total int) []byte {
+			payload := fmt.Sprintf(`{"pad":"%s","model":"gpt-4","usage":{"prompt_tokens":%d,"completion_tokens":%d,"total_tokens":%d}}`,
+				strings.Repeat("x", maxIncompleteSSEEventBytes), prompt, completion, total)
+			return sseEvent(payload)
+		}
+
+		// T-25: an incomplete suffix of exactly 1 MiB is retained as the tail
+		// (no RESYNC), so the event completes on the next callback and usage is
+		// recovered.
+		t.Run("suffix_exactly_one_mib_retained_and_recovered", func(t *testing.T) {
+			host := setupStreamingHost(t, emptyAttributesConfig)
+			defer host.Reset()
+			event := paddedUsageEvent(7, 8, 15)
+			deliverStreamChunks(t, host, event[:maxIncompleteSSEEventBytes], event[maxIncompleteSSEEventBytes:])
+			attrs := getAILogAttributes(t, host)
+			assertTokenAttrs(t, attrs, 7, 8, 15)
+			host.CompleteHttp()
+		})
+
+		// T-26: a 1 MiB+1 incomplete suffix enters RESYNC and is dropped; the
+		// next delimiter-terminated event is still recovered.
+		t.Run("suffix_one_mib_plus_one_resyncs", func(t *testing.T) {
+			host := setupStreamingHost(t, emptyAttributesConfig)
+			defer host.Reset()
+			event := paddedUsageEvent(99, 99, 198)
+			deliverStreamChunk(t, host, event[:maxIncompleteSSEEventBytes+1], false)
+			// The remainder carries the oversized event's own terminating
+			// delimiter; RESYNC discards everything through it.
+			deliverStreamChunk(t, host, event[maxIncompleteSSEEventBytes+1:], false)
+			attrs := getAILogAttributes(t, host)
+			assertNoTokenAttrs(t, attrs)
+
+			final := sseEvent(`{"model":"gpt-4","usage":{"prompt_tokens":5,"completion_tokens":8,"total_tokens":13}}`)
+			deliverStreamChunks(t, host, final)
+			attrs = getAILogAttributes(t, host)
+			assertTokenAttrs(t, attrs, 5, 8, 13)
+			host.CompleteHttp()
+		})
+
+		// T-13 + T-14: a complete usage event emitted before the overflow is
+		// still delivered, and after the overflow the framer resumes processing
+		// bytes after the next delimiter within the same callback.
+		t.Run("events_before_overflow_and_same_callback_resume", func(t *testing.T) {
+			host := setupStreamingHost(t, emptyAttributesConfig)
+			defer host.Reset()
+
+			first := sseEvent(`{"model":"gpt-4","usage":{"prompt_tokens":5,"completion_tokens":3,"total_tokens":8}}`)
+			oversizedTail := []byte(`data: {"pad":"` + strings.Repeat("x", maxIncompleteSSEEventBytes) + `"`)
+			deliverStreamChunk(t, host, concatStreamBytes(first, oversizedTail), false)
+			attrs := getAILogAttributes(t, host)
+			assertTokenAttrs(t, attrs, 5, 3, 8)
+
+			second := sseEvent(`{"model":"gpt-4","usage":{"prompt_tokens":5,"completion_tokens":8,"total_tokens":13}}`)
+			deliverStreamChunk(t, host, concatStreamBytes([]byte("\n\n"), second), false)
+			attrs = getAILogAttributes(t, host)
+			assertTokenAttrs(t, attrs, 5, 8, 13)
+
+			// EOS: drain() reports the single RESYNC entry via one debug log
+			// line; previously recorded values are preserved.
+			deliverStreamChunks(t, host, sseEvent("[DONE]"))
+			attrs = getAILogAttributes(t, host)
+			assertTokenAttrs(t, attrs, 5, 8, 13)
+			host.CompleteHttp()
 		})
 	})
 }

--- a/plugins/wasm-go/extensions/ai-statistics/sse_framer.go
+++ b/plugins/wasm-go/extensions/ai-statistics/sse_framer.go
@@ -1,0 +1,239 @@
+// Copyright (c) 2025 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"github.com/higress-group/wasm-go/pkg/wrapper"
+)
+
+const maxIncompleteSSEEventBytes = 1 * 1024 * 1024 // 1 MiB
+
+// maxSSEDelimiterBytes is the length of the longest event delimiter
+// ("\r\n\r\n"). A delimiter split across a callback boundary can therefore
+// have at most maxSSEDelimiterBytes-1 bytes in the previous callback, which is
+// why the RESYNC matcher carry never exceeds 3 bytes.
+const maxSSEDelimiterBytes = 4
+
+// sseFramer is a request-scoped SSE event framer. NOT safe for concurrent use;
+// one instance lives in HttpContext for the lifetime of a streaming response.
+//
+// The framer is a read-only observer: it never mutates the callback chunk and
+// never blocks the downstream response. It operates on raw bytes only (no
+// provider-specific JSON parsing) and is deliberately provider-neutral so it
+// can later be extracted to github.com/higress-group/wasm-go/pkg/sseframe with
+// a mechanical mapping: frameCallback -> (*Framer).Frame, drain ->
+// (*Framer).Drain, maxIncompleteSSEEventBytes -> WithMaxIncompleteEventBytes.
+type sseFramer struct {
+	tail          []byte // raw incomplete-event bytes (FRAMING); len <= maxIncompleteSSEEventBytes
+	resyncing     bool   // true while in RESYNC
+	resyncCarry   []byte // <= 3 bytes of delimiter-matcher state (RESYNC); never content
+	overflowCount int    // bounded diagnostic: number of RESYNC entries
+}
+
+// frameCallback scans tail‖chunk incrementally and returns the ordered complete
+// SSE events found, each normalized with wrapper.UnifySSEChunk after its
+// boundary was determined on raw bytes. The final incomplete suffix is
+// retained as the new raw tail; if it would exceed maxIncompleteSSEEventBytes
+// the framer enters RESYNC instead. In RESYNC, bytes are discarded through the
+// next delimiter and scanning resumes within the same callback.
+//
+// Postconditions: tail is nil or len(tail) <= maxIncompleteSSEEventBytes;
+// resyncCarry is nil or len(resyncCarry) <= 3.
+func (f *sseFramer) frameCallback(chunk []byte) (events [][]byte) {
+	if f.resyncing {
+		w := byteWindow{a: f.resyncCarry, b: chunk}
+		ends := w.scanEventEnds(1)
+		if len(ends) == 0 {
+			// No complete delimiter yet (it may be split across this
+			// boundary). Retain only the matcher state; discarded content is
+			// never stored.
+			f.resyncCarry = w.lastBytes(0, maxSSEDelimiterBytes-1)
+			return nil
+		}
+		// Delimiter found: discard everything through it and immediately
+		// process the remainder of this same callback as FRAMING input, so
+		// valid events following the delimiter are not lost.
+		end := ends[0]
+		f.resyncing = false
+		f.resyncCarry = nil
+		f.tail = nil
+		if end > len(w.a) {
+			chunk = chunk[end-len(w.a):]
+		}
+		// Otherwise the delimiter completed within the carry (e.g. a carried
+		// "\n\r" resolved as LF + bare CR by this chunk's first byte) and the
+		// whole chunk remains to be processed.
+	}
+
+	w := byteWindow{a: f.tail, b: chunk}
+	ends := w.scanEventEnds(0)
+	n := w.len()
+	prev := 0
+	for _, end := range ends {
+		var event []byte
+		if prev >= len(f.tail) {
+			// Event lies entirely inside the current chunk: sub-slice, no
+			// copy. The tail is delimiter-free by invariant, so only the
+			// first event of a callback can span the tail/chunk boundary.
+			event = chunk[prev-len(f.tail) : end-len(f.tail)]
+		} else {
+			// Event spans the tail/chunk boundary: materialize it, bounded
+			// by the event's actual size (complete events are not capped).
+			event = w.sliceRange(prev, end)
+		}
+		// Normalize at emission only; the retained tail is never normalized.
+		events = append(events, wrapper.UnifySSEChunk(event))
+		prev = end
+	}
+
+	// The cap applies only to the final incomplete suffix after all complete
+	// events have been emitted; it is enforced before the tail copy so the
+	// retained state never exceeds maxIncompleteSSEEventBytes.
+	switch suffixLen := n - prev; {
+	case suffixLen == 0:
+		f.tail = nil
+	case suffixLen <= maxIncompleteSSEEventBytes:
+		// Bounded copy: the tail must not alias the caller-owned chunk.
+		f.tail = w.sliceRange(prev, n)
+	default:
+		// Drop the oversized suffix and enter RESYNC. Complete events
+		// already emitted above are still delivered; only the incomplete
+		// suffix is discarded.
+		f.tail = nil
+		f.resyncing = true
+		f.resyncCarry = w.lastBytes(prev, maxSSEDelimiterBytes-1)
+		f.overflowCount++
+	}
+	return events
+}
+
+// drain is called when endOfStream == true. It discards any retained tail (an
+// unterminated event at EOS is not recoverable, including any pending trailing
+// '\r') and returns overflowCount.
+func (f *sseFramer) drain() (overflowCount int) {
+	f.tail = nil
+	f.resyncing = false
+	f.resyncCarry = nil
+	return f.overflowCount
+}
+
+// byteWindow is a read-only view over the virtual concatenation a‖b. It lets
+// the scanner run index arithmetic over the retained tail (or RESYNC carry)
+// and the current callback chunk without materializing a combined buffer.
+type byteWindow struct {
+	a []byte // prefix: retained tail (FRAMING) or resyncCarry (RESYNC)
+	b []byte // current callback chunk
+}
+
+func (w byteWindow) len() int { return len(w.a) + len(w.b) }
+
+func (w byteWindow) at(i int) byte {
+	if i < len(w.a) {
+		return w.a[i]
+	}
+	return w.b[i-len(w.a)]
+}
+
+// lineEndingEnd classifies the line ending starting at offset i, whose byte
+// must be '\r' or '\n', and returns the offset just past it:
+//   - '\n'            -> i+1 (LF)
+//   - '\r' + '\n'     -> i+2 (CRLF)
+//   - '\r' + any other -> i+1 (bare CR line ending, per the SSE spec)
+//
+// pending is true when the byte at i is a '\r' at the very end of the window:
+// the CR is not yet classifiable (it may be the first half of a CRLF), so the
+// caller must stop scanning and leave the CR unclassified in the tail until
+// the next callback's first byte arrives.
+func (w byteWindow) lineEndingEnd(i int) (end int, pending bool) {
+	if w.at(i) == '\n' {
+		return i + 1, false
+	}
+	if i+1 == w.len() {
+		return i, true
+	}
+	if w.at(i+1) == '\n' {
+		return i + 2, false
+	}
+	return i + 1, false
+}
+
+// scanEventEnds scans the window from offset 0 and returns the end offset of
+// each complete event, where a complete event includes its terminating
+// delimiter: two consecutive line endings ("\n\n", "\r\n\r\n", the mixed forms
+// "\n\r\n"/"\r\n\n", and forms involving bare CR line endings). At most limit
+// offsets are returned when limit > 0. Everything after the last returned
+// offset is the incomplete suffix: bytes containing no full delimiter yet,
+// possibly ending in a pending '\r' whose classification depends on the next
+// callback.
+func (w byteWindow) scanEventEnds(limit int) []int {
+	var ends []int
+	n := w.len()
+	pos := 0
+	for pos < n {
+		c := w.at(pos)
+		if c != '\n' && c != '\r' {
+			pos++
+			continue
+		}
+		firstEnd, pending := w.lineEndingEnd(pos)
+		if pending {
+			break
+		}
+		if firstEnd < n {
+			if c2 := w.at(firstEnd); c2 == '\n' || c2 == '\r' {
+				secondEnd, pending := w.lineEndingEnd(firstEnd)
+				if pending {
+					break
+				}
+				// Two consecutive line endings: event delimiter.
+				ends = append(ends, secondEnd)
+				if limit > 0 && len(ends) >= limit {
+					return ends
+				}
+				pos = secondEnd
+				continue
+			}
+		}
+		pos = firstEnd
+	}
+	return ends
+}
+
+// sliceRange returns a fresh copy of w[from:to]. Used for the retained tail,
+// the RESYNC carry, and boundary-spanning events; the results must never alias
+// the caller-owned chunk (the host reuses that buffer across callbacks).
+func (w byteWindow) sliceRange(from, to int) []byte {
+	out := make([]byte, 0, to-from)
+	if from >= len(w.a) {
+		return append(out, w.b[from-len(w.a):to-len(w.a)]...)
+	}
+	if to <= len(w.a) {
+		return append(out, w.a[from:to]...)
+	}
+	out = append(out, w.a[from:]...)
+	return append(out, w.b[:to-len(w.a)]...)
+}
+
+// lastBytes returns a fresh copy of the last min(k, len-from) bytes of
+// w[from:]. It derives the <= 3-byte RESYNC matcher carry from a dropped
+// suffix (or from the not-yet-matched carry‖chunk window).
+func (w byteWindow) lastBytes(from, k int) []byte {
+	n := w.len()
+	start := n - k
+	if start < from {
+		start = from
+	}
+	return w.sliceRange(start, n)
+}

--- a/plugins/wasm-go/extensions/ai-statistics/sse_framer_test.go
+++ b/plugins/wasm-go/extensions/ai-statistics/sse_framer_test.go
@@ -1,0 +1,483 @@
+// Copyright (c) 2025 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/higress-group/wasm-go/pkg/wrapper"
+	"github.com/stretchr/testify/require"
+)
+
+// sseUsageEvent is a realistic ~220-byte single-line OpenAI-style usage event
+// (including its "\n\n" delimiter) used for split/reassembly tests.
+var sseUsageEvent = []byte(`data: {"id":"chatcmpl-1","object":"chat.completion.chunk","created":1700000000,"model":"gpt-4o","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":10,"completion_tokens":20,"total_tokens":30}}` + "\n\n")
+
+// frameChecked feeds one callback through the framer and asserts the pinned
+// postconditions after every callback (Design T-22): the retained tail never
+// exceeds maxIncompleteSSEEventBytes and the RESYNC carry never exceeds 3
+// bytes. It also asserts the structural invariants that the carry exists only
+// while resyncing and that no tail is retained while resyncing.
+func frameChecked(t *testing.T, f *sseFramer, chunk []byte) [][]byte {
+	t.Helper()
+	events := f.frameCallback(chunk)
+	require.LessOrEqualf(t, len(f.tail), maxIncompleteSSEEventBytes, "tail len %d exceeds cap", len(f.tail))
+	require.LessOrEqualf(t, len(f.resyncCarry), maxSSEDelimiterBytes-1, "resyncCarry len %d exceeds 3", len(f.resyncCarry))
+	if f.resyncing {
+		require.Nil(t, f.tail, "tail must be nil while resyncing")
+	} else {
+		require.Nil(t, f.resyncCarry, "resyncCarry must be nil while framing")
+	}
+	return events
+}
+
+// T-01 (framer level): a single intact event in one callback is emitted
+// immediately; CRLF forms are normalized at emission only.
+func TestSseFramerSingleIntactEvent(t *testing.T) {
+	t.Run("lf", func(t *testing.T) {
+		f := &sseFramer{}
+		chunk := []byte("data: a\n\n")
+		orig := append([]byte(nil), chunk...)
+		events := frameChecked(t, f, chunk)
+		require.Equal(t, [][]byte{[]byte("data: a\n\n")}, events)
+		require.Equal(t, orig, chunk, "framer must not mutate the callback chunk")
+		require.Nil(t, f.tail)
+	})
+	t.Run("crlf_normalized_at_emission", func(t *testing.T) {
+		f := &sseFramer{}
+		events := frameChecked(t, f, []byte("data: a\r\nb\r\n\r\n"))
+		require.Equal(t, [][]byte{[]byte("data: a\nb\n\n")}, events)
+		require.Nil(t, f.tail)
+	})
+}
+
+// T-02 (framer level): splits inside the JSON body at the pinned offsets
+// (50/100/120/130/140 of the ~220-byte event) reassemble to the intact event;
+// exhaustively verified for every split offset.
+func TestSseFramerSplitInsideJSONBody(t *testing.T) {
+	require.Greater(t, len(sseUsageEvent), 141, "test event must cover the pinned offsets")
+	for _, off := range []int{50, 100, 120, 130, 140} {
+		t.Run(fmt.Sprintf("offset_%d", off), func(t *testing.T) {
+			f := &sseFramer{}
+			require.Empty(t, frameChecked(t, f, sseUsageEvent[:off]))
+			events := frameChecked(t, f, sseUsageEvent[off:])
+			require.Equal(t, [][]byte{wrapper.UnifySSEChunk(sseUsageEvent)}, events)
+		})
+	}
+	t.Run("every_offset", func(t *testing.T) {
+		for off := 1; off < len(sseUsageEvent); off++ {
+			f := &sseFramer{}
+			frameChecked(t, f, sseUsageEvent[:off])
+			events := frameChecked(t, f, sseUsageEvent[off:])
+			require.Equalf(t, [][]byte{wrapper.UnifySSEChunk(sseUsageEvent)}, events, "split at offset %d", off)
+		}
+	})
+}
+
+// T-03 (framer level): a split inside the "data:" prefix reassembles by byte
+// shape, not by "data:" parsing.
+func TestSseFramerSplitInsideDataPrefix(t *testing.T) {
+	f := &sseFramer{}
+	require.Empty(t, frameChecked(t, f, []byte("da")))
+	events := frameChecked(t, f, []byte("ta: {\"usage\":{\"total_tokens\":30}}\n\n"))
+	require.Equal(t, [][]byte{[]byte("data: {\"usage\":{\"total_tokens\":30}}\n\n")}, events)
+}
+
+// T-04 (framer level): an LF delimiter split across callbacks emits the event
+// only after the second "\n" arrives.
+func TestSseFramerLFDelimiterSplit(t *testing.T) {
+	f := &sseFramer{}
+	require.Empty(t, frameChecked(t, f, []byte("data: a\n")))
+	require.Equal(t, []byte("data: a\n"), f.tail, "raw tail retained un-normalized")
+	events := frameChecked(t, f, []byte("\n"))
+	require.Equal(t, [][]byte{[]byte("data: a\n\n")}, events)
+	require.Nil(t, f.tail)
+}
+
+// T-05 (framer level): a CRLF delimiter split at every byte boundary is
+// recognized and the event is emitted exactly once.
+func TestSseFramerCRLFDelimiterSplitEveryBoundary(t *testing.T) {
+	normalized := []byte("data: a\n\n")
+	splits := []struct {
+		name          string
+		first, second string
+	}{
+		{"after_cr", "data: a\r", "\n\r\n"},
+		{"after_crlf", "data: a\r\n", "\r\n"},
+		{"after_crlf_cr", "data: a\r\n\r", "\n"},
+	}
+	for _, tc := range splits {
+		t.Run(tc.name, func(t *testing.T) {
+			f := &sseFramer{}
+			require.Empty(t, frameChecked(t, f, []byte(tc.first)))
+			events := frameChecked(t, f, []byte(tc.second))
+			require.Equal(t, [][]byte{normalized}, events)
+			require.Nil(t, f.tail)
+		})
+	}
+}
+
+// Exhaustive boundary sweep (T-05/T-06 framer level): a two-event CRLF stream
+// with a mid-event CRLF line ending, split at every byte offset, always
+// yields the same two normalized events.
+func TestSseFramerCRLFStreamSplitEveryBoundary(t *testing.T) {
+	stream := []byte("data: one\r\n\r\ndata: two\r\nthree\r\n\r\n")
+	want := [][]byte{[]byte("data: one\n\n"), []byte("data: two\nthree\n\n")}
+	for off := 0; off <= len(stream); off++ {
+		f := &sseFramer{}
+		var got [][]byte
+		got = append(got, frameChecked(t, f, stream[:off])...)
+		got = append(got, frameChecked(t, f, stream[off:])...)
+		require.Equalf(t, want, got, "split at offset %d", off)
+		require.Nilf(t, f.tail, "split at offset %d", off)
+	}
+}
+
+// T-06 (framer level): a CRLF line ending split mid-event ("...foo\r" |
+// "\nbar...") must NOT produce a false event boundary (regression for
+// premature normalization of a trailing raw CR).
+func TestSseFramerCRLFLineEndingSplitMidEvent(t *testing.T) {
+	f := &sseFramer{}
+	require.Empty(t, frameChecked(t, f, []byte("data: foo\r")))
+	events := frameChecked(t, f, []byte("\nbar\r\n\r\n"))
+	require.Equal(t, [][]byte{[]byte("data: foo\nbar\n\n")}, events)
+	require.Nil(t, f.tail)
+}
+
+// T-07 (framer level): a trailing raw '\r' is held un-normalized in the tail
+// and classified when the next callback's first byte arrives.
+func TestSseFramerPendingTrailingCR(t *testing.T) {
+	t.Run("classified_as_crlf", func(t *testing.T) {
+		f := &sseFramer{}
+		require.Empty(t, frameChecked(t, f, []byte("data: a\r")))
+		require.Equal(t, []byte("data: a\r"), f.tail, "trailing CR stays raw and unclassified")
+		// "\n" completes the CRLF line ending; it is not yet a delimiter.
+		require.Empty(t, frameChecked(t, f, []byte("\n")))
+		require.Equal(t, []byte("data: a\r\n"), f.tail, "tail is never normalized")
+		events := frameChecked(t, f, []byte("\n"))
+		require.Equal(t, [][]byte{[]byte("data: a\n\n")}, events)
+	})
+	t.Run("classified_as_bare_cr", func(t *testing.T) {
+		f := &sseFramer{}
+		require.Empty(t, frameChecked(t, f, []byte("data: a\r")))
+		require.Equal(t, []byte("data: a\r"), f.tail)
+		// A non-"\n" first byte classifies the CR as a bare CR line ending
+		// (SSE spec): a mid-event line break, not a delimiter.
+		events := frameChecked(t, f, []byte("b\n\n"))
+		require.Equal(t, [][]byte{[]byte("data: a\nb\n\n")}, events)
+	})
+}
+
+// T-08 (framer level): one callback larger than 1 MiB containing many complete
+// small events emits all of them in order and does NOT enter RESYNC; the cap
+// applies only to the final incomplete suffix.
+func TestSseFramerLargeCallbackOfCompleteEvents(t *testing.T) {
+	event := []byte("data: " + strings.Repeat("x", 1016) + "\n\n") // 1024 bytes
+	const count = 2049                                             // > 2 MiB of complete events
+	buf := make([]byte, 0, len(event)*count)
+	for i := 0; i < count; i++ {
+		buf = append(buf, event...)
+	}
+	buf = append(buf, []byte("data: incomplete-tail")...)
+	require.Greater(t, len(buf), maxIncompleteSSEEventBytes)
+
+	f := &sseFramer{}
+	events := frameChecked(t, f, buf)
+	require.Len(t, events, count)
+	for i, ev := range events {
+		require.Equalf(t, event, ev, "event %d", i)
+	}
+	require.False(t, f.resyncing, "a large callback of complete events must not trigger RESYNC")
+	require.Equal(t, 0, f.overflowCount)
+	require.Equal(t, []byte("data: incomplete-tail"), f.tail)
+}
+
+// Multiple events in one callback are emitted in stream order; mixed
+// delimiter forms ("\n\n", "\r\n\r\n", "\n\r\n", "\r\n\n") are recognized.
+func TestSseFramerMultipleEventsOneCallback(t *testing.T) {
+	f := &sseFramer{}
+	events := frameChecked(t, f, []byte("data: 1\n\ndata: 2\r\n\r\ndata: 3\n\r\ndata: 4\r\n\n"))
+	require.Equal(t, [][]byte{
+		[]byte("data: 1\n\n"),
+		[]byte("data: 2\n\n"),
+		[]byte("data: 3\n\n"),
+		[]byte("data: 4\n\n"),
+	}, events)
+	require.Nil(t, f.tail)
+}
+
+// T-23 (framer level): one event delivered across many 1-byte callbacks is
+// emitted exactly once, on the completing callback.
+func TestSseFramerOneEventAcrossOneByteCallbacks(t *testing.T) {
+	t.Run("lf", func(t *testing.T) {
+		f := &sseFramer{}
+		var got [][]byte
+		for i := 0; i < len(sseUsageEvent); i++ {
+			events := frameChecked(t, f, sseUsageEvent[i:i+1])
+			if i < len(sseUsageEvent)-1 {
+				require.Emptyf(t, events, "callback %d emitted prematurely", i)
+			} else {
+				got = events
+			}
+		}
+		require.Equal(t, [][]byte{wrapper.UnifySSEChunk(sseUsageEvent)}, got)
+		require.Nil(t, f.tail)
+	})
+	t.Run("crlf_pending_cr_every_step", func(t *testing.T) {
+		stream := []byte("data: a\r\nb\r\n\r\n")
+		want := []byte("data: a\nb\n\n")
+		f := &sseFramer{}
+		var got [][]byte
+		for i := 0; i < len(stream); i++ {
+			events := frameChecked(t, f, stream[i:i+1])
+			if i < len(stream)-1 {
+				require.Emptyf(t, events, "callback %d emitted prematurely", i)
+			} else {
+				got = events
+			}
+		}
+		require.Equal(t, [][]byte{want}, got)
+	})
+}
+
+// T-25 (framer level): an incomplete suffix of exactly 1 MiB is retained as
+// the tail (no RESYNC); the completed event (larger than the cap) is still
+// delivered once its delimiter arrives, because the cap applies only to the
+// retained suffix, never to complete events.
+func TestSseFramerSuffixExactlyOneMiB(t *testing.T) {
+	f := &sseFramer{}
+	suffix := make([]byte, maxIncompleteSSEEventBytes)
+	copy(suffix, "data: ")
+	for i := 6; i < len(suffix); i++ {
+		suffix[i] = 'a'
+	}
+	require.Empty(t, frameChecked(t, f, suffix))
+	require.False(t, f.resyncing)
+	require.Equal(t, 0, f.overflowCount)
+	require.Len(t, f.tail, maxIncompleteSSEEventBytes)
+	require.Equal(t, suffix, f.tail)
+
+	intact := append(append([]byte(nil), suffix...), '\n', '\n')
+	events := frameChecked(t, f, []byte("\n\n"))
+	require.Equal(t, [][]byte{wrapper.UnifySSEChunk(intact)}, events)
+	require.Nil(t, f.tail)
+}
+
+// T-26 (framer level): an incomplete suffix of 1 MiB+1 enters RESYNC (suffix
+// dropped, tail nil, carry <= 3 bytes); a subsequent valid event after the
+// next delimiter is still recovered.
+func TestSseFramerSuffixOneMiBPlusOne(t *testing.T) {
+	f := &sseFramer{}
+	suffix := make([]byte, maxIncompleteSSEEventBytes+1)
+	copy(suffix, "data: ")
+	for i := 6; i < len(suffix); i++ {
+		suffix[i] = 'a'
+	}
+	require.Empty(t, frameChecked(t, f, suffix))
+	require.True(t, f.resyncing)
+	require.Nil(t, f.tail)
+	require.Equal(t, 1, f.overflowCount)
+	require.Equal(t, []byte("aaa"), f.resyncCarry)
+
+	events := frameChecked(t, f, []byte("bbb\n\ndata: ok\n\n"))
+	require.Equal(t, [][]byte{[]byte("data: ok\n\n")}, events)
+	require.False(t, f.resyncing)
+	require.Nil(t, f.tail)
+	require.Equal(t, 1, f.drain())
+}
+
+// T-13 + T-14 (framer level): when a callback emits complete events and then
+// overflows on the final suffix, the complete events are still delivered; and
+// after the overflow, a delimiter arriving mid-callback followed by valid
+// events emits those events from that same callback.
+func TestSseFramerOversizedSuffixResumeSameCallback(t *testing.T) {
+	f := &sseFramer{}
+	big := make([]byte, 0, maxIncompleteSSEEventBytes+16)
+	big = append(big, []byte("data: first\n\n")...)
+	big = append(big, []byte("data: ")...)
+	for len(big) < maxIncompleteSSEEventBytes+16 {
+		big = append(big, 'a')
+	}
+	events := frameChecked(t, f, big)
+	require.Equal(t, [][]byte{[]byte("data: first\n\n")}, events,
+		"complete events emitted before the overflow are still delivered")
+	require.True(t, f.resyncing)
+	require.Equal(t, 1, f.overflowCount)
+
+	// The delimiter arrives mid-callback, followed by valid events.
+	events = frameChecked(t, f, []byte("aa\n\ndata: second\n\ndata: third\n\n"))
+	require.Equal(t, [][]byte{[]byte("data: second\n\n"), []byte("data: third\n\n")}, events,
+		"valid events after the delimiter must be emitted from the same callback")
+	require.False(t, f.resyncing)
+	require.Nil(t, f.tail)
+}
+
+// T-15 (framer level): while in RESYNC, a delimiter split across callbacks is
+// recognized; processing resumes only after the full delimiter.
+func TestSseFramerResyncDelimiterSplitAcrossCallbacks(t *testing.T) {
+	newOverflowedFramer := func(t *testing.T, suffixEnd []byte) *sseFramer {
+		f := &sseFramer{}
+		big := make([]byte, maxIncompleteSSEEventBytes+1)
+		for i := range big {
+			big[i] = 'a'
+		}
+		copy(big, "data: ")
+		copy(big[len(big)-len(suffixEnd):], suffixEnd)
+		require.Empty(t, frameChecked(t, f, big))
+		require.True(t, f.resyncing)
+		require.Equal(t, 1, f.overflowCount)
+		return f
+	}
+
+	t.Run("crlf_cr_then_lf", func(t *testing.T) {
+		// Suffix ends with "\r\n\r"; the delimiter completes only when the
+		// next callback's "\n" arrives.
+		f := newOverflowedFramer(t, []byte("\r\n\r"))
+		require.Equal(t, []byte("\r\n\r"), f.resyncCarry)
+		require.Empty(t, frameChecked(t, f, []byte("\n")))
+		require.False(t, f.resyncing)
+		events := frameChecked(t, f, []byte("data: ok\n\n"))
+		require.Equal(t, [][]byte{[]byte("data: ok\n\n")}, events)
+	})
+	t.Run("lf_then_lf", func(t *testing.T) {
+		f := newOverflowedFramer(t, []byte("x"))
+		// A single LF is not a delimiter: still resyncing.
+		require.Empty(t, frameChecked(t, f, []byte("\n")))
+		require.True(t, f.resyncing)
+		events := frameChecked(t, f, []byte("\ndata: ok\n\n"))
+		require.Equal(t, [][]byte{[]byte("data: ok\n\n")}, events)
+		require.False(t, f.resyncing)
+	})
+	t.Run("cr_then_split_crlf_crlf", func(t *testing.T) {
+		f := newOverflowedFramer(t, []byte("\r"))
+		// "\r\n" + a pending "\r": not a full delimiter yet, no resume.
+		require.Empty(t, frameChecked(t, f, []byte("\n\r")))
+		require.True(t, f.resyncing)
+		// "\r\n\r\n" completes across three callbacks.
+		require.Empty(t, frameChecked(t, f, []byte("\n")))
+		require.False(t, f.resyncing)
+		events := frameChecked(t, f, []byte("data: ok\n\n"))
+		require.Equal(t, [][]byte{[]byte("data: ok\n\n")}, events)
+	})
+}
+
+// T-24 (framer level): at end-of-stream, drain discards an incomplete tail
+// (including a pending '\r') without fabricating an event; input remaining at
+// EOS while resyncing is discarded as well.
+func TestSseFramerDrainDiscardsIncompleteTail(t *testing.T) {
+	t.Run("partial_event", func(t *testing.T) {
+		f := &sseFramer{}
+		events := frameChecked(t, f, []byte("data: done\n\ndata: partial"))
+		require.Equal(t, [][]byte{[]byte("data: done\n\n")}, events)
+		require.Equal(t, []byte("data: partial"), f.tail)
+		require.Equal(t, 0, f.drain())
+		require.Nil(t, f.tail, "unterminated event at EOS is discarded, not emitted")
+		require.False(t, f.resyncing)
+	})
+	t.Run("pending_cr", func(t *testing.T) {
+		f := &sseFramer{}
+		require.Empty(t, frameChecked(t, f, []byte("data: x\r")))
+		require.Equal(t, []byte("data: x\r"), f.tail)
+		require.Equal(t, 0, f.drain())
+		require.Nil(t, f.tail)
+	})
+	t.Run("while_resyncing", func(t *testing.T) {
+		f := &sseFramer{}
+		big := make([]byte, maxIncompleteSSEEventBytes+1)
+		for i := range big {
+			big[i] = 'a'
+		}
+		require.Empty(t, frameChecked(t, f, big))
+		require.True(t, f.resyncing)
+		require.Empty(t, frameChecked(t, f, []byte("still no delimiter")))
+		require.Equal(t, 1, f.drain())
+		require.False(t, f.resyncing)
+		require.Nil(t, f.resyncCarry)
+	})
+}
+
+// T-21 (framer level): drain returns the number of RESYNC entries.
+func TestSseFramerDrainReturnsOverflowCount(t *testing.T) {
+	f := &sseFramer{}
+	overflow := func() {
+		big := make([]byte, maxIncompleteSSEEventBytes+1)
+		for i := range big {
+			big[i] = 'a'
+		}
+		require.Empty(t, frameChecked(t, f, big))
+		require.True(t, f.resyncing)
+	}
+	overflow()
+	// Resume through a delimiter, then overflow a second time.
+	require.Empty(t, frameChecked(t, f, []byte("\n\n")))
+	require.False(t, f.resyncing)
+	overflow()
+	require.Equal(t, 2, f.drain())
+}
+
+// The retained tail is a bounded copy: mutating a delivered chunk (the host
+// reuses callback buffers) must not corrupt retained state.
+func TestSseFramerTailDoesNotAliasChunk(t *testing.T) {
+	f := &sseFramer{}
+	chunk1 := []byte("data: abc")
+	require.Empty(t, frameChecked(t, f, chunk1))
+	for i := range chunk1 {
+		chunk1[i] = 'X'
+	}
+	events := frameChecked(t, f, []byte("def\n\n"))
+	require.Equal(t, [][]byte{[]byte("data: abcdef\n\n")}, events)
+}
+
+// Bare CR line endings (SSE spec): a '\r' not followed by '\n' is one line
+// ending; two consecutive line endings involving bare CRs still delimit an
+// event. This follows from the pinned pending-CR classification rule.
+func TestSseFramerBareCRLineEndings(t *testing.T) {
+	t.Run("lf_then_bare_cr_split", func(t *testing.T) {
+		f := &sseFramer{}
+		require.Empty(t, frameChecked(t, f, []byte("data: a\n\r")))
+		require.Equal(t, []byte("data: a\n\r"), f.tail)
+		events := frameChecked(t, f, []byte("x\n\n"))
+		require.Equal(t, [][]byte{[]byte("data: a\n\n"), []byte("x\n\n")}, events)
+	})
+	t.Run("cr_cr_single_callback", func(t *testing.T) {
+		f := &sseFramer{}
+		events := frameChecked(t, f, []byte("data: a\r\rb\n\n"))
+		require.Equal(t, [][]byte{[]byte("data: a\n\n"), []byte("b\n\n")}, events)
+	})
+}
+
+// Byte-shape only: empty events and comment (keepalive) events are emitted
+// as-is; consumers gate on content.
+func TestSseFramerEmptyAndCommentEvents(t *testing.T) {
+	f := &sseFramer{}
+	events := frameChecked(t, f, []byte("\n\n: keepalive\r\n\r\n"))
+	require.Equal(t, [][]byte{[]byte("\n\n"), []byte(": keepalive\n\n")}, events)
+	require.Nil(t, f.tail)
+}
+
+// Empty callbacks are no-ops and do not disturb retained state.
+func TestSseFramerEmptyChunk(t *testing.T) {
+	f := &sseFramer{}
+	require.Empty(t, frameChecked(t, f, nil))
+	require.Nil(t, f.tail)
+	require.Empty(t, frameChecked(t, f, []byte("data: a\n")))
+	require.Equal(t, []byte("data: a\n"), f.tail)
+	require.Empty(t, frameChecked(t, f, nil))
+	require.Equal(t, []byte("data: a\n"), f.tail)
+	events := frameChecked(t, f, []byte("\n"))
+	require.Equal(t, [][]byte{[]byte("data: a\n\n")}, events)
+}


### PR DESCRIPTION
## Summary

Fixes #4146: streaming requests through `/v1/messages` against OpenAI-compatible upstreams intermittently recorded `input_token`/`output_token`/`total_token` = 0 because `ai-statistics` ran token-usage and stream-error parsing directly on each arbitrary host byte chunk. One `onHttpStreamingBody` callback is not a complete SSE event.

- Adds a request-scoped SSE event framer (`sse_framer.go`): raw-byte incremental scanning with correct LF/CRLF boundary handling (pending-CR), a suffix-only 1 MiB incomplete-tail bound, and delimiter resynchronization that resumes within the same callback.
- Routes exactly two consumers over framed complete events: token usage (with final-state-wins and token-details retain/replace semantics against real `tokenusage.GetTokenUsage`) and stream-error detection (split error events now reassemble and produce exactly one `llm_failure_count` increment).
- Fail-open: a local panic-recovery boundary guarantees `onHttpStreamingBody` always returns the original `data` unchanged; retained state is bounded at 1 MiB per request.
- ChatID extraction, tool-call extraction, full-body JSONPath, and `writeMetric` stay on their existing paths (no duplicate tool-call arguments).

Workflow artifacts: Proposal #4248, confirmed SPEC-4248001, Design #4249, Implement #4263. Follow-up Issue #4264 tracks extracting the shared `wasm-go/pkg/sseframe` utility (release sequence pinned in Design §Follow-up). Independent review: APPROVE (no P1/P2 findings).

## Test plan

- [x] `go vet ./...` clean
- [x] `go test ./... -count=1` in `plugins/wasm-go/extensions/ai-statistics` — ok (full suite incl. 18 framer unit tests and new integration tests covering Design matrix T-01..T-26: splits at every byte boundary for LF/CRLF delimiters, >1 MiB callback of complete events, 1 MiB / 1 MiB+1 boundaries, RESYNC same-callback resume, split error event exactly-once, no duplicate tool calls, panic fail-open, buffering disabled, #4145 unchanged)
- [ ] Maintainer review

<!-- issue-spec:pr-close-issues version=1 -->
Issue-spec managed closing links:
Closes #4248
Closes #4249
Closes #4263
<!-- /issue-spec:pr-close-issues -->
