### PR TITLE
bugfix(ai-cache): validate Chroma query responses

### DIFF
--- a/plugins/wasm-go/extensions/ai-cache/vector/chroma.go
+++ b/plugins/wasm-go/extensions/ai-cache/vector/chroma.go
@@ -186,15 +186,34 @@ func (d *ChromaProvider) parseQueryResponse(responseBody []byte, log log.Log) ([
 	}
 
 	log.Debugf("[Chroma] queryResp Ids len: %d", len(queryResp.Ids))
-	if len(queryResp.Ids) == 1 && len(queryResp.Ids[0]) == 0 {
+	if len(queryResp.Ids) != 1 {
+		return nil, fmt.Errorf("invalid query response: expected exactly one ids batch, got %d", len(queryResp.Ids))
+	}
+	ids := queryResp.Ids[0]
+	if len(ids) == 0 {
 		return nil, errors.New("no query results found in response")
 	}
-	results := make([]QueryResult, 0, len(queryResp.Ids[0]))
-	for i := range queryResp.Ids[0] {
+	if len(queryResp.Distances) != len(queryResp.Ids) {
+		return nil, fmt.Errorf("invalid query response: distances batch count %d does not match ids batch count %d", len(queryResp.Distances), len(queryResp.Ids))
+	}
+	if len(queryResp.Documents) != len(queryResp.Ids) {
+		return nil, fmt.Errorf("invalid query response: documents batch count %d does not match ids batch count %d", len(queryResp.Documents), len(queryResp.Ids))
+	}
+	distances := queryResp.Distances[0]
+	documents := queryResp.Documents[0]
+	if len(distances) != len(ids) {
+		return nil, fmt.Errorf("invalid query response: distances element count %d does not match ids element count %d", len(distances), len(ids))
+	}
+	if len(documents) != len(ids) {
+		return nil, fmt.Errorf("invalid query response: documents element count %d does not match ids element count %d", len(documents), len(ids))
+	}
+
+	results := make([]QueryResult, 0, len(ids))
+	for i := range ids {
 		result := QueryResult{
-			Text:   queryResp.Ids[0][i],
-			Score:  queryResp.Distances[0][i],
-			Answer: queryResp.Documents[0][i],
+			Text:   ids[i],
+			Score:  distances[i],
+			Answer: documents[i],
 		}
 		results = append(results, result)
 	}

--- a/plugins/wasm-go/extensions/ai-cache/vector/chroma_test.go
+++ b/plugins/wasm-go/extensions/ai-cache/vector/chroma_test.go
@@ -1,0 +1,116 @@
+// Copyright (c) 2026 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vector
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+type noopChromaLog struct{}
+
+func (noopChromaLog) Trace(string)                     {}
+func (noopChromaLog) Tracef(string, ...interface{})    {}
+func (noopChromaLog) Debug(string)                     {}
+func (noopChromaLog) Debugf(string, ...interface{})    {}
+func (noopChromaLog) Info(string)                      {}
+func (noopChromaLog) Infof(string, ...interface{})     {}
+func (noopChromaLog) Warn(string)                      {}
+func (noopChromaLog) Warnf(string, ...interface{})     {}
+func (noopChromaLog) Error(string)                     {}
+func (noopChromaLog) Errorf(string, ...interface{})    {}
+func (noopChromaLog) Critical(string)                  {}
+func (noopChromaLog) Criticalf(string, ...interface{}) {}
+func (noopChromaLog) ResetID(string)                   {}
+
+func TestChromaProvider_ParseQueryResponse(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		response    string
+		want        []QueryResult
+		wantErrText string
+	}{
+		{
+			name:     "valid response",
+			response: `{"ids":[["question-1","question-2"]],"distances":[[0.1,0.2]],"documents":[["answer-1","answer-2"]]}`,
+			want: []QueryResult{
+				{Text: "question-1", Score: 0.1, Answer: "answer-1"},
+				{Text: "question-2", Score: 0.2, Answer: "answer-2"},
+			},
+		},
+		{
+			name:        "empty result",
+			response:    `{"ids":[[]]}`,
+			wantErrText: "no query results found in response",
+		},
+		{
+			name:        "empty ids batches",
+			response:    `{"ids":[]}`,
+			wantErrText: "ids",
+		},
+		{
+			name:        "multiple ids batches",
+			response:    `{"ids":[["question-1"],["question-2"]],"distances":[[0.1],[0.2]],"documents":[["answer-1"],["answer-2"]]}`,
+			wantErrText: "ids",
+		},
+		{
+			name:        "missing distances batch",
+			response:    `{"ids":[["question"]],"documents":[["answer"]]}`,
+			wantErrText: "distances",
+		},
+		{
+			name:        "missing documents batch",
+			response:    `{"ids":[["question"]],"distances":[[0.1]]}`,
+			wantErrText: "documents",
+		},
+		{
+			name:        "distance count mismatch",
+			response:    `{"ids":[["question-1","question-2"]],"distances":[[0.1]],"documents":[["answer-1","answer-2"]]}`,
+			wantErrText: "distances",
+		},
+		{
+			name:        "document count mismatch",
+			response:    `{"ids":[["question-1","question-2"]],"distances":[[0.1,0.2]],"documents":[["answer-1"]]}`,
+			wantErrText: "documents",
+		},
+	}
+
+	provider := &ChromaProvider{}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := provider.parseQueryResponse([]byte(tt.response), noopChromaLog{})
+			if tt.wantErrText != "" {
+				if err == nil {
+					t.Fatalf("parseQueryResponse() error = nil, want error containing %q", tt.wantErrText)
+				}
+				if !strings.Contains(err.Error(), tt.wantErrText) {
+					t.Fatalf("parseQueryResponse() error = %q, want error containing %q", err, tt.wantErrText)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseQueryResponse() unexpected error: %v", err)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("parseQueryResponse() = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!-- issue-spec-inflight-disclosure:v1 -->
## I. Summary

This is a reporting-only update for an in-flight, materially agent-assisted contribution opened before Higress adopted the issue-spec gate. The implementation summary and original verification record are preserved verbatim in Section VIII. No code, commit, or review head is changed by this disclosure update.

## II. Related issue

Fixes #4334

Reproduction and problem statement: https://github.com/higress-group/higress/issues/4334

## III. Change type

- [x] Bug fix
- [ ] Feature or enhancement
- [ ] Documentation or configuration only
- [ ] Refactoring, tests, or maintenance

## IV. Agent participation and issue-spec gate

- [ ] **No agent participation:** This PR is human-only.
- [ ] **Trivial agent-use exception:** Agent use was limited to spelling, punctuation, whitespace, or formatting with no substantive choice or behavioral effect; the explanation is below.
- [x] **Material agent participation:** An AI or coding agent materially participated in analysis, design, implementation, testing, or PR preparation.

For material participation, check each timed obligation:

- [ ] **Before implementation began:** A Higress maintainer had approved the Proposal and Design Issues, and authorized implementation TASKs linked the work to the applicable SPECs.
- [ ] **Before verification began:** The Design contained a concrete Verification Plan.
- [ ] **Before requesting maintainer review or acceptance:** Applicable implementation and verification TASKs were `done` with exact commands, results, evidence links, and hashes.

Then choose exactly one overall gate status:

- [ ] Complete: all three timed obligations above were satisfied.
- [x] Noncompliant: one or more obligations were not satisfied; explain below.
- [ ] N/A because the PR is human-only or qualifies for the trivial exception.

**Gate-status explanation (or N/A):**

This PR was opened at 2026-08-07T16:17:51Z, before policy commit [`13d2c5446ed232eb439b682bbf1abc22433e81a9`](https://github.com/higress-group/higress/commit/13d2c5446ed232eb439b682bbf1abc22433e81a9) merged on 2026-08-08T11:05:38Z. It is an in-flight materially agent-assisted contribution. Retroactive Proposal/Design approval does not exist and is not fabricated; this PR is explicitly marked Noncompliant while adding best-effort traceability and evidence.

**Trivial-exception explanation (or N/A):**

N/A — material agent participation is declared above.

**Approved Proposal Issue URL (or N/A with explanation):**

N/A — https://github.com/higress-group/higress/issues/4334 is a reproduction/tracking issue, not an approved issue-spec Proposal.

**Approved Design Issue URL (or N/A with explanation):**

N/A — no retroactive Design artifact or approval is claimed.

**Maintainer approval link(s) (or N/A with explanation):**

N/A — no retroactive Proposal/Design approval is claimed.

**Authorized implementation TASK link(s) (or N/A with explanation):**

N/A — no retroactive TASK authorization is claimed.

**Verification Plan and verification TASK/evidence link(s) (or N/A with explanation):**

N/A — no pre-approved Verification Plan or verification TASK exists. Best-effort verification is preserved in Section VIII without representing it as issue-spec evidence.

## V. Testing and verification

**Test and deterministic rerun commands (or N/A with explanation):**

```text
See Section VIII, "Describe how to verify it." This body-only update does not claim that tests were rerun.
```

**Environment and configuration (or N/A with explanation):**

N/A — the original submission did not record a complete OS, architecture, and toolchain matrix; that omission remains explicit.

**Exact tested revision, version, image tag/digest, manifests, and values (or N/A with explanation):**

Current PR head is [`023e98e2ccb256129b4afe0980cb098102ba9233`](https://github.com/higress-group/higress/commit/023e98e2ccb256129b4afe0980cb098102ba9233). Section VIII preserves the focused verification originally reported for this revision. N/A for unrecorded image digest, manifests, or values.

**Baseline reproduction evidence for bug fixes (or N/A with explanation):**

The reproducible problem statement is recorded in https://github.com/higress-group/higress/issues/4334. This is an ordinary tracking/reproduction issue, not an approved issue-spec Proposal; policy-required same-input pre-fix runtime output was not collected.

**Fixed-version verification evidence for bug fixes (or N/A with explanation):**

Section VIII preserves the focused verification originally reported for [`023e98e2ccb256129b4afe0980cb098102ba9233`](https://github.com/higress-group/higress/commit/023e98e2ccb256129b4afe0980cb098102ba9233). Policy-required production-path red/green runtime evidence was not collected and remains an explicit evidence gap.

**Wasm source revision and SHA-256 (or N/A with explanation):**

Source revision: [`023e98e2ccb256129b4afe0980cb098102ba9233`](https://github.com/higress-group/higress/commit/023e98e2ccb256129b4afe0980cb098102ba9233). SHA-256: not available because no Wasm module was built and no digest was recorded; this remains an explicit runtime-evidence gap.

## VI. Special notes for reviewers

- This update only brings the PR report into the current template and records the issue-spec status honestly.
- It does not claim gate completion, maintainer acceptance, or stronger verification than the original submission.

## VII. AI coding disclosure

**Tool(s) used (or N/A):**

Codex using the GitHub five-PR contribution workflow.

### Prompts or instructions

The original prompt is preserved verbatim in Section VIII. Current instruction: audit and revise the August 8–9 Higress PR reports to reflect the maintainer's issue-spec requirements, without updating the skill or fabricating approvals.

### AI-assisted work summary

PR-body reporting only. The code, branch, commits, and original verification text are unchanged. The issue-spec status and missing runtime evidence are now explicit.

## VIII. Original submission details (preserved verbatim)

<!-- original-submission-body:start -->
## Ⅰ. Describe what this PR did

This PR prevents the Chroma vector provider from panicking when a successful query response has missing or mismatched `ids`, `distances`, or `documents` batches. Malformed response shapes now produce descriptive errors before any nested slice access.

## Ⅱ. Does this pull request fix one issue?

No linked issue. This was found during a repository safety scan. A file-level comparison against all 178 open upstream PRs on 2026-08-08 found no overlap.

## Ⅲ. Why don't you add test cases (unit test/integration test)?

N/A. New table-driven unit tests cover valid responses, empty results, missing and multiple batches, and per-batch element-count mismatches.

## Ⅳ. Describe how to verify it

```shell
cd plugins/wasm-go/extensions/ai-cache
go test ./vector -count=1 -cover
```

Local result: pass; package statement coverage 6.4%, with the changed parser covered by the focused cases.

## Ⅴ. Special notes for reviews

The provider still accepts exactly the single query batch it requests today. This PR does not add multi-query response semantics.

## Ⅵ. AI Coding Tool Usage Checklist (if applicable)

**Please check all applicable items:**

- [x] **For regular updates/changes** (not new plugins):
  - [x] I have provided the prompts/instructions I gave to the AI Coding tool below
  - [x] I have included the AI Coding summary below

### AI Coding Prompts (for regular updates)

Scan the Higress repository for five independent, small bugs; use a common upstream baseline and date-named branches; avoid duplicate open work; add focused regression tests; keep every PR below 400 changed lines; run lightweight local verification; and submit five separate upstream PRs. For this branch, validate third-party vector response shapes before indexing nested slices.

### AI Coding Summary

- Key decision: enforce the provider's existing one-query contract and reject inconsistent response dimensions explicitly.
- Major changes: validate outer batch counts and inner element counts before constructing query results; add regression coverage for each malformed shape.
- Considerations: malformed upstream responses now return errors instead of crashing the WASM request path.
<!-- original-submission-body:end -->
