### PR TITLE
bugfix(ai-agent): validate OpenAPI server configuration

### DIFF
--- a/plugins/wasm-go/extensions/ai-agent/config.go
+++ b/plugins/wasm-go/extensions/ai-agent/config.go
@@ -301,6 +301,9 @@ func initAPIs(gjson gjson.Result, c *PluginConfig) error {
 		if err != nil {
 			return err
 		}
+		if len(apiStruct.Servers) == 0 || apiStruct.Servers[0].URL == "" {
+			return errors.New("api servers is required")
+		}
 
 		var allTool_param []ToolsParam
 		//拆除服务下面的每个api的path

--- a/plugins/wasm-go/extensions/ai-agent/config_test.go
+++ b/plugins/wasm-go/extensions/ai-agent/config_test.go
@@ -1,0 +1,65 @@
+// Copyright (c) 2026 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+func TestInitAPIsRejectsOpenAPIWithoutServerURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		servers string
+	}{
+		{name: "missing servers"},
+		{name: "empty server URL", servers: "servers:\n  - url: ''\n"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			configJSON, err := json.Marshal(map[string]any{
+				"apis": []map[string]any{
+					{
+						"apiProvider": map[string]any{
+							"serviceName": "api-service",
+							"servicePort": 8080,
+							"domain":      "api.example.com",
+						},
+						"api": `openapi: 3.0.0
+info:
+  title: API without servers
+  version: 1.0.0
+` + tt.servers + `
+paths:
+  /items:
+    get:
+      operationId: listItems`,
+					},
+				},
+			})
+			require.NoError(t, err)
+
+			var initErr error
+			require.NotPanics(t, func() {
+				initErr = initAPIs(gjson.ParseBytes(configJSON), &PluginConfig{})
+			})
+			require.EqualError(t, initErr, "api servers is required")
+		})
+	}
+}


### PR DESCRIPTION
<!-- issue-spec-inflight-disclosure:v1 -->
## I. Summary

This is a reporting-only update for an in-flight, materially agent-assisted contribution opened before Higress adopted the issue-spec gate. The implementation summary and original verification record are preserved verbatim in Section VIII. No code, commit, or review head is changed by this disclosure update.

## II. Related issue

Fixes #4335

Reproduction and problem statement: https://github.com/higress-group/higress/issues/4335

## III. Change type

- [x] Bug fix
- [ ] Feature or enhancement
- [ ] Documentation or configuration only
- [ ] Refactoring, tests, or maintenance

## IV. Agent participation and issue-spec gate

- [ ] **No agent participation:** This PR is human-only.
- [ ] **Trivial agent-use exception:** Agent use was limited to spelling, punctuation, whitespace, or formatting with no substantive choice or behavioral effect; the explanation is below.
- [x] **Material agent participation:** An AI or coding agent materially participated in analysis, design, implementation, testing, or PR preparation.

For material participation, check each timed obligation:

- [ ] **Before implementation began:** A Higress maintainer had approved the Proposal and Design Issues, and authorized implementation TASKs linked the work to the applicable SPECs.
- [ ] **Before verification began:** The Design contained a concrete Verification Plan.
- [ ] **Before requesting maintainer review or acceptance:** Applicable implementation and verification TASKs were `done` with exact commands, results, evidence links, and hashes.

Then choose exactly one overall gate status:

- [ ] Complete: all three timed obligations above were satisfied.
- [x] Noncompliant: one or more obligations were not satisfied; explain below.
- [ ] N/A because the PR is human-only or qualifies for the trivial exception.

**Gate-status explanation (or N/A):**

