### PR TITLE
bugfix(hgctl): validate Envoy config dumps

### DIFF
--- a/hgctl/pkg/utils.go
+++ b/hgctl/pkg/utils.go
@@ -16,6 +16,7 @@ package hgctl
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 )
 
@@ -33,49 +34,45 @@ var (
 func GetXDSResource(resourceType envoyConfigType, configDump []byte) (any, error) {
 	cd := map[string]any{}
 	if err := json.Unmarshal(configDump, &cd); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("decode config dump: %w", err)
 	}
 	if resourceType == AllEnvoyConfigType {
 		return cd, nil
 	}
-	configs := cd["configs"]
-	globalConfigs := configs.([]any)
-
-	switch resourceType {
-	case BootstrapEnvoyConfigType:
-		for _, config := range globalConfigs {
-			if config.(map[string]interface{})["@type"] == "type.googleapis.com/envoy.admin.v3.BootstrapConfigDump" {
-				return config, nil
-			}
-		}
-	case EndpointEnvoyConfigType:
-		for _, config := range globalConfigs {
-			if config.(map[string]interface{})["@type"] == "type.googleapis.com/envoy.admin.v3.EndpointsConfigDump" {
-				return config, nil
-			}
-		}
-
-	case ClusterEnvoyConfigType:
-		for _, config := range globalConfigs {
-			if config.(map[string]interface{})["@type"] == "type.googleapis.com/envoy.admin.v3.ClustersConfigDump" {
-				return config, nil
-			}
-		}
-	case ListenerEnvoyConfigType:
-		for _, config := range globalConfigs {
-			if config.(map[string]interface{})["@type"] == "type.googleapis.com/envoy.admin.v3.ListenersConfigDump" {
-				return config, nil
-			}
-		}
-	case RouteEnvoyConfigType:
-		for _, config := range globalConfigs {
-			if config.(map[string]interface{})["@type"] == "type.googleapis.com/envoy.admin.v3.RoutesConfigDump" {
-				return config, nil
-			}
-		}
-	default:
-		return nil, fmt.Errorf("unknown resourceType %s", resourceType)
+	configs, ok := cd["configs"]
+	if !ok {
+		return nil, errors.New("config dump is missing configs")
+	}
+	globalConfigs, ok := configs.([]any)
+	if !ok {
+		return nil, errors.New("config dump configs must be an array")
 	}
 
-	return nil, fmt.Errorf("unknown resourceType %s", resourceType)
+	var typeURL string
+	switch resourceType {
+	case BootstrapEnvoyConfigType:
+		typeURL = "type.googleapis.com/envoy.admin.v3.BootstrapConfigDump"
+	case EndpointEnvoyConfigType:
+		typeURL = "type.googleapis.com/envoy.admin.v3.EndpointsConfigDump"
+	case ClusterEnvoyConfigType:
+		typeURL = "type.googleapis.com/envoy.admin.v3.ClustersConfigDump"
+	case ListenerEnvoyConfigType:
+		typeURL = "type.googleapis.com/envoy.admin.v3.ListenersConfigDump"
+	case RouteEnvoyConfigType:
+		typeURL = "type.googleapis.com/envoy.admin.v3.RoutesConfigDump"
+	default:
+		return nil, fmt.Errorf("unknown resource type %q", resourceType)
+	}
+
+	for i, config := range globalConfigs {
+		configObject, ok := config.(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("config dump configs[%d] must be an object", i)
+		}
+		if configObject["@type"] == typeURL {
+			return config, nil
+		}
+	}
+
+	return nil, fmt.Errorf("config dump is missing %s resource", resourceType)
 }

--- a/hgctl/pkg/utils_test.go
+++ b/hgctl/pkg/utils_test.go
@@ -1,0 +1,151 @@
+// Copyright (c) 2026 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hgctl
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestGetXDSResource(t *testing.T) {
+	tests := []struct {
+		name         string
+		resourceType envoyConfigType
+		configDump   string
+		wantType     string
+		wantErr      string
+	}{
+		{
+			name:         "invalid JSON",
+			resourceType: ClusterEnvoyConfigType,
+			configDump:   `{`,
+			wantErr:      "decode config dump",
+		},
+		{
+			name:         "missing configs",
+			resourceType: ClusterEnvoyConfigType,
+			configDump:   `{}`,
+			wantErr:      "config dump is missing configs",
+		},
+		{
+			name:         "null configs",
+			resourceType: ClusterEnvoyConfigType,
+			configDump:   `{"configs":null}`,
+			wantErr:      "config dump configs must be an array",
+		},
+		{
+			name:         "non-array configs",
+			resourceType: ClusterEnvoyConfigType,
+			configDump:   `{"configs":{}}`,
+			wantErr:      "config dump configs must be an array",
+		},
+		{
+			name:         "non-object config",
+			resourceType: ClusterEnvoyConfigType,
+			configDump:   `{"configs":["invalid"]}`,
+			wantErr:      "config dump configs[0] must be an object",
+		},
+		{
+			name:         "null config",
+			resourceType: ClusterEnvoyConfigType,
+			configDump:   `{"configs":[null]}`,
+			wantErr:      "config dump configs[0] must be an object",
+		},
+		{
+			name:         "missing requested resource",
+			resourceType: ClusterEnvoyConfigType,
+			configDump:   `{"configs":[]}`,
+			wantErr:      "config dump is missing cluster resource",
+		},
+		{
+			name:         "unknown resource type",
+			resourceType: envoyConfigType("secret"),
+			configDump:   `{"configs":[]}`,
+			wantErr:      `unknown resource type "secret"`,
+		},
+		{
+			name:         "valid bootstrap resource",
+			resourceType: BootstrapEnvoyConfigType,
+			configDump:   `{"configs":[{"@type":"type.googleapis.com/envoy.admin.v3.BootstrapConfigDump","value":"preserved"}]}`,
+			wantType:     "type.googleapis.com/envoy.admin.v3.BootstrapConfigDump",
+		},
+		{
+			name:         "valid endpoint resource",
+			resourceType: EndpointEnvoyConfigType,
+			configDump:   `{"configs":[{"@type":"type.googleapis.com/envoy.admin.v3.EndpointsConfigDump","value":"preserved"}]}`,
+			wantType:     "type.googleapis.com/envoy.admin.v3.EndpointsConfigDump",
+		},
+		{
+			name:         "valid cluster resource",
+			resourceType: ClusterEnvoyConfigType,
+			configDump:   `{"configs":[{"@type":"type.googleapis.com/envoy.admin.v3.ClustersConfigDump","value":"preserved"}]}`,
+			wantType:     "type.googleapis.com/envoy.admin.v3.ClustersConfigDump",
+		},
+		{
+			name:         "valid listener resource",
+			resourceType: ListenerEnvoyConfigType,
+			configDump:   `{"configs":[{"@type":"type.googleapis.com/envoy.admin.v3.ListenersConfigDump","value":"preserved"}]}`,
+			wantType:     "type.googleapis.com/envoy.admin.v3.ListenersConfigDump",
+		},
+		{
+			name:         "valid route resource",
+			resourceType: RouteEnvoyConfigType,
+			configDump:   `{"configs":[{"@type":"type.googleapis.com/envoy.admin.v3.RoutesConfigDump","value":"preserved"}]}`,
+			wantType:     "type.googleapis.com/envoy.admin.v3.RoutesConfigDump",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resource, err := GetXDSResource(tt.resourceType, []byte(tt.configDump))
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("GetXDSResource() error = nil, want error containing %q", tt.wantErr)
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("GetXDSResource() error = %q, want error containing %q", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("GetXDSResource() unexpected error: %v", err)
+			}
+			config, ok := resource.(map[string]any)
+			if !ok {
+				t.Fatalf("GetXDSResource() result type = %T, want map[string]any", resource)
+			}
+			if got := config["@type"]; got != tt.wantType {
+				t.Errorf("GetXDSResource() resource @type = %v, want %q", got, tt.wantType)
+			}
+			if got := config["value"]; got != "preserved" {
+				t.Errorf("GetXDSResource() resource value = %v, want preserved", got)
+			}
+		})
+	}
+}
+
+func TestGetXDSResourceAll(t *testing.T) {
+	resource, err := GetXDSResource(AllEnvoyConfigType, []byte(`{"metadata":"preserved"}`))
+	if err != nil {
+		t.Fatalf("GetXDSResource() unexpected error: %v", err)
+	}
+	configDump, ok := resource.(map[string]any)
+	if !ok {
+		t.Fatalf("GetXDSResource() result type = %T, want map[string]any", resource)
+	}
+	if got := configDump["metadata"]; got != "preserved" {
+		t.Errorf("GetXDSResource() config dump metadata = %v, want preserved", got)
+	}
+}


