### PR TITLE
fix(ai-proxy): preserve Gemini function calls

### DIFF
--- a/plugins/wasm-go/extensions/ai-proxy/provider/gemini.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/gemini.go
@@ -752,28 +752,37 @@ func (g *geminiProvider) buildChatCompletionResponse(ctx wrapper.HttpContext, re
 			TotalTokens:      response.UsageMetadata.TotalTokenCount,
 		},
 	}
-	choiceIndex := 0
 	for _, candidate := range response.Candidates {
-		for _, part := range candidate.Content.Parts {
-			choice := chatCompletionChoice{
-				Index: choiceIndex,
-				Message: &chatMessage{
-					Role: roleAssistant,
-				},
-				FinishReason: util.Ptr(finishReasonStop),
-			}
-			if part.FunctionCall != nil {
-				choice.Message.ToolCalls = g.buildToolCalls(&candidate)
-			} else if part.InlineData != nil {
-				choice.Message.Content = part.InlineData.Data
-			} else {
-				choice.Message.Content = part.Text
-			}
-
-			choice.FinishReason = util.Ptr(strings.ToLower(candidate.FinishReason))
-			fullTextResponse.Choices = append(fullTextResponse.Choices, choice)
-			choiceIndex += 1
+		if len(candidate.Content.Parts) == 0 {
+			continue
 		}
+		choice := chatCompletionChoice{
+			Index: int(candidate.Index),
+			Message: &chatMessage{
+				Role: roleAssistant,
+			},
+			FinishReason: util.Ptr(strings.ToLower(candidate.FinishReason)),
+		}
+		var content strings.Builder
+		for _, part := range candidate.Content.Parts {
+			switch {
+			case part.FunctionCall != nil:
+				// Function calls are collected below so that one Gemini candidate
+				// remains one OpenAI choice even when it contains multiple calls.
+			case part.InlineData != nil:
+				content.WriteString(part.InlineData.Data)
+			default:
+				content.WriteString(part.Text)
+			}
+		}
+		if content.Len() > 0 {
+			choice.Message.Content = content.String()
+		}
+		choice.Message.ToolCalls = g.buildToolCalls(&candidate)
+		if len(choice.Message.ToolCalls) > 0 {
+			choice.FinishReason = util.Ptr(finishReasonToolCall)
+		}
+		fullTextResponse.Choices = append(fullTextResponse.Choices, choice)
 	}
 	return &fullTextResponse
 }
