### PR TITLE
fix(ai-agent): handle non-string path parameters

### DIFF
--- a/plugins/wasm-go/extensions/ai-agent/main.go
+++ b/plugins/wasm-go/extensions/ai-agent/main.go
@@ -446,7 +446,7 @@ func toolsCall(ctx wrapper.HttpContext, llmClient wrapper.HttpClient, llmInfo LL
 									// 删除已经使用过的
 									delete(data, param)
 									// 替换模板中的占位符
-									urlParts[i] = url.QueryEscape(value.(string))
+									urlParts[i] = escapePathParameter(value)
 								}
 							}
 						}
@@ -519,6 +519,10 @@ func toolsCall(ctx wrapper.HttpContext, llmClient wrapper.HttpClient, llmInfo LL
 	}
 
 	return types.ActionPause, ""
+}
+
+func escapePathParameter(value interface{}) string {
+	return url.QueryEscape(fmt.Sprintf("%v", value))
 }
 
 // 从response接收到firstreq的大模型返回

--- a/plugins/wasm-go/extensions/ai-agent/main_test.go
+++ b/plugins/wasm-go/extensions/ai-agent/main_test.go
@@ -404,6 +404,12 @@ func TestParseConfig(t *testing.T) {
 	})
 }
 
+func TestEscapePathParameter(t *testing.T) {
+	require.Equal(t, "123", escapePathParameter(float64(123)))
+	require.Equal(t, "true", escapePathParameter(true))
+	require.Equal(t, "a+b%2Fc", escapePathParameter("a b/c"))
+}
+
 func TestOnHttpRequestHeaders(t *testing.T) {
 	test.RunTest(t, func(t *testing.T) {
 		t.Run("basic request headers", func(t *testing.T) {


### PR DESCRIPTION
## What changed
- format OpenAPI path-template values without unsafe string assertions
- URL-escape numeric, boolean, and string tool arguments consistently
- add focused regression coverage

## Why
Valid JSON tool arguments are not always strings. The previous `value.(string)` panicked for numeric or boolean path parameters.

Fixes #4299

## Validation
- `go test ./...`
- `git diff --check`