### PR DESCRIPTION
<!-- issue-spec-inflight-disclosure:v1 -->
## I. Summary

This is a reporting-only update for an in-flight, materially agent-assisted contribution opened before Higress adopted the issue-spec gate. The implementation summary and original verification record are preserved verbatim in Section VIII. No code, commit, or review head is changed by this disclosure update.

## II. Related issue

Fixes #4333

Reproduction and problem statement: https://github.com/higress-group/higress/issues/4333

## III. Change type

- [x] Bug fix
- [ ] Feature or enhancement
- [ ] Documentation or configuration only
- [ ] Refactoring, tests, or maintenance

## IV. Agent participation and issue-spec gate

- [ ] **No agent participation:** This PR is human-only.
- [ ] **Trivial agent-use exception:** Agent use was limited to spelling, punctuation, whitespace, or formatting with no substantive choice or behavioral effect; the explanation is below.
- [x] **Material agent participation:** An AI or coding agent materially participated in analysis, design, implementation, testing, or PR preparation.

For material participation, check each timed obligation:

- [ ] **Before implementation began:** A Higress maintainer had approved the Proposal and Design Issues, and authorized implementation TASKs linked the work to the applicable SPECs.
- [ ] **Before verification began:** The Design contained a concrete Verification Plan.
- [ ] **Before requesting maintainer review or acceptance:** Applicable implementation and verification TASKs were `done` with exact commands, results, evidence links, and hashes.