@@ -781,24 +790,25 @@ func (g *geminiProvider) buildChatCompletionResponse(ctx wrapper.HttpContext, re
 func (g *geminiProvider) buildToolCalls(candidate *geminiChatCandidate) []toolCall {
 	var toolCalls []toolCall
 
-	item := candidate.Content.Parts[0]
-	if item.FunctionCall != nil {
-		return toolCalls
+	for _, item := range candidate.Content.Parts {
+		if item.FunctionCall == nil {
+			continue
+		}
+		argsBytes, err := json.Marshal(item.FunctionCall.Arguments)
+		if err != nil {
+			log.Errorf("get toolCalls from gemini response failed: " + err.Error())
+			continue
+		}
+		toolCalls = append(toolCalls, toolCall{
+			Index: len(toolCalls),
+			Id:    fmt.Sprintf("call_%s", uuid.New().String()),
+			Type:  "function",
+			Function: functionCall{
+				Arguments: string(argsBytes),
+				Name:      item.FunctionCall.FunctionName,
+			},
+		})
 	}
-	argsBytes, err := json.Marshal(item.FunctionCall.Arguments)
-	if err != nil {
-		log.Errorf("get toolCalls from gemini response failed: " + err.Error())
-		return toolCalls
-	}
-	toolCall := toolCall{
-		Id:   fmt.Sprintf("call_%s", uuid.New().String()),
-		Type: "function",
-		Function: functionCall{
-			Arguments: string(argsBytes),
-			Name:      item.FunctionCall.FunctionName,
-		},
-	}
-	toolCalls = append(toolCalls, toolCall)
 	return toolCalls
 }
 

--- a/plugins/wasm-go/extensions/ai-proxy/provider/gemini_test.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/gemini_test.go
@@ -1,0 +1,177 @@
+// Copyright (c) 2026 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provider
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGeminiBuildChatCompletionResponseFunctionCalls(t *testing.T) {
+	provider := &geminiProvider{}
+	response := provider.buildChatCompletionResponse(newMockMultipartHttpContext(), &geminiChatResponse{
+		Candidates: []geminiChatCandidate{
+			{
+				Index:        0,
+				FinishReason: "STOP",
+				Content: geminiChatContent{
+					Parts: []geminiPart{
+						{FunctionCall: &geminiFunctionCall{
+							FunctionName: "get_weather",
+							Arguments:    map[string]any{"city": "Hangzhou"},
+						}},
+						{FunctionCall: &geminiFunctionCall{
+							FunctionName: "get_time",
+							Arguments:    map[string]any{"timezone": "Asia/Shanghai"},
+						}},
+					},
+				},
+			},
+		},
+	})
+
+	require.Len(t, response.Choices, 1)
+	choice := response.Choices[0]
+	require.NotNil(t, choice.Message)
+	require.Len(t, choice.Message.ToolCalls, 2)
+	assert.Equal(t, "get_weather", choice.Message.ToolCalls[0].Function.Name)
+	assert.JSONEq(t, `{"city":"Hangzhou"}`, choice.Message.ToolCalls[0].Function.Arguments)
+	assert.Equal(t, 0, choice.Message.ToolCalls[0].Index)
+	assert.Equal(t, "get_time", choice.Message.ToolCalls[1].Function.Name)
+	assert.JSONEq(t, `{"timezone":"Asia/Shanghai"}`, choice.Message.ToolCalls[1].Function.Arguments)
+	assert.Equal(t, 1, choice.Message.ToolCalls[1].Index)
+	assert.NotEmpty(t, choice.Message.ToolCalls[0].Id)
+	assert.NotEmpty(t, choice.Message.ToolCalls[1].Id)
+	assert.NotEqual(t, choice.Message.ToolCalls[0].Id, choice.Message.ToolCalls[1].Id)
+	require.NotNil(t, choice.FinishReason)
+	assert.Equal(t, finishReasonToolCall, *choice.FinishReason)
+}
+
+func TestGeminiBuildChatCompletionResponseMixedParts(t *testing.T) {
+	provider := &geminiProvider{}
+	response := provider.buildChatCompletionResponse(newMockMultipartHttpContext(), &geminiChatResponse{
+		Candidates: []geminiChatCandidate{
+			{
+				Index:        0,
+				FinishReason: "STOP",
+				Content: geminiChatContent{
+					Parts: []geminiPart{
+						{Text: "Let me check. "},
+						{FunctionCall: &geminiFunctionCall{
+							FunctionName: "lookup",
+							Arguments:    map[string]any{"id": float64(42)},
+						}},
+						{Text: "One moment."},
+					},
+				},
+			},
+		},
+	})
+
+	require.Len(t, response.Choices, 1)
+	choice := response.Choices[0]
+	require.NotNil(t, choice.Message)
+	assert.Equal(t, "Let me check. One moment.", choice.Message.Content)
+	require.Len(t, choice.Message.ToolCalls, 1)
+	assert.Equal(t, "lookup", choice.Message.ToolCalls[0].Function.Name)
+	assert.JSONEq(t, `{"id":42}`, choice.Message.ToolCalls[0].Function.Arguments)
+}
+
+func TestGeminiBuildChatCompletionResponseSkipsEmptyCandidateAndPreservesInlineData(t *testing.T) {
+	provider := &geminiProvider{}
+	response := provider.buildChatCompletionResponse(newMockMultipartHttpContext(), &geminiChatResponse{
+		Candidates: []geminiChatCandidate{
+			{
+				Index:   0,
+				Content: geminiChatContent{},
+			},
+			{
+				Index:        1,
+				FinishReason: "STOP",
+				Content: geminiChatContent{
+					Parts: []geminiPart{
+						{InlineData: &geminiInlineData{
+							MimeType: "text/plain",
+							Data:     "inline-data",
+						}},
+					},
+				},
+			},
+		},
+	})
+
+	require.Len(t, response.Choices, 1)
+	assert.Equal(t, 1, response.Choices[0].Index)
+	require.NotNil(t, response.Choices[0].Message)
+	assert.Equal(t, "inline-data", response.Choices[0].Message.Content)
+	assert.Empty(t, response.Choices[0].Message.ToolCalls)
+}
+
+func TestGeminiBuildToolCallsSkipsUnmarshalableArguments(t *testing.T) {
+	provider := &geminiProvider{}
+	candidate := &geminiChatCandidate{
+		Content: geminiChatContent{
+			Parts: []geminiPart{
+				{FunctionCall: &geminiFunctionCall{
+					FunctionName: "invalid",
+					Arguments:    make(chan int),
+				}},
+				{FunctionCall: &geminiFunctionCall{
+					FunctionName: "valid",
+					Arguments:    map[string]any{"id": float64(42)},
+				}},
+			},
+		},
+	}
+
+	calls := provider.buildToolCalls(candidate)
+
+	require.Len(t, calls, 1)
+	assert.Equal(t, 0, calls[0].Index)
+	assert.Equal(t, "valid", calls[0].Function.Name)
+	assert.JSONEq(t, `{"id":42}`, calls[0].Function.Arguments)
+}
+
+func TestGeminiTransformResponseBodyFunctionCall(t *testing.T) {
+	provider := &geminiProvider{}
+	body, err := provider.TransformResponseBody(newMockMultipartHttpContext(), ApiNameChatCompletion, []byte(`{
+		"candidates":[{
+			"content":{"role":"model","parts":[
+				{"functionCall":{"name":"get_weather","args":{"city":"Hangzhou"}}},
+				{"functionCall":{"name":"get_time","args":{"timezone":"Asia/Shanghai"}}}
+			]},
+			"finishReason":"STOP",
+			"index":0
+		}],
+		"usageMetadata":{"promptTokenCount":10,"candidatesTokenCount":5,"totalTokenCount":15}
+	}`))
+	require.NoError(t, err)
+
+	var response chatCompletionResponse
+	require.NoError(t, json.Unmarshal(body, &response))
+	require.Len(t, response.Choices, 1)
+	require.NotNil(t, response.Choices[0].Message)
+	require.Len(t, response.Choices[0].Message.ToolCalls, 2)
+	assert.Equal(t, "get_weather", response.Choices[0].Message.ToolCalls[0].Function.Name)
+	assert.Equal(t, "get_time", response.Choices[0].Message.ToolCalls[1].Function.Name)
+	require.NotNil(t, response.Choices[0].FinishReason)
+	assert.Equal(t, finishReasonToolCall, *response.Choices[0].FinishReason)
+	assert.Equal(t, 10, response.Usage.PromptTokens)
+	assert.Equal(t, 5, response.Usage.CompletionTokens)
+	assert.Equal(t, 15, response.Usage.TotalTokens)
+}


### PR DESCRIPTION
## I. Summary

Fix direct Gemini non-streaming function-call conversion.

The previous converter returned no OpenAI `tool_calls` when a candidate began
with a function call, panicked when a later part was a function call after text,
and emitted one OpenAI choice per Gemini part. This change preserves one choice
per candidate, concatenates text/inline content, collects all function calls in
order, and uses `finish_reason: "tool_calls"` when calls are present.

Streaming and Vertex conversion paths are unchanged. The 2026-08-30 update
rebases onto current `main` and adds tests for all seven lines previously
reported uncovered; no production behavior was changed by that update.

## II. Related issue

Fixes #4284.

## III. Change type

- [x] Bug fix
- [ ] Feature or enhancement
- [ ] Documentation or configuration only
- [x] Refactoring, tests, or maintenance

## IV. Agent participation and issue-spec gate

See the [agent-assisted contribution policy](https://github.com/higress-group/higress/blob/main/docs/developers/agent-assisted-contributions.md).
Materially agent-assisted PRs that miss the gate receive low review priority,
and timely maintainer review is not guaranteed; this author declaration is the
deterministic prioritization signal.
Choose exactly one participation declaration:

- [ ] **No agent participation:** This PR is human-only.
- [ ] **Trivial agent-use exception:** Agent use was limited to spelling,
      punctuation, whitespace, or formatting with no substantive choice or
      behavioral effect; the explanation is below.
- [ ] **Verified maintainer/administrator exception:** Material agent
      participation occurred, and authenticated `gh` verification confirmed
      a `role_name` of `maintain` or `admin` on `higress-group/higress`, and the
      verified login matches this PR's GitHub author; record the required
      evidence and rationale below.
- [x] **Material agent participation:** An AI or coding agent materially
      participated in analysis, design, implementation, testing, or PR
      preparation.

For material participation that does not use the verified maintainer/administrator
exception, check each timed obligation:

- [ ] **Before implementation began:** A Higress maintainer had approved the
      Proposal and Design Issues, and authorized implementation TASKs linked the
      work to the applicable SPECs.
- [ ] **Before verification began:** The Design contained a concrete
      Verification Plan.
- [ ] **Before requesting maintainer review or acceptance:** Applicable
      implementation and verification TASKs were `done` with exact commands,
      results, evidence links, and hashes.

Then choose exactly one overall gate status:

- [ ] Complete: all three timed obligations above were satisfied.
- [x] Noncompliant: one or more obligations were not satisfied; explain below.
- [ ] Verified exception: material agent participation used the
      verified-maintainer/administrator exception; provide the required evidence
      and rationale below.
- [ ] N/A because the PR is human-only or qualifies for the trivial exception.

**Gate-status explanation (or N/A):** Material agent-assisted implementation
began and this PR was opened on 2026-08-07, before the current timed policy was
merged on 2026-08-08 in #4353. The prospective pre-implementation and
pre-verification obligations were not met and cannot be claimed retroactively.
The PR is therefore declared noncompliant. Current-template traceability and
post-hoc reproducible technical evidence are supplied without claiming gate
compliance.

**Trivial-exception explanation (or N/A):** N/A; participation was material.

**Verified maintainer/administrator exception evidence (or N/A):** N/A; no
exception is claimed.

- This PR's number or URL: N/A
- Authenticated `gh` login: N/A
- Canonical-repository `role_name`: N/A
- Actual PR author from `gh pr view`: N/A
- Login/author match: N/A
- Token override attestation (`GH_TOKEN` and `GITHUB_TOKEN` were unset for every verification command; required: `yes`): N/A
- Bypass rationale: N/A
- Maintainer live validation (review URL or N/A until performed): N/A

**Approved Proposal Issue URL (or N/A with explanation):** N/A; no approved
Proposal existed before implementation. #4284 is the bug report.

**Approved Design Issue URL (or N/A with explanation):** N/A; no approved Design
Issue existed before implementation.

**Maintainer approval link(s) (or N/A with explanation):** N/A; no gate approval
is claimed.

**Authorized implementation TASK link(s) (or N/A with explanation):** N/A; no
policy TASK existed before implementation.

**Verification Plan and verification TASK/evidence link(s) (or N/A with explanation):**
The timed pre-verification obligation was not satisfied. The post-hoc plan,
harness, raw logs/results, environment pins, validation report, and integrity
manifest are in the
[immutable R3 evidence bundle](https://github.com/ai-yang/higress/tree/1715e5c6735b2225c28821dec070609ba505d84a/review-evidence/r3/pr-4288).

## V. Testing and verification

**Test and deterministic rerun commands (or N/A with explanation):**

```text
# Export the two source roots, disposable cache/artifact directories, and the
# pinned GO_IMAGE/GOPROXY documented by the evidence README.
./review-evidence/r3/pr-4288/harness/go-verify.sh

# Export BASELINE_WASM, FIXED_WASM, HIGRESS_GATEWAY_IMAGE, and MOCK_IMAGE.
./review-evidence/r3/pr-4288/harness/run-runtime.sh

cd review-evidence/r3/pr-4288
./harness/verify-evidence.py
sha256sum --check SHA256SUMS
```

Recorded checks: baseline/fixed provider suites; targeted Gemini tests with
`-race -count=20`; baseline/fixed vet comparison; both WASI c-shared builds;
uncached fixed Wasm-host full-module tests; fixed provider coverage; and three
real Proxy-Wasm rounds per variant. All assertions pass.

**Environment and configuration (or N/A with explanation):** Linux x86_64;
Docker/Compose 26.0.0/2.25.0; Go 1.24.4; Envoy 1.27.7 from the pinned Higress
gateway; Nginx 1.27.5 mock; one Envoy worker. The same non-streaming request and
mixed Gemini text/function-call/text response are used for both variants. The
fixture contains only `<redacted-test-token>` and requires no real credential.

**Exact tested revision, version, image tag/digest, manifests, and values (or N/A with explanation):**
Baseline/main `409b3ed2644a977776391eae78ed6cb11e99d3d3`; fixed
`2869a8e75a9ea2ac8a15364fc17cf5c493f97440`, whose parent is that exact
baseline. Image references/IDs, Envoy/Nginx versions, build flags, fixtures, and
ports are in
[`environment.json`](https://github.com/ai-yang/higress/blob/1715e5c6735b2225c28821dec070609ba505d84a/review-evidence/r3/pr-4288/environment.json).

**Baseline reproduction evidence for bug fixes (or N/A with explanation):**
All three requests reached the mock and returned HTTP 200, but conversion
recovered from the same nil-pointer panic 3/3 times. The client received the
unchanged 274-byte Gemini body with no OpenAI `choices`, and the OpenAI
assertion failed as expected in all three rounds. See
[baseline results](https://github.com/ai-yang/higress/tree/1715e5c6735b2225c28821dec070609ba505d84a/review-evidence/r3/pr-4288/results/baseline).

**Fixed-version verification evidence for bug fixes (or N/A with explanation):**
All three requests returned structurally valid OpenAI responses with one choice,
content `Let me check. One moment.`, one indexed `lookup({"id":42})` call,
`finish_reason: "tool_calls"`, exact usage `10/5/15`, and zero panic. Both
changed conversion helpers report 100% statement coverage. See
[`results/summary.json`](https://github.com/ai-yang/higress/blob/1715e5c6735b2225c28821dec070609ba505d84a/review-evidence/r3/pr-4288/results/summary.json)
and the [validation report](https://github.com/ai-yang/higress/blob/1715e5c6735b2225c28821dec070609ba505d84a/review-evidence/r3/pr-4288/validation-report.md).

**Wasm source revision and SHA-256 (or N/A with explanation):** Baseline source
`409b3ed2644a977776391eae78ed6cb11e99d3d3`, artifact
`e68ef323ba48290ee562980c921b5cfef9c2820d1b636bd6701c2fbbfb676671`;
fixed source `2869a8e75a9ea2ac8a15364fc17cf5c493f97440`, artifact
`369ff42b1dec10851c9c5f7e323c852bb04045e417d9f3b36f1cc671b5a816ec`.
Both use the same pinned Go image and
`GOOS=wasip1 GOARCH=wasm -trimpath -buildmode=c-shared -buildvcs=false`.

## VI. Special notes for reviewers

- Review scope is the direct Gemini provider's non-streaming response path.
- The production `gemini.go` patch is byte-identical to the prior reviewed head
  (SHA256 `cc9102b1…eff`); the rebase update adds only 55 test lines.
- Empty candidates are skipped, inline-data content is preserved, and an
  unmarshalable function call is skipped without preventing a later valid call.
- Candidate-only function calls omit message content, as expected for an
  OpenAI assistant tool-call message.
- Provider vet still exits 1 for byte-identical pre-existing JSON-tag warnings;
  neither changed Gemini file appears in the diagnostics.
- Generated call IDs and timestamps make fixed response bytes nondeterministic,
  so validation asserts structure and semantics.

## VII. AI coding disclosure

**Tool(s) used (or N/A):** OpenAI Codex.

### Prompts or instructions

Audit Higress for reproducible functional bugs; avoid duplicates; validate the
Gemini non-streaming conversion fix without changing streaming or Vertex paths;
inspect current PR feedback and policy; rebase onto current `main`; address
actionable coverage gaps; and publish sanitized, repeatable baseline/fixed
Proxy-Wasm evidence with logs, machine results, and SHA256 checksums.

### AI-assisted work summary

The agent traced the dropped calls and mixed-part panic to the original
part-wise conversion, helped implement one-candidate/one-choice aggregation,
added direct and serialized-response tests, identified and covered the remaining
empty/inline/marshal-error branches, rebased the signed commit, and prepared the
R3 evidence. Human review retained responsibility for the change and public
submission. The gate remains explicitly noncompliant because work predates the
current timed policy.
