### PR TITLE
fix(ai-cache): validate Elasticsearch source fields

### DIFF
--- a/plugins/wasm-go/extensions/ai-cache/vector/elasticsearch.go
+++ b/plugins/wasm-go/extensions/ai-cache/vector/elasticsearch.go
@@ -178,22 +178,34 @@ type esQueryResponse struct {
 }
 
 func (d *ESProvider) parseQueryResponse(responseBody []byte, log log.Log) ([]QueryResult, error) {
-	log.Infof("[ES] responseBody: %s", string(responseBody))
+	if log != nil {
+		log.Infof("[ES] responseBody: %s", string(responseBody))
+	}
 	var queryResp esQueryResponse
 	err := json.Unmarshal(responseBody, &queryResp)
 	if err != nil {
 		return []QueryResult{}, err
 	}
-	log.Debugf("[ES] queryResp Hits len: %d", len(queryResp.Hits.Hits))
+	if log != nil {
+		log.Debugf("[ES] queryResp Hits len: %d", len(queryResp.Hits.Hits))
+	}
 	if len(queryResp.Hits.Hits) == 0 {
 		return nil, errors.New("no query results found in response")
 	}
 	results := make([]QueryResult, 0, queryResp.Hits.Total.Value)
 	for _, hit := range queryResp.Hits.Hits {
+		question, ok := hit.Source["question"].(string)
+		if !ok {
+			return nil, fmt.Errorf("[ES] hit %q has missing or non-string question", hit.ID)
+		}
+		answer, ok := hit.Source["answer"].(string)
+		if !ok {
+			return nil, fmt.Errorf("[ES] hit %q has missing or non-string answer", hit.ID)
+		}
 		result := QueryResult{
-			Text:   hit.Source["question"].(string),
+			Text:   question,
 			Score:  hit.Score,
-			Answer: hit.Source["answer"].(string),
+			Answer: answer,
 		}
 		results = append(results, result)
 	}

--- a/plugins/wasm-go/extensions/ai-cache/vector/elasticsearch_test.go
+++ b/plugins/wasm-go/extensions/ai-cache/vector/elasticsearch_test.go
@@ -1,0 +1,30 @@
+package vector
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestESParseQueryResponseValidatesSourceFields(t *testing.T) {
+	provider := &ESProvider{}
+
+	results, err := provider.parseQueryResponse([]byte(`{"hits":{"total":{"value":1},"hits":[{"_id":"ok","_score":0.9,"_source":{"question":"q","answer":"a"}}]}}`), nil)
+	require.NoError(t, err)
+	require.Equal(t, []QueryResult{{Text: "q", Score: 0.9, Answer: "a"}}, results)
+
+	for _, tc := range []struct {
+		name string
+		body string
+		want string
+	}{
+		{name: "missing question", body: `{"hits":{"total":{"value":1},"hits":[{"_id":"bad","_source":{"answer":"a"}}]}}`, want: `hit "bad" has missing or non-string question`},
+		{name: "non-string answer", body: `{"hits":{"total":{"value":1},"hits":[{"_id":"bad","_source":{"question":"q","answer":42}}]}}`, want: `hit "bad" has missing or non-string answer`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			results, err := provider.parseQueryResponse([]byte(tc.body), nil)
+			require.Nil(t, results)
+			require.ErrorContains(t, err, tc.want)
+		})
+	}
+}


### PR DESCRIPTION
## What changed
- validate Elasticsearch `_source.question` and `_source.answer` before constructing cache results
- return an actionable error containing the malformed hit ID
- cover valid, missing, and wrong-type fields

## Why
Elasticsearch mappings and documents can drift. Direct type assertions allowed a malformed hit to panic the ai-cache WASM plugin.

Fixes #4300

## Validation
- `go test ./vector`
- `git diff --check`