### PR TITLE
test(ingress): cover McpBridge destination routes

### DIFF
--- a/pkg/ingress/kube/ingress/controller_test.go
+++ b/pkg/ingress/kube/ingress/controller_test.go
@@ -1026,6 +1026,77 @@ func TestSSLPassthroughIgnoresNonRootPath(t *testing.T) {
 	}
 }
 
+func TestHTTPRouteUsesMCPDestinationForResourceBackend(t *testing.T) {
+	c := controller{}
+	apiGroup := "networking.higress.io"
+	wrapper := &common.WrapperConfig{
+		Config: &config.Config{
+			Meta: config.Meta{
+				Namespace: "default",
+				Name:      "ai-route",
+			},
+			Spec: ingress.IngressSpec{
+				Rules: []ingress.IngressRule{
+					{
+						Host: "ai.example.com",
+						IngressRuleValue: ingress.IngressRuleValue{
+							HTTP: &ingress.HTTPIngressRuleValue{
+								Paths: []ingress.HTTPIngressPath{
+									{
+										Path: "/v1/chat/completions",
+										Backend: ingress.IngressBackend{
+											Resource: &v1.TypedLocalObjectReference{
+												APIGroup: &apiGroup,
+												Kind:     "McpBridge",
+												Name:     "default",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		AnnotationsConfig: &annotations.Ingress{
+			Destination: &annotations.DestinationConfig{
+				McpDestination: []*v1alpha3.HTTPRouteDestination{
+					{
+						Destination: &v1alpha3.Destination{
+							Host: "llm-supplier-xxx.internal.dns",
+							Port: &v1alpha3.PortSelector{Number: 443},
+						},
+						Weight: 100,
+					},
+				},
+				WeightSum: 100,
+			},
+		},
+	}
+
+	routeOptions := &common.ConvertOptions{}
+	if err := c.ConvertHTTPRoute(routeOptions, wrapper); err != nil {
+		t.Fatalf("ConvertHTTPRoute() error = %v", err)
+	}
+
+	httpRoutes := routeOptions.HTTPRoutes["ai.example.com"]
+	if len(httpRoutes) != 1 {
+		t.Fatalf("http route count mismatch, want 1, got %d", len(httpRoutes))
+	}
+	routeDestinations := httpRoutes[0].HTTPRoute.Route
+	if len(routeDestinations) != 1 {
+		t.Fatalf("route destination count mismatch, want 1, got %d", len(routeDestinations))
+	}
+	destination := routeDestinations[0].Destination
+	if got := destination.Host; got != "llm-supplier-xxx.internal.dns" {
+		t.Fatalf("destination host mismatch, want llm-supplier-xxx.internal.dns, got %s", got)
+	}
+	if got := destination.GetPort().GetNumber(); got != 443 {
+		t.Fatalf("destination port mismatch, want 443, got %d", got)
+	}
+}
+
 func testApplyCanaryIngress(t *testing.T, c common.IngressController) {
 	testcases := []struct {
 		description string

--- a/pkg/ingress/kube/ingressv1/controller_test.go
+++ b/pkg/ingress/kube/ingressv1/controller_test.go
@@ -902,6 +902,78 @@ func TestSSLPassthroughIgnoresNonRootPath(t *testing.T) {
 	}
 }
 
+func TestHTTPRouteUsesMCPDestinationForResourceBackend(t *testing.T) {
+	c := controller{}
+	apiGroup := "networking.higress.io"
+	wrapper := &common.WrapperConfig{
+		Config: &config.Config{
+			Meta: config.Meta{
+				Namespace: "default",
+				Name:      "ai-route",
+			},
+			Spec: v1.IngressSpec{
+				Rules: []v1.IngressRule{
+					{
+						Host: "ai.example.com",
+						IngressRuleValue: v1.IngressRuleValue{
+							HTTP: &v1.HTTPIngressRuleValue{
+								Paths: []v1.HTTPIngressPath{
+									{
+										Path:     "/v1/chat/completions",
+										PathType: pathTypePtr(v1.PathTypePrefix),
+										Backend: v1.IngressBackend{
+											Resource: &corev1.TypedLocalObjectReference{
+												APIGroup: &apiGroup,
+												Kind:     "McpBridge",
+												Name:     "default",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		AnnotationsConfig: &annotations.Ingress{
+			Destination: &annotations.DestinationConfig{
+				McpDestination: []*networking.HTTPRouteDestination{
+					{
+						Destination: &networking.Destination{
+							Host: "llm-supplier-xxx.internal.dns",
+							Port: &networking.PortSelector{Number: 443},
+						},
+						Weight: 100,
+					},
+				},
+				WeightSum: 100,
+			},
+		},
+	}
+
+	routeOptions := &common.ConvertOptions{}
+	if err := c.ConvertHTTPRoute(routeOptions, wrapper); err != nil {
+		t.Fatalf("ConvertHTTPRoute() error = %v", err)
+	}
+
+	httpRoutes := routeOptions.HTTPRoutes["ai.example.com"]
+	if len(httpRoutes) != 1 {
+		t.Fatalf("http route count mismatch, want 1, got %d", len(httpRoutes))
+	}
+	routeDestinations := httpRoutes[0].HTTPRoute.Route
+	if len(routeDestinations) != 1 {
+		t.Fatalf("route destination count mismatch, want 1, got %d", len(routeDestinations))
+	}
+	destination := routeDestinations[0].Destination
+	if got := destination.Host; got != "llm-supplier-xxx.internal.dns" {
+		t.Fatalf("destination host mismatch, want llm-supplier-xxx.internal.dns, got %s", got)
+	}
+	if got := destination.GetPort().GetNumber(); got != 443 {
+		t.Fatalf("destination port mismatch, want 443, got %d", got)
+	}
+}
+
 func TestSSLPassthroughKeepsMCPResourceBackend(t *testing.T) {
 	c := controller{}
 	apiGroup := "networking.higress.io"


### PR DESCRIPTION
Refs #3992.

## What changed
- Added regression coverage for Ingress v1 McpBridge resource backends using `higress.io/destination`.
- Added the same coverage for the legacy Ingress v1beta1 path.
- The tests assert that normal HTTP routes use the destination annotation's real upstream service (`llm-supplier-xxx.internal.dns:443`) rather than the `McpBridge/default` resource backend as the route destination.

## Notes
The current control-plane path already routes McpBridge resource backends through `higress.io/destination`; this PR locks that behavior with tests for the AI-route-style HTTP path described in #3992. If the reporter still sees model-mapper service matching fail, the issue likely needs a concrete reproduction where the generated route lacks or differs from the destination annotation.

## Validation
- `go test -mod=mod -modfile=/tmp/higress-3992-go-*.mod ./pkg/ingress/kube/ingress ./pkg/ingress/kube/ingressv1 -run TestHTTPRouteUsesMCPDestinationForResourceBackend -count=1`
- `go test -mod=mod -modfile=/tmp/higress-3992-full-*.mod ./pkg/ingress/kube/ingress ./pkg/ingress/kube/ingressv1 -count=1`
- `git diff --check`
