### PR TITLE
bugfix(hgctl): handle malformed PDB specs

### DIFF
--- a/hgctl/pkg/helm/object/objects.go
+++ b/hgctl/pkg/helm/object/objects.go
@@ -531,10 +531,10 @@ func resolvePDBConflict(o *K8sObject) *K8sObject {
 	if o.json == nil {
 		return o
 	}
-	if o.object.Object["spec"] == nil {
+	spec, ok := o.object.Object["spec"].(map[string]any)
+	if !ok {
 		return o
 	}
-	spec := o.object.Object["spec"].(map[string]any)
 	isDefault := func(item any) bool {
 		var ii intstr.IntOrString
 		switch item := item.(type) {

--- a/hgctl/pkg/helm/object/objects_test.go
+++ b/hgctl/pkg/helm/object/objects_test.go
@@ -699,6 +699,21 @@ func TestK8sObject_ResolveK8sConflict(t *testing.T) {
                     maxUnavailable: 0
                     minAvailable: 0`),
 		},
+		{
+			desc: "non-object spec is ignored",
+			o1: getK8sObject(`
+                  apiVersion: policy/v1
+                  kind: PodDisruptionBudget
+                  metadata:
+                    name: invalid-pdb
+                  spec: invalid`),
+			o2: getK8sObject(`
+                  apiVersion: policy/v1
+                  kind: PodDisruptionBudget
+                  metadata:
+                    name: invalid-pdb
+                  spec: invalid`),
+		},
 	}
 	for _, tt := range cases {
 		t.Run(tt.desc, func(t *testing.T) {


### PR DESCRIPTION
<!-- issue-spec-inflight-disclosure:v1 -->
## I. Summary

This is a reporting-only update for an in-flight, materially agent-assisted contribution opened before Higress adopted the issue-spec gate. The implementation summary and original verification record are preserved verbatim in Section VIII. No code, commit, or review head is changed by this disclosure update.

## II. Related issue

Fixes #4332

Reproduction and problem statement: https://github.com/higress-group/higress/issues/4332

## III. Change type

- [x] Bug fix
- [ ] Feature or enhancement
- [ ] Documentation or configuration only
- [ ] Refactoring, tests, or maintenance

## IV. Agent participation and issue-spec gate

- [ ] **No agent participation:** This PR is human-only.
- [ ] **Trivial agent-use exception:** Agent use was limited to spelling, punctuation, whitespace, or formatting with no substantive choice or behavioral effect; the explanation is below.
- [x] **Material agent participation:** An AI or coding agent materially participated in analysis, design, implementation, testing, or PR preparation.

For material participation, check each timed obligation:

- [ ] **Before implementation began:** A Higress maintainer had approved the Proposal and Design Issues, and authorized implementation TASKs linked the work to the applicable SPECs.
- [ ] **Before verification began:** The Design contained a concrete Verification Plan.
- [ ] **Before requesting maintainer review or acceptance:** Applicable implementation and verification TASKs were `done` with exact commands, results, evidence links, and hashes.

Then choose exactly one overall gate status:

- [ ] Complete: all three timed obligations above were satisfied.
- [x] Noncompliant: one or more obligations were not satisfied; explain below.
- [ ] N/A because the PR is human-only or qualifies for the trivial exception.

**Gate-status explanation (or N/A):**

This PR was opened at 2026-08-07T16:17:39Z, before policy commit [`13d2c5446ed232eb439b682bbf1abc22433e81a9`](https://github.com/higress-group/higress/commit/13d2c5446ed232eb439b682bbf1abc22433e81a9) merged on 2026-08-08T11:05:38Z. It is an in-flight materially agent-assisted contribution. Retroactive Proposal/Design approval does not exist and is not fabricated; this PR is explicitly marked Noncompliant while adding best-effort traceability and evidence.

**Trivial-exception explanation (or N/A):**

N/A — material agent participation is declared above.

**Approved Proposal Issue URL (or N/A with explanation):**

N/A — https://github.com/higress-group/higress/issues/4332 is a reproduction/tracking issue, not an approved issue-spec Proposal.

**Approved Design Issue URL (or N/A with explanation):**

N/A — no retroactive Design artifact or approval is claimed.

**Maintainer approval link(s) (or N/A with explanation):**

N/A — no retroactive Proposal/Design approval is claimed.

**Authorized implementation TASK link(s) (or N/A with explanation):**

N/A — no retroactive TASK authorization is claimed.

**Verification Plan and verification TASK/evidence link(s) (or N/A with explanation):**

N/A — no pre-approved Verification Plan or verification TASK exists. Best-effort verification is preserved in Section VIII without representing it as issue-spec evidence.

## V. Testing and verification

**Test and deterministic rerun commands (or N/A with explanation):**

```text
See Section VIII, "Describe how to verify it." This body-only update does not claim that tests were rerun.
```

**Environment and configuration (or N/A with explanation):**

N/A — the original submission did not record a complete OS, architecture, and toolchain matrix; that omission remains explicit.

**Exact tested revision, version, image tag/digest, manifests, and values (or N/A with explanation):**

Current PR head is [`8bf6e6cff56e25d2aafbb75c6ebfe93964b88a97`](https://github.com/higress-group/higress/commit/8bf6e6cff56e25d2aafbb75c6ebfe93964b88a97). Section VIII preserves the focused verification originally reported for this revision. N/A for unrecorded image digest, manifests, or values.

**Baseline reproduction evidence for bug fixes (or N/A with explanation):**

The reproducible problem statement is recorded in https://github.com/higress-group/higress/issues/4332. This is an ordinary tracking/reproduction issue, not an approved issue-spec Proposal; policy-required same-input pre-fix runtime output was not collected.

**Fixed-version verification evidence for bug fixes (or N/A with explanation):**

Section VIII preserves the focused verification originally reported for [`8bf6e6cff56e25d2aafbb75c6ebfe93964b88a97`](https://github.com/higress-group/higress/commit/8bf6e6cff56e25d2aafbb75c6ebfe93964b88a97). Policy-required production-path red/green runtime evidence was not collected and remains an explicit evidence gap.

**Wasm source revision and SHA-256 (or N/A with explanation):**

N/A — this PR does not deliver a Wasm module.

## VI. Special notes for reviewers

- This update only brings the PR report into the current template and records the issue-spec status honestly.
- It does not claim gate completion, maintainer acceptance, or stronger verification than the original submission.
- Issue #4332 records that production reachability of the changed resolver remains unresolved; this reporting update does not claim that gap is closed.

## VII. AI coding disclosure

**Tool(s) used (or N/A):**

Codex using the GitHub five-PR contribution workflow.

### Prompts or instructions

The original prompt is preserved verbatim in Section VIII. Current instruction: audit and revise the August 8–9 Higress PR reports to reflect the maintainer's issue-spec requirements, without updating the skill or fabricating approvals.

### AI-assisted work summary

PR-body reporting only. The code, branch, commits, and original verification text are unchanged. The issue-spec status and missing runtime evidence are now explicit.

## VIII. Original submission details (preserved verbatim)

<!-- original-submission-body:start -->
## Ⅰ. Describe what this PR did

This PR prevents `hgctl` from panicking when a PodDisruptionBudget contains a non-object `spec`. `resolvePDBConflict` now uses a checked type assertion and leaves malformed input unchanged, matching its existing behavior for a missing spec.

## Ⅱ. Does this pull request fix one issue?

No linked issue. This was found during a repository safety scan. A file-level comparison against all 178 open upstream PRs on 2026-08-08 found no overlap.

## Ⅲ. Why don't you add test cases (unit test/integration test)?

N/A. A unit regression case covers a scalar PDB `spec` and verifies that conflict resolution does not panic or rewrite it.

## Ⅳ. Describe how to verify it

```shell
cd hgctl
go test ./pkg/helm/object -count=1 -cover
```

Local result: pass; package statement coverage 49.5%.

## Ⅴ. Special notes for reviews

The change is limited to the PDB conflict helper and one table-driven test case. No Kubernetes, Docker, or end-to-end environment is required for this path.

## Ⅵ. AI Coding Tool Usage Checklist (if applicable)

**Please check all applicable items:**

- [x] **For regular updates/changes** (not new plugins):
  - [x] I have provided the prompts/instructions I gave to the AI Coding tool below
  - [x] I have included the AI Coding summary below

### AI Coding Prompts (for regular updates)

Scan the Higress repository for five independent, small bugs; use a common upstream baseline and date-named branches; avoid duplicate open work; add focused regression tests; keep every PR below 400 changed lines; run lightweight local verification; and submit five separate upstream PRs. For this branch, investigate unchecked type assertions in hgctl's Kubernetes object handling.

### AI Coding Summary

- Key decision: preserve the existing no-op behavior for absent or unusable PDB specs instead of inventing validation policy in this conflict-resolution helper.
- Major changes: replace the direct `spec` assertion with a checked assertion and add a malformed-manifest regression case.
- Considerations: this PR deliberately does not perform schema validation; it only prevents a local rendering crash.
<!-- original-submission-body:end -->