Then choose exactly one overall gate status:

- [ ] Complete: all three timed obligations above were satisfied.
- [x] Noncompliant: one or more obligations were not satisfied; explain below.
- [ ] N/A because the PR is human-only or qualifies for the trivial exception.

**Gate-status explanation (or N/A):**

This PR was opened at 2026-08-07T16:17:43Z, before policy commit [`13d2c5446ed232eb439b682bbf1abc22433e81a9`](https://github.com/higress-group/higress/commit/13d2c5446ed232eb439b682bbf1abc22433e81a9) merged on 2026-08-08T11:05:38Z. It is an in-flight materially agent-assisted contribution. Retroactive Proposal/Design approval does not exist and is not fabricated; this PR is explicitly marked Noncompliant while adding best-effort traceability and evidence.

**Trivial-exception explanation (or N/A):**

N/A — material agent participation is declared above.

**Approved Proposal Issue URL (or N/A with explanation):**

N/A — https://github.com/higress-group/higress/issues/4333 is a reproduction/tracking issue, not an approved issue-spec Proposal.

**Approved Design Issue URL (or N/A with explanation):**

N/A — no retroactive Design artifact or approval is claimed.

**Maintainer approval link(s) (or N/A with explanation):**

N/A — no retroactive Proposal/Design approval is claimed.

**Authorized implementation TASK link(s) (or N/A with explanation):**

N/A — no retroactive TASK authorization is claimed.

**Verification Plan and verification TASK/evidence link(s) (or N/A with explanation):**

N/A — no pre-approved Verification Plan or verification TASK exists. Best-effort verification is preserved in Section VIII without representing it as issue-spec evidence.

## V. Testing and verification

**Test and deterministic rerun commands (or N/A with explanation):**

```text
See Section VIII, "Describe how to verify it." This body-only update does not claim that tests were rerun.
```

**Environment and configuration (or N/A with explanation):**

N/A — the original submission did not record a complete OS, architecture, and toolchain matrix; that omission remains explicit.

**Exact tested revision, version, image tag/digest, manifests, and values (or N/A with explanation):**

Current PR head is [`c1260f204e3d22391e6f3b1abb3d328a8b80a485`](https://github.com/higress-group/higress/commit/c1260f204e3d22391e6f3b1abb3d328a8b80a485). Section VIII preserves the focused verification originally reported for this revision. N/A for unrecorded image digest, manifests, or values.

**Baseline reproduction evidence for bug fixes (or N/A with explanation):**

The reproducible problem statement is recorded in https://github.com/higress-group/higress/issues/4333. This is an ordinary tracking/reproduction issue, not an approved issue-spec Proposal; policy-required same-input pre-fix runtime output was not collected.

**Fixed-version verification evidence for bug fixes (or N/A with explanation):**

Section VIII preserves the focused verification originally reported for [`c1260f204e3d22391e6f3b1abb3d328a8b80a485`](https://github.com/higress-group/higress/commit/c1260f204e3d22391e6f3b1abb3d328a8b80a485). Policy-required production-path red/green runtime evidence was not collected and remains an explicit evidence gap.

**Wasm source revision and SHA-256 (or N/A with explanation):**

N/A — this PR does not deliver a Wasm module.

## VI. Special notes for reviewers

- This update only brings the PR report into the current template and records the issue-spec status honestly.
- It does not claim gate completion, maintainer acceptance, or stronger verification than the original submission.
- Issue #4333 records a production-path scope mismatch: the production CLI uses a duplicate parser outside the file changed by this PR. This reporting update does not claim that gap is closed.

## VII. AI coding disclosure

**Tool(s) used (or N/A):**

Codex using the GitHub five-PR contribution workflow.

### Prompts or instructions

The original prompt is preserved verbatim in Section VIII. Current instruction: audit and revise the August 8–9 Higress PR reports to reflect the maintainer's issue-spec requirements, without updating the skill or fabricating approvals.

### AI-assisted work summary

PR-body reporting only. The code, branch, commits, and original verification text are unchanged. The issue-spec status and missing runtime evidence are now explicit.

## VIII. Original submission details (preserved verbatim)

<!-- original-submission-body:start -->
## Ⅰ. Describe what this PR did

This PR makes `GetXDSResource` safely parse Envoy config dumps instead of panicking on missing, null, non-array, or non-object `configs` values. It also separates unknown resource types from missing requested resources and adds context to JSON decoding errors.

## Ⅱ. Does this pull request fix one issue?

No linked issue. This was found during a repository safety scan. A file-level comparison against all 178 open upstream PRs on 2026-08-08 found no overlap.

## Ⅲ. Why don't you add test cases (unit test/integration test)?

N/A. New table-driven unit tests cover malformed config-dump shapes, all five supported resource types, unknown resource types, missing requested resources, and the `all` path.

## Ⅳ. Describe how to verify it

```shell
cd hgctl
go test ./pkg/utils.go ./pkg/utils_test.go -run '^TestGetXDSResource' -count=1 -cover
```

Local result: pass; the file-level test target reports 100.0% statement coverage. The broader `./pkg` target is not locally runnable in this checkout because its `external/go-control-plane/contrib` module is absent; upstream CI remains the broader integration gate.

## Ⅴ. Special notes for reviews

Successful return values are unchanged. Invalid config-dump shapes now return descriptive errors rather than panicking.

## Ⅵ. AI Coding Tool Usage Checklist (if applicable)

**Please check all applicable items:**

- [x] **For regular updates/changes** (not new plugins):
  - [x] I have provided the prompts/instructions I gave to the AI Coding tool below
  - [x] I have included the AI Coding summary below

### AI Coding Prompts (for regular updates)

Scan the Higress repository for five independent, small bugs; use a common upstream baseline and date-named branches; avoid duplicate open work; add focused regression tests; keep every PR below 400 changed lines; run lightweight local verification; and submit five separate upstream PRs. For this branch, inspect hgctl's Envoy config-dump parsing for unchecked assertions and ambiguous errors.

### AI Coding Summary

- Key decision: validate the config-dump container once, then map supported resource types to their canonical type URLs.
- Major changes: add checked shape validation, contextual errors, and exhaustive table-driven unit coverage.
- Considerations: the test is intentionally file-scoped because this checkout lacks a broader hgctl external module; CI can exercise the full package graph.
<!-- original-submission-body:end -->
