### PR TITLE
fix(ai-proxy): reduce default failure retry timeout

### DIFF
--- a/plugins/wasm-go/extensions/ai-proxy/provider/retry.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/retry.go
@@ -7,14 +7,15 @@ import (
 	"net/http"
 
 	"github.com/alibaba/higress/plugins/wasm-go/extensions/ai-proxy/util"
+	"github.com/higress-group/proxy-wasm-go-sdk/proxywasm"
 	"github.com/higress-group/wasm-go/pkg/log"
 	"github.com/higress-group/wasm-go/pkg/wrapper"
-	"github.com/higress-group/proxy-wasm-go-sdk/proxywasm"
 	"github.com/tidwall/gjson"
 )
 
 const (
-	ctxRetryCount = "retryCount"
+	ctxRetryCount              = "retryCount"
+	defaultRetryFailureTimeout = 30 * 1000
 )
 
 type retryOnFailure struct {
@@ -36,7 +37,7 @@ func (r *retryOnFailure) FromJson(json gjson.Result) {
 	}
 	r.retryTimeout = json.Get("retryTimeout").Int()
 	if r.retryTimeout == 0 {
-		r.retryTimeout = 60 * 1000
+		r.retryTimeout = defaultRetryFailureTimeout
 	}
 	for _, status := range json.Get("retryOnStatus").Array() {
 		r.retryOnStatus = append(r.retryOnStatus, status.String())

--- a/plugins/wasm-go/extensions/ai-proxy/provider/retry_test.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/retry_test.go
@@ -98,8 +98,19 @@ func TestRetryOnFailure_FromJson_defaults(t *testing.T) {
 	c.FromJson(gjson.Parse(`{"type":"openai","apiTokens":["t"],"retryOnFailure":{"enabled":true}}`))
 	require.True(t, c.IsRetryOnFailureEnabled())
 	assert.Equal(t, int64(1), c.retryOnFailure.maxRetries)
-	assert.Equal(t, int64(60*1000), c.retryOnFailure.retryTimeout)
+	assert.Equal(t, int64(defaultRetryFailureTimeout), c.retryOnFailure.retryTimeout)
 	assert.Equal(t, []string{"4.*", "5.*"}, c.retryOnFailure.retryOnStatus)
+}
+
+func TestRetryOnFailure_FromJson_explicitRetryTimeout(t *testing.T) {
+	var c ProviderConfig
+	c.FromJson(gjson.Parse(`{
+		"type":"openai",
+		"apiTokens":["t"],
+		"retryOnFailure":{"enabled":true,"retryTimeout":90000}
+	}`))
+	require.True(t, c.IsRetryOnFailureEnabled())
+	assert.Equal(t, int64(90000), c.retryOnFailure.retryTimeout)
 }
 
 func TestOnRequestFailed_offlineBranches(t *testing.T) {


### PR DESCRIPTION
## What changed

- Align the `retryOnFailure.retryTimeout` default with the documented 30000ms value.
- Add a named default constant for failure retry timeout.
- Add coverage proving explicit `retryTimeout` values still override the default.

This is a narrow mitigation for #4179: when AI upstreams fail and `retryOnFailure` is enabled without an explicit timeout, retries now hold resources for 30s by default instead of 60s. It does not claim to cover the issue’s broader deployment tuning items such as circuit breaking, route-not-found polling, or body logging behavior.

## Validation

- `go test ./provider -count=1` from `plugins/wasm-go/extensions/ai-proxy`
- `git diff --check`
