### PR TITLE
bugfix(ai-history): reject negative history counts

### DIFF
--- a/plugins/wasm-go/extensions/ai-history/main.go
+++ b/plugins/wasm-go/extensions/ai-history/main.go
@@ -317,7 +317,7 @@ func getIntQueryParameter(name string, path string, defaultValue int) int {
 		return defaultValue
 	}
 	num, err := strconv.Atoi(queryStr)
-	if err != nil {
+	if err != nil || num < 0 {
 		return defaultValue
 	}
 	return num

--- a/plugins/wasm-go/extensions/ai-history/main_test.go
+++ b/plugins/wasm-go/extensions/ai-history/main_test.go
@@ -154,6 +154,27 @@ func TestDistinctChat(t *testing.T) {
 	}
 }
 
+func TestGetIntQueryParameter(t *testing.T) {
+	tests := []struct {
+		name         string
+		path         string
+		defaultValue int
+		want         int
+	}{
+		{name: "positive value", path: "/api/chat?cnt=2", defaultValue: 3, want: 2},
+		{name: "zero value", path: "/api/chat?cnt=0", defaultValue: 3, want: 0},
+		{name: "negative value", path: "/api/chat?cnt=-1", defaultValue: 3, want: 3},
+		{name: "invalid value", path: "/api/chat?cnt=invalid", defaultValue: 3, want: 3},
+		{name: "missing value", path: "/api/chat", defaultValue: 3, want: 3},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, getIntQueryParameter("cnt", tt.path, tt.defaultValue))
+		})
+	}
+}
+
 func TestParseConfig(t *testing.T) {
 	test.RunGoTest(t, func(t *testing.T) {
 		// 测试基本Redis配置解析


### PR DESCRIPTION
<!-- issue-spec-inflight-disclosure:v1 -->
## I. Summary

This is a reporting-only update for an in-flight, materially agent-assisted contribution opened before Higress adopted the issue-spec gate. The implementation summary and original verification record are preserved verbatim in Section VIII. No code, commit, or review head is changed by this disclosure update.

## II. Related issue

Fixes #4336

Reproduction and problem statement: https://github.com/higress-group/higress/issues/4336

## III. Change type

- [x] Bug fix
- [ ] Feature or enhancement
- [ ] Documentation or configuration only
- [ ] Refactoring, tests, or maintenance

## IV. Agent participation and issue-spec gate

- [ ] **No agent participation:** This PR is human-only.
- [ ] **Trivial agent-use exception:** Agent use was limited to spelling, punctuation, whitespace, or formatting with no substantive choice or behavioral effect; the explanation is below.
- [x] **Material agent participation:** An AI or coding agent materially participated in analysis, design, implementation, testing, or PR preparation.

For material participation, check each timed obligation:

- [ ] **Before implementation began:** A Higress maintainer had approved the Proposal and Design Issues, and authorized implementation TASKs linked the work to the applicable SPECs.
- [ ] **Before verification began:** The Design contained a concrete Verification Plan.
- [ ] **Before requesting maintainer review or acceptance:** Applicable implementation and verification TASKs were `done` with exact commands, results, evidence links, and hashes.

Then choose exactly one overall gate status:

- [ ] Complete: all three timed obligations above were satisfied.
- [x] Noncompliant: one or more obligations were not satisfied; explain below.
- [ ] N/A because the PR is human-only or qualifies for the trivial exception.

**Gate-status explanation (or N/A):**

This PR was opened at 2026-08-07T16:18:00Z, before policy commit [`13d2c5446ed232eb439b682bbf1abc22433e81a9`](https://github.com/higress-group/higress/commit/13d2c5446ed232eb439b682bbf1abc22433e81a9) merged on 2026-08-08T11:05:38Z. It is an in-flight materially agent-assisted contribution. Retroactive Proposal/Design approval does not exist and is not fabricated; this PR is explicitly marked Noncompliant while adding best-effort traceability and evidence.

**Trivial-exception explanation (or N/A):**

N/A — material agent participation is declared above.

**Approved Proposal Issue URL (or N/A with explanation):**

N/A — https://github.com/higress-group/higress/issues/4336 is a reproduction/tracking issue, not an approved issue-spec Proposal.

**Approved Design Issue URL (or N/A with explanation):**

N/A — no retroactive Design artifact or approval is claimed.

**Maintainer approval link(s) (or N/A with explanation):**

N/A — no retroactive Proposal/Design approval is claimed.

**Authorized implementation TASK link(s) (or N/A with explanation):**

N/A — no retroactive TASK authorization is claimed.

**Verification Plan and verification TASK/evidence link(s) (or N/A with explanation):**

N/A — no pre-approved Verification Plan or verification TASK exists. Best-effort verification is preserved in Section VIII without representing it as issue-spec evidence.

## V. Testing and verification

**Test and deterministic rerun commands (or N/A with explanation):**

```text
See Section VIII, "Describe how to verify it." This body-only update does not claim that tests were rerun.
```

**Environment and configuration (or N/A with explanation):**

N/A — the original submission did not record a complete OS, architecture, and toolchain matrix; that omission remains explicit.

**Exact tested revision, version, image tag/digest, manifests, and values (or N/A with explanation):**

Current PR head is [`a1f3cccdde23fd8d1e8ad98b7aa7ba5871cd5631`](https://github.com/higress-group/higress/commit/a1f3cccdde23fd8d1e8ad98b7aa7ba5871cd5631). Section VIII preserves the focused verification originally reported for this revision. N/A for unrecorded image digest, manifests, or values.

**Baseline reproduction evidence for bug fixes (or N/A with explanation):**

The reproducible problem statement is recorded in https://github.com/higress-group/higress/issues/4336. This is an ordinary tracking/reproduction issue, not an approved issue-spec Proposal; policy-required same-input pre-fix runtime output was not collected.

**Fixed-version verification evidence for bug fixes (or N/A with explanation):**

Section VIII preserves the focused verification originally reported for [`a1f3cccdde23fd8d1e8ad98b7aa7ba5871cd5631`](https://github.com/higress-group/higress/commit/a1f3cccdde23fd8d1e8ad98b7aa7ba5871cd5631). Policy-required production-path red/green runtime evidence was not collected and remains an explicit evidence gap.

**Wasm source revision and SHA-256 (or N/A with explanation):**

Source revision: [`a1f3cccdde23fd8d1e8ad98b7aa7ba5871cd5631`](https://github.com/higress-group/higress/commit/a1f3cccdde23fd8d1e8ad98b7aa7ba5871cd5631). SHA-256: not available because no Wasm module was built and no digest was recorded; this remains an explicit runtime-evidence gap.

## VI. Special notes for reviewers

- This update only brings the PR report into the current template and records the issue-spec status honestly.
- It does not claim gate completion, maintainer acceptance, or stronger verification than the original submission.

## VII. AI coding disclosure

**Tool(s) used (or N/A):**

Codex using the GitHub five-PR contribution workflow.

### Prompts or instructions

The original prompt is preserved verbatim in Section VIII. Current instruction: audit and revise the August 8–9 Higress PR reports to reflect the maintainer's issue-spec requirements, without updating the skill or fabricating approvals.

### AI-assisted work summary

PR-body reporting only. The code, branch, commits, and original verification text are unchanged. The issue-spec status and missing runtime evidence are now explicit.

## VIII. Original submission details (preserved verbatim)

<!-- original-submission-body:start -->
## Ⅰ. Describe what this PR did

This PR prevents negative `cnt` and `fill_history_cnt` query parameters from reaching `ai-history` slice calculations. Negative values now fall back to the configured default, while zero and positive values retain their existing behavior.

## Ⅱ. Does this pull request fix one issue?

No linked issue. This was found during a repository safety scan. A file-level comparison against all 178 open upstream PRs on 2026-08-08 found no overlap.

## Ⅲ. Why don't you add test cases (unit test/integration test)?

N/A. A table-driven unit test covers negative, zero, positive, invalid, and missing integer query values.

## Ⅳ. Describe how to verify it

```shell
cd plugins/wasm-go/extensions/ai-history
go test ./... -count=1 -cover
```

Local result: pass; package statement coverage 76.7%. Before the fix, the negative-value case failed by returning `-1`; that value becomes a negative slice count in Redis-hit request paths.

## Ⅴ. Special notes for reviews

The parser remains generic for both history-count parameters. No Redis protocol or cache format behavior changes.

## Ⅵ. AI Coding Tool Usage Checklist (if applicable)

**Please check all applicable items:**

- [x] **For regular updates/changes** (not new plugins):
  - [x] I have provided the prompts/instructions I gave to the AI Coding tool below
  - [x] I have included the AI Coding summary below

### AI Coding Prompts (for regular updates)

Scan the Higress repository for five independent, small bugs; use a common upstream baseline and date-named branches; avoid duplicate open work; add focused regression tests; keep every PR below 400 changed lines; run lightweight local verification; and submit five separate upstream PRs. For this branch, trace user-controlled history counts into slice boundaries and preserve valid count semantics.

### AI Coding Summary

- Key decision: treat negative query counts like other invalid integers and use the existing default-value path.
- Major changes: reject negative parsed values and add focused parser regression coverage.
- Considerations: zero remains explicitly supported; positive count semantics are unchanged.
<!-- original-submission-body:end -->
