### PR TITLE
fix(mcp-session): avoid buffering request body for plain proxying

### DIFF
--- a/plugins/golang-filter/mcp-session/filter.go
+++ b/plugins/golang-filter/mcp-session/filter.go
@@ -122,9 +122,19 @@ func (f *filter) processMcpRequestHeadersForRestUpstream(header api.RequestHeade
 		}
 		if endStream {
 			return api.Continue
-		} else {
-			return api.StopAndBuffer
 		}
+		// The request body only needs to be buffered when user-level rate
+		// limiting is enabled, since that path inspects the JSON-RPC method in
+		// the body (see DecodeData). For plain REST/streamable MCP proxying we
+		// never touch the body, so skip buffering it and stream it directly to
+		// the upstream. Buffering the full body would otherwise cause large
+		// requests to be rejected with a 413 once the body exceeds Envoy's
+		// buffer limit, which cannot be enlarged from the Go filter. See #3238.
+		if !f.ratelimit {
+			f.skipRequestBody = true
+			return api.Continue
+		}
+		return api.StopAndBuffer
 	}
 
 	if method != http.MethodGet {

--- a/plugins/golang-filter/mcp-session/filter_test.go
+++ b/plugins/golang-filter/mcp-session/filter_test.go
@@ -2,6 +2,8 @@ package mcp_session
 
 import (
 	"fmt"
+	"net/http"
+	"net/url"
 	"testing"
 
 	"github.com/alibaba/higress/plugins/golang-filter/mcp-session/common"
@@ -460,5 +462,83 @@ func TestFindNextLineBreak(t *testing.T) {
 				t.Errorf("Expected line break '%v', got '%v'", []byte(tc.expectedBreak), []byte(lineBreak))
 			}
 		})
+	}
+}
+
+// minimal RequestHeaderMap mock for header-phase tests
+type testHeaderMap struct {
+	api.RequestHeaderMap
+	values map[string]string
+}
+
+func (h testHeaderMap) Get(key string) (string, bool) {
+	v, ok := h.values[key]
+	return v, ok
+}
+
+func (h testHeaderMap) Set(key, value string) { h.values[key] = value }
+func (h testHeaderMap) Del(key string)        { delete(h.values, key) }
+
+// TestRestUpstreamSkipsBodyBufferingWithoutRateLimit verifies that plain
+// REST/streamable MCP proxying does not buffer the request body, so that large
+// requests are not rejected with a 413. See #3238.
+func TestRestUpstreamSkipsBodyBufferingWithoutRateLimit(t *testing.T) {
+	mockAPI := &mockCommonCAPI{}
+	api.SetCommonCAPI(mockAPI)
+
+	for _, upstreamType := range []common.UpstreamType{common.RestUpstream, common.StreamableUpstream} {
+		t.Run(string(upstreamType), func(t *testing.T) {
+			parsedURL, _ := url.Parse("http://example.com/mcp/api")
+			f := &filter{
+				config:      &config{enableUserLevelServer: false},
+				matchedRule: common.MatchRule{UpstreamType: upstreamType},
+				needProcess: true,
+				req:         &http.Request{Method: http.MethodPost, URL: parsedURL},
+			}
+			header := testHeaderMap{values: map[string]string{}}
+
+			// endStream=false would previously return StopAndBuffer and buffer
+			// the whole body. Without rate limiting we should stream instead.
+			status := f.processMcpRequestHeadersForRestUpstream(header, false)
+			if status != api.Continue {
+				t.Errorf("expected api.Continue, got %v", status)
+			}
+			if !f.skipRequestBody {
+				t.Errorf("expected skipRequestBody to be true")
+			}
+
+			// DecodeData must then pass the body through untouched.
+			if got := f.DecodeData(nil, false); got != api.Continue {
+				t.Errorf("expected DecodeData to Continue when body is skipped, got %v", got)
+			}
+		})
+	}
+}
+
+// TestRestUpstreamBuffersBodyWhenRateLimitEnabled verifies that the body is
+// still buffered when user-level rate limiting is enabled, since that path
+// needs to inspect the JSON-RPC method in the body.
+func TestRestUpstreamBuffersBodyWhenRateLimitEnabled(t *testing.T) {
+	mockAPI := &mockCommonCAPI{}
+	api.SetCommonCAPI(mockAPI)
+
+	// Use a path with fewer than 3 segments so the config handler (which is
+	// nil in this test) is never queried; f.ratelimit is still set to true
+	// because enableUserLevelServer is enabled.
+	parsedURL, _ := url.Parse("http://example.com/mcp")
+	f := &filter{
+		config:      &config{enableUserLevelServer: true},
+		matchedRule: common.MatchRule{UpstreamType: common.RestUpstream},
+		needProcess: true,
+		req:         &http.Request{Method: http.MethodPost, URL: parsedURL},
+	}
+
+	header := testHeaderMap{values: map[string]string{}}
+	status := f.processMcpRequestHeadersForRestUpstream(header, false)
+	if status != api.StopAndBuffer {
+		t.Errorf("expected api.StopAndBuffer when rate limiting is enabled, got %v", status)
+	}
+	if f.skipRequestBody {
+		t.Errorf("expected skipRequestBody to be false when buffering is required")
 	}
 }