This PR was opened at 2026-08-07T16:17:56Z, before policy commit [`13d2c5446ed232eb439b682bbf1abc22433e81a9`](https://github.com/higress-group/higress/commit/13d2c5446ed232eb439b682bbf1abc22433e81a9) merged on 2026-08-08T11:05:38Z. It is an in-flight materially agent-assisted contribution. Retroactive Proposal/Design approval does not exist and is not fabricated; this PR is explicitly marked Noncompliant while adding best-effort traceability and evidence.

**Trivial-exception explanation (or N/A):**

N/A — material agent participation is declared above.

**Approved Proposal Issue URL (or N/A with explanation):**

N/A — https://github.com/higress-group/higress/issues/4335 is a reproduction/tracking issue, not an approved issue-spec Proposal.

**Approved Design Issue URL (or N/A with explanation):**

N/A — no retroactive Design artifact or approval is claimed.

**Maintainer approval link(s) (or N/A with explanation):**

N/A — no retroactive Proposal/Design approval is claimed.

**Authorized implementation TASK link(s) (or N/A with explanation):**

N/A — no retroactive TASK authorization is claimed.

**Verification Plan and verification TASK/evidence link(s) (or N/A with explanation):**

N/A — no pre-approved Verification Plan or verification TASK exists. Best-effort verification is preserved in Section VIII without representing it as issue-spec evidence.

## V. Testing and verification

**Test and deterministic rerun commands (or N/A with explanation):**

```text
See Section VIII, "Describe how to verify it." This body-only update does not claim that tests were rerun.
```

**Environment and configuration (or N/A with explanation):**

N/A — the original submission did not record a complete OS, architecture, and toolchain matrix; that omission remains explicit.

**Exact tested revision, version, image tag/digest, manifests, and values (or N/A with explanation):**

Current PR head is [`69443f0702192b67548ddd9cb968ef4ac6c27c9e`](https://github.com/higress-group/higress/commit/69443f0702192b67548ddd9cb968ef4ac6c27c9e). Section VIII preserves the focused verification originally reported for this revision. N/A for unrecorded image digest, manifests, or values.

**Baseline reproduction evidence for bug fixes (or N/A with explanation):**

The reproducible problem statement is recorded in https://github.com/higress-group/higress/issues/4335. This is an ordinary tracking/reproduction issue, not an approved issue-spec Proposal; policy-required same-input pre-fix runtime output was not collected.

**Fixed-version verification evidence for bug fixes (or N/A with explanation):**

Section VIII preserves the focused verification originally reported for [`69443f0702192b67548ddd9cb968ef4ac6c27c9e`](https://github.com/higress-group/higress/commit/69443f0702192b67548ddd9cb968ef4ac6c27c9e). Policy-required production-path red/green runtime evidence was not collected and remains an explicit evidence gap.

**Wasm source revision and SHA-256 (or N/A with explanation):**

Source revision: [`69443f0702192b67548ddd9cb968ef4ac6c27c9e`](https://github.com/higress-group/higress/commit/69443f0702192b67548ddd9cb968ef4ac6c27c9e). SHA-256: not available because no Wasm module was built and no digest was recorded; this remains an explicit runtime-evidence gap.

## VI. Special notes for reviewers

- This update only brings the PR report into the current template and records the issue-spec status honestly.
- It does not claim gate completion, maintainer acceptance, or stronger verification than the original submission.

## VII. AI coding disclosure

**Tool(s) used (or N/A):**

Codex using the GitHub five-PR contribution workflow.

### Prompts or instructions

The original prompt is preserved verbatim in Section VIII. Current instruction: audit and revise the August 8–9 Higress PR reports to reflect the maintainer's issue-spec requirements, without updating the skill or fabricating approvals.

### AI-assisted work summary

PR-body reporting only. The code, branch, commits, and original verification text are unchanged. The issue-spec status and missing runtime evidence are now explicit.

## VIII. Original submission details (preserved verbatim)

<!-- original-submission-body:start -->
## Ⅰ. Describe what this PR did

This PR prevents `ai-agent` configuration parsing from panicking when an OpenAPI document omits `servers` or provides an empty first server URL. Such documents now fail configuration with `api servers is required`.

## Ⅱ. Does this pull request fix one issue?

No linked issue. This was found during a repository safety scan. A file-level comparison against all 178 open upstream PRs on 2026-08-08 found no overlap.

## Ⅲ. Why don't you add test cases (unit test/integration test)?

N/A. New unit tests cover both a missing `servers` list and an empty server URL, and explicitly assert that initialization does not panic.

## Ⅳ. Describe how to verify it

```shell
cd plugins/wasm-go/extensions/ai-agent
go test . -count=1 -cover
```

Local result: pass; package statement coverage 77.2%.

## Ⅴ. Special notes for reviews

This validates only the server data already required by the current initialization logic; it does not change path or operation parsing.

## Ⅵ. AI Coding Tool Usage Checklist (if applicable)

**Please check all applicable items:**

- [x] **For regular updates/changes** (not new plugins):
  - [x] I have provided the prompts/instructions I gave to the AI Coding tool below
  - [x] I have included the AI Coding summary below

### AI Coding Prompts (for regular updates)

Scan the Higress repository for five independent, small bugs; use a common upstream baseline and date-named branches; avoid duplicate open work; add focused regression tests; keep every PR below 400 changed lines; run lightweight local verification; and submit five separate upstream PRs. For this branch, reproduce and replace unchecked OpenAPI server indexing with a configuration error.

### AI Coding Summary

- Key decision: reject unusable OpenAPI server configuration at initialization, before the existing first-server access.
- Major changes: add a length and URL guard plus two no-panic regression cases.
- Considerations: valid OpenAPI documents follow the unchanged initialization path.
<!-- original-submission-body:end -->
