### PR TITLE
fix(ai-proxy): guard malformed multimodal fields

### DIFF
--- a/plugins/wasm-go/extensions/ai-proxy/provider/model.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/model.go
@@ -452,10 +452,14 @@ func (m *chatMessage) ParseContent() []chatMessageContent {
 				}
 			case contentTypeImageUrl:
 				if subObj, ok := contentMap[contentTypeImageUrl].(map[string]any); ok {
+					imageURL, ok := subObj["url"].(string)
+					if !ok {
+						continue
+					}
 					msg := chatMessageContent{
 						Type: contentTypeImageUrl,
 						ImageUrl: &chatMessageContentImageUrl{
-							Url: subObj["url"].(string),
+							Url: imageURL,
 						},
 					}
 					if detail, ok := subObj["detail"].(string); ok {
@@ -465,20 +469,29 @@ func (m *chatMessage) ParseContent() []chatMessageContent {
 				}
 			case contentTypeInputAudio:
 				if subObj, ok := contentMap[contentTypeInputAudio].(map[string]any); ok {
+					data, dataOK := subObj["data"].(string)
+					format, formatOK := subObj["format"].(string)
+					if !dataOK || !formatOK {
+						continue
+					}
 					contentList = append(contentList, chatMessageContent{
 						Type: contentTypeInputAudio,
 						InputAudio: &chatMessageContentAudio{
-							Data:   subObj["data"].(string),
-							Format: subObj["format"].(string),
+							Data:   data,
+							Format: format,
 						},
 					})
 				}
 			case contentTypeFile:
 				if subObj, ok := contentMap[contentTypeFile].(map[string]any); ok {
+					fileID, ok := subObj["file_id"].(string)
+					if !ok {
+						continue
+					}
 					contentList = append(contentList, chatMessageContent{
 						Type: contentTypeFile,
 						File: &chatMessageContentFile{
-							FileId: subObj["file_id"].(string),
+							FileId: fileID,
 							// FileName: subObj["file_name"].(string),
 							// FileData: subObj["file_data"].(string),
 						},

--- a/plugins/wasm-go/extensions/ai-proxy/provider/model_test.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/model_test.go
@@ -1,0 +1,37 @@
+package provider
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestChatMessageParseContentSkipsMalformedMultimodalParts(t *testing.T) {
+	message := chatMessage{Content: []any{
+		map[string]any{"type": contentTypeImageUrl, contentTypeImageUrl: map[string]any{}},
+		map[string]any{"type": contentTypeInputAudio, contentTypeInputAudio: map[string]any{"data": "audio", "format": 1}},
+		map[string]any{"type": contentTypeFile, contentTypeFile: map[string]any{"file_id": nil}},
+		map[string]any{"type": contentTypeText, contentTypeText: "kept"},
+	}}
+
+	content := message.ParseContent()
+	require.Len(t, content, 1)
+	require.Equal(t, contentTypeText, content[0].Type)
+	require.Equal(t, "kept", content[0].Text)
+}
+
+func TestChatMessageParseContentPreservesValidMultimodalParts(t *testing.T) {
+	message := chatMessage{Content: []any{
+		map[string]any{"type": contentTypeImageUrl, contentTypeImageUrl: map[string]any{"url": "https://example.com/image.png", "detail": "low"}},
+		map[string]any{"type": contentTypeInputAudio, contentTypeInputAudio: map[string]any{"data": "audio", "format": "wav"}},
+		map[string]any{"type": contentTypeFile, contentTypeFile: map[string]any{"file_id": "file-1"}},
+	}}
+
+	content := message.ParseContent()
+	require.Len(t, content, 3)
+	require.Equal(t, "https://example.com/image.png", content[0].ImageUrl.Url)
+	require.Equal(t, "low", content[0].ImageUrl.Detail)
+	require.Equal(t, "audio", content[1].InputAudio.Data)
+	require.Equal(t, "wav", content[1].InputAudio.Format)
+	require.Equal(t, "file-1", content[2].File.FileId)
+}


### PR DESCRIPTION
## What changed
- validate nested image URL, input audio, and file fields before constructing message content
- skip malformed content parts while preserving valid multimodal and text parts
- add focused malformed/valid regression coverage

## Why
Client-controlled OpenAI-format content could reach direct string assertions and panic the ai-proxy WASM plugin.

Fixes #4301

## Validation
- `go test ./provider`
- `git diff --check`