### PR DESCRIPTION
## Ⅰ. Describe what this PR did

The `mcp-session` filter used to return `StopAndBuffer` for REST/streamable MCP upstreams during plain proxying, buffering the **entire request body** even though the body is never parsed on that path. Once the buffered body exceeded Envoy's decoder buffer limit, the request was rejected with `413 Payload Too Large` before ever reaching the upstream. The golang filter SDK exposes no API to enlarge that buffer limit, so the fix removes the unnecessary buffering instead.

Now the request body is only buffered when user-level rate limiting is enabled (the only path that inspects the JSON-RPC method inside the body). For plain REST/streamable proxying the filter sets `skipRequestBody` and returns `Continue`, streaming the body straight to the upstream.

## Ⅱ. Does this pull request fix one issue?

fixes #3238

## Ⅲ. Why don't you add test cases (unit test/integration test)?

Unit tests are added in `filter_test.go`:
- `TestRestUpstreamSkipsBodyBufferingWithoutRateLimit` — REST and streamable upstreams stream the body (return `Continue`, `skipRequestBody == true`) instead of buffering it.
- `TestRestUpstreamBuffersBodyWhenRateLimitEnabled` — the body is still buffered (`StopAndBuffer`) when user-level rate limiting is enabled.

## Ⅳ. Describe how to verify it

1. `cd plugins/golang-filter && go test ./mcp-session/...` — all tests pass.
2. Manual: configure an `mcp-session` match rule with `upstream_type: rest` (or `streamable`) and `enable_user_level_server: false`, then send a POST whose body is larger than the downstream connection buffer limit (default 32 KiB). Before this change the request returns `413`; after it, the body is forwarded to the upstream.

## Ⅴ. Special notes for reviews

- The golang filter Go SDK (`contrib/golang/common/go/api`) has no method to raise the decoder buffer limit; the C++ side derives the watermark from `decoder_callbacks_->decoderBufferLimit()` (`processor_state.cc`), so enlarging the buffer from Go is not possible. Removing the needless buffering is the correct fix.
- The existing `skipRequestBody` flag and the early return in `DecodeData` are reused, so behavior for the SSE upstream, user-level config POST, and rate-limiting paths is unchanged.

## Ⅵ. AI Coding Tool Usage Checklist (if applicable)

**Please check all applicable items:**

- [x] **For regular updates/changes** (not new plugins):
  - [x] I have provided the prompts/instructions I gave to the AI Coding tool below
  - [x] I have included the AI Coding summary below

### AI Coding Prompts (for regular updates)

- Investigate upstream issue #3238 (mcp-session filter causes MCP requests with large body rejected with 413), confirm the root cause, and implement a fix following the project's conventions with tests.

### AI Coding Summary

- **Key decisions**: Confirmed via the vendored Envoy fork that the golang filter Go SDK has no API to enlarge the request-body buffer limit, so "enlarging the buffer" is not achievable from Go. Chose instead to stop buffering the body on the plain-proxy path where it is never read.
- **Major changes**: In `processMcpRequestHeadersForRestUpstream`, when user-level rate limiting is not enabled, set `skipRequestBody = true` and return `Continue` instead of `StopAndBuffer`, reusing the existing early return in `DecodeData`.
- **Considerations/limitations**: Body buffering is preserved when rate limiting is enabled, because that path inspects the JSON-RPC method in the body. SSE upstream, user-level config POST, and rate-limit behavior are unchanged.
