### PR TITLE
fix(ai-proxy): reject oversized content length early

### DIFF
--- a/plugins/wasm-go/extensions/ai-proxy/main.go
+++ b/plugins/wasm-go/extensions/ai-proxy/main.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"fmt"
+	"net/http"
 	"net/url"
 	"regexp"
 	"strconv"
@@ -35,6 +36,8 @@ const (
 	ctxOriginalAuth                = "original_auth"
 	ctxUpstreamErrorResponseStatus = "upstream_error_response_status"
 )
+
+const headerContentLength = "Content-Length"
 
 type pair[K, V any] struct {
 	key   K
@@ -280,6 +283,19 @@ func onHttpRequestHeader(ctx wrapper.HttpContext, pluginConfig config.PluginConf
 	// allowing plugins to inspect or modify the response correctly
 	_ = proxywasm.RemoveHttpRequestHeader("Accept-Encoding")
 
+	_, hasRequestBodyHandler := activeProvider.(provider.RequestBodyHandler)
+	hasRequestBody := ctx.HasRequestBody()
+	if hasRequestBody && hasRequestBodyHandler && requestContentLengthExceedsLimit(defaultMaxBodyBytes) {
+		_ = proxywasm.SendHttpResponseWithDetail(
+			http.StatusRequestEntityTooLarge,
+			"request_payload_too_large",
+			util.CreateHeaders(util.HeaderContentType, util.MimeTypeTextPlain),
+			[]byte("request payload too large"),
+			-1,
+		)
+		return types.ActionPause
+	}
+
 	if handler, ok := activeProvider.(provider.RequestHeadersHandler); ok {
 		// Set the apiToken for the current request.
 		providerConfig.SetApiTokenInUse(ctx)
@@ -296,10 +312,8 @@ func onHttpRequestHeader(ctx wrapper.HttpContext, pluginConfig config.PluginConf
 			return types.ActionContinue
 		}
 
-		_, hasRequestBodyHandler := activeProvider.(provider.RequestBodyHandler)
-		hasRequestBody := ctx.HasRequestBody()
 		if hasRequestBody && hasRequestBodyHandler {
-			_ = proxywasm.RemoveHttpRequestHeader("Content-Length")
+			_ = proxywasm.RemoveHttpRequestHeader(headerContentLength)
 			ctx.SetRequestBodyBufferLimit(defaultMaxBodyBytes)
 			// Delay the header processing to allow changing in OnRequestBody
 			return types.HeaderStopIteration
@@ -309,6 +323,40 @@ func onHttpRequestHeader(ctx wrapper.HttpContext, pluginConfig config.PluginConf
 	}
 
 	return types.ActionContinue
+}
+
+func requestContentLengthExceedsLimit(limit uint32) bool {
+	contentLength, _ := proxywasm.GetHttpRequestHeader(headerContentLength)
+	if contentLengthExceedsLimit(contentLength, limit) {
+		return true
+	}
+
+	headers, err := proxywasm.GetHttpRequestHeaders()
+	if err != nil {
+		return false
+	}
+	for _, header := range headers {
+		if strings.EqualFold(header[0], headerContentLength) {
+			return contentLengthExceedsLimit(header[1], limit)
+		}
+	}
+	return false
+}
+
+func contentLengthExceedsLimit(contentLength string, limit uint32) bool {
+	contentLength = strings.TrimSpace(contentLength)
+	if contentLength == "" {
+		return false
+	}
+
+	length, err := strconv.ParseUint(contentLength, 10, 64)
+	if err != nil {
+		if numErr, ok := err.(*strconv.NumError); ok && numErr.Err == strconv.ErrRange {
+			return true
+		}
+		return false
+	}
+	return length > uint64(limit)
 }
 
 func onHttpRequestBody(ctx wrapper.HttpContext, pluginConfig config.PluginConfig, body []byte) types.Action {

--- a/plugins/wasm-go/extensions/ai-proxy/main_test.go
+++ b/plugins/wasm-go/extensions/ai-proxy/main_test.go
@@ -150,6 +150,33 @@ func Test_isSupportedRequestContentType(t *testing.T) {
 	}
 }
 
+func Test_contentLengthExceedsLimit(t *testing.T) {
+	const limit uint32 = 100
+	tests := []struct {
+		name          string
+		contentLength string
+		want          bool
+	}{
+		{"missing", "", false},
+		{"blank", " \t", false},
+		{"below limit", "99", false},
+		{"equal limit", "100", false},
+		{"above limit", "101", true},
+		{"trim spaces", " 101 ", true},
+		{"invalid", "invalid", false},
+		{"negative", "-1", false},
+		{"overflow", "184467440737095516160", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := contentLengthExceedsLimit(tt.contentLength, limit); got != tt.want {
+				t.Fatalf("contentLengthExceedsLimit(%q, %d) = %v, want %v", tt.contentLength, limit, got, tt.want)
+			}
+		})
+	}
+}
+
 func Test_normalizeOpenAiRequestBody(t *testing.T) {
 	t.Run("stream_adds_include_usage", func(t *testing.T) {
 		in := []byte(`{"model":"x","stream":true}`)

--- a/plugins/wasm-go/extensions/ai-proxy/test/openai.go
+++ b/plugins/wasm-go/extensions/ai-proxy/test/openai.go
@@ -222,6 +222,50 @@ func RunOpenAIOnHttpRequestHeadersTests(t *testing.T) {
 			require.True(t, hasOpenAILogs, "Should have OpenAI processing logs")
 		})
 
+		t.Run("openai chat completion rejects oversized content length", func(t *testing.T) {
+			host, status := test.NewTestHost(basicOpenAIConfig)
+			defer host.Reset()
+			require.Equal(t, types.OnPluginStartStatusOK, status)
+
+			action := host.CallOnHttpRequestHeaders([][2]string{
+				{":authority", "example.com"},
+				{":path", "/v1/chat/completions"},
+				{":method", "POST"},
+				{"Content-Type", "application/json"},
+				{"Content-Length", "104857601"},
+			})
+
+			require.Equal(t, types.ActionPause, action)
+			require.Equal(t, types.ActionPause, host.GetHttpStreamAction())
+
+			localResponse := host.GetLocalResponse()
+			require.NotNil(t, localResponse)
+			require.Equal(t, uint32(413), localResponse.StatusCode)
+			require.Equal(t, "request payload too large", string(localResponse.Data))
+		})
+
+		t.Run("openai chat completion rejects oversized lowercase content length", func(t *testing.T) {
+			host, status := test.NewTestHost(basicOpenAIConfig)
+			defer host.Reset()
+			require.Equal(t, types.OnPluginStartStatusOK, status)
+
+			action := host.CallOnHttpRequestHeaders([][2]string{
+				{":authority", "example.com"},
+				{":path", "/v1/chat/completions"},
+				{":method", "POST"},
+				{"Content-Type", "application/json"},
+				{"content-length", "104857601"},
+			})
+
+			require.Equal(t, types.ActionPause, action)
+			require.Equal(t, types.ActionPause, host.GetHttpStreamAction())
+
+			localResponse := host.GetLocalResponse()
+			require.NotNil(t, localResponse)
+			require.Equal(t, uint32(413), localResponse.StatusCode)
+			require.Equal(t, "request payload too large", string(localResponse.Data))
+		})
+
 		// 测试OpenAI请求头处理（嵌入接口）
 		t.Run("openai embeddings request headers", func(t *testing.T) {
 			host, status := test.NewTestHost(basicOpenAIConfig)


### PR DESCRIPTION
## What changed

- Reject ai-proxy requests in the request-header phase when `Content-Length` is larger than the existing 100MB request body buffer limit.
- Return local HTTP 413 with `request_payload_too_large` before setting the wasm request body buffer limit.
- Keep the existing body-buffer path unchanged when `Content-Length` is missing, invalid, or within the limit.
- Handle `Content-Length` case-insensitively for the early reject check.

## Scope note

This only enables immediate rejection when the client declares an oversized `Content-Length`. For chunked/no-`Content-Length` requests, the gateway still cannot know the body is oversized before reading enough data, so rejection continues to depend on the configured Envoy/Wasm body buffer limit.

Fixes #3986.

## Validation

- `go test . -run 'Test_contentLengthExceedsLimit|TestOpenAI/openai_chat_completion_rejects_oversized|TestOpenAI/openai_chat_completion_request_headers' -count=1 -v`
- `git diff --check`

Note: local `go test ./... -count=1` and `go test . -count=1` were started, but did not complete within a reasonable local wait window and were interrupted with no failure output.
