### PR TITLE
fix(mcp-server): allow custom server version

### DIFF
--- a/plugins/wasm-go/extensions/mcp-server/README.md
+++ b/plugins/wasm-go/extensions/mcp-server/README.md
@@ -11,13 +11,20 @@
 
 # 配置说明
 
-本插件通过编译期注册 MCP Server，**WasmPlugin 的 `defaultConfig` 通常无需额外字段**。具体工具列表、参数与鉴权由各子 Server 实现决定，开发新 MCP Server 请参考 [MCP Server 实现指南](../../mcp-servers/README.md)。
+本插件通过编译期注册 MCP Server，**WasmPlugin 的 `defaultConfig` 通常无需额外字段**。如需在 MCP `initialize` 响应中展示自定义服务版本，可在 `server.version` 中配置；未配置时默认返回 `1.0.0`。具体工具列表、参数与鉴权由各子 Server 实现决定，开发新 MCP Server 请参考 [MCP Server 实现指南](../../mcp-servers/README.md)。
 
 # 配置示例
 
 ```yaml
 # 多数场景下使用空配置或仅配置路由匹配即可
 {}
+```
+
+```yaml
+# 自定义 initialize 响应中的 serverInfo.version
+server:
+  name: quark-search
+  version: 2.5.0
 ```
 
 # 引用插件

--- a/plugins/wasm-go/extensions/mcp-server/main_test.go
+++ b/plugins/wasm-go/extensions/mcp-server/main_test.go
@@ -54,6 +54,35 @@ var restMCPServerConfig = func() json.RawMessage {
 	return data
 }()
 
+var restMCPServerWithVersionConfig = func() json.RawMessage {
+	data, _ := json.Marshal(map[string]interface{}{
+		"server": map[string]interface{}{
+			"name":    "rest-test-server",
+			"type":    "rest",
+			"version": "2.5.0",
+		},
+		"tools": []map[string]interface{}{
+			{
+				"name":        "get_weather",
+				"description": "获取天气信息",
+				"args": []map[string]interface{}{
+					{
+						"name":        "location",
+						"description": "城市名称",
+						"type":        "string",
+						"required":    true,
+					},
+				},
+				"requestTemplate": map[string]interface{}{
+					"url":    "https://httpbin.org/get?city={{.location}}",
+					"method": "GET",
+				},
+			},
+		},
+	})
+	return data
+}()
+
 // MCP代理服务器配置
 var mcpProxyServerConfig = func() json.RawMessage {
 	data, _ := json.Marshal(map[string]interface{}{
@@ -172,6 +201,51 @@ func TestMcpProxyServerConfig(t *testing.T) {
 // TestRestMCPServerBasicFlow 测试REST MCP服务器基本流程
 func TestRestMCPServerBasicFlow(t *testing.T) {
 	test.RunTest(t, func(t *testing.T) {
+		t.Run("initialize returns configured server version", func(t *testing.T) {
+			host, status := test.NewTestHost(restMCPServerWithVersionConfig)
+			defer host.Reset()
+			require.Equal(t, types.OnPluginStartStatusOK, status)
+
+			initializeRequest := `{
+				"jsonrpc": "2.0",
+				"id": 1,
+				"method": "initialize",
+				"params": {
+					"protocolVersion": "2025-03-26"
+				}
+			}`
+
+			host.InitHttp()
+
+			action := host.CallOnHttpRequestHeaders([][2]string{
+				{":authority", "mcp-server.example.com"},
+				{":method", "POST"},
+				{":path", "/mcp"},
+				{"content-type", "application/json"},
+			})
+			require.Equal(t, types.HeaderStopIteration, action)
+
+			action = host.CallOnHttpRequestBody([]byte(initializeRequest))
+			require.Equal(t, types.ActionContinue, action)
+
+			localResponse := host.GetLocalResponse()
+			require.NotNil(t, localResponse)
+			require.NotEmpty(t, localResponse.Data)
+
+			var response map[string]interface{}
+			err := json.Unmarshal(localResponse.Data, &response)
+			require.NoError(t, err)
+
+			result, ok := response["result"].(map[string]interface{})
+			require.True(t, ok)
+			serverInfo, ok := result["serverInfo"].(map[string]interface{})
+			require.True(t, ok)
+			require.Equal(t, "rest-test-server", serverInfo["name"])
+			require.Equal(t, "2.5.0", serverInfo["version"])
+
+			host.CompleteHttp()
+		})
+
 		t.Run("tools/list request", func(t *testing.T) {
 			host, status := test.NewTestHost(restMCPServerConfig)
 			defer host.Reset()

--- a/plugins/wasm-go/pkg/mcp/server/plugin.go
+++ b/plugins/wasm-go/pkg/mcp/server/plugin.go
@@ -27,14 +27,15 @@ import (
 	"github.com/invopop/jsonschema"
 	"github.com/tidwall/gjson"
 
-	"github.com/higress-group/wasm-go/pkg/log"
 	"github.com/alibaba/higress/plugins/wasm-go/pkg/mcp/utils"
+	"github.com/higress-group/wasm-go/pkg/log"
 	"github.com/higress-group/wasm-go/pkg/wrapper"
 )
 
 const (
 	DefaultMaxBodyBytes   uint32 = 100 * 1024 * 1024
 	GlobalToolRegistryKey        = "GlobalToolRegistry"
+	DefaultServerVersion         = "1.0.0"
 )
 
 // SupportedMCPVersions contains all supported MCP protocol versions
@@ -243,6 +244,7 @@ type ToolWithOutputSchema interface {
 // ToolSetConfig defines the configuration for a toolset.
 type ToolSetConfig struct {
 	Name        string             `json:"name"`
+	Version     string             `json:"version,omitempty"`
 	ServerTools []ServerToolConfig `json:"serverTools"`
 }
 
@@ -262,6 +264,7 @@ type ConfigOptions struct {
 
 type McpServerConfig struct {
 	serverName     string // Store the server name directly
+	serverVersion  string
 	server         Server // Can be a single server or a composed server
 	methodHandlers utils.MethodHandlers
 	toolSet        *ToolSetConfig // Parsed toolset configuration
@@ -273,9 +276,22 @@ func (c *McpServerConfig) GetServerName() string {
 	return c.serverName
 }
 
+// GetServerVersion returns the configured server version.
+func (c *McpServerConfig) GetServerVersion() string {
+	return c.serverVersion
+}
+
 // GetIsComposed returns whether this is a composed server for external access
 func (c *McpServerConfig) GetIsComposed() bool {
 	return c.isComposed
+}
+
+func normalizeServerVersion(version string) string {
+	version = strings.TrimSpace(version)
+	if version == "" {
+		return DefaultServerVersion
+	}
+	return version
 }
 
 // computeEffectiveAllowTools computes the effective allowTools by taking the intersection
@@ -338,6 +354,7 @@ func parseConfigCore(configJson gjson.Result, config *McpServerConfig, opts *Con
 	toolSetJson := configJson.Get("toolSet")
 	serverJson := configJson.Get("server")                        // This is for single server or REST server definition
 	pluginServerConfigJson := configJson.Get("server.config").Raw // Config for the plugin instance itself, if any.
+	config.serverVersion = DefaultServerVersion
 
 	// serverConfigJsonForInstance is the config passed to the specific server instance (single or REST)
 	// It's distinct from pluginServerConfigJson which might be for the mcp-server plugin itself.
@@ -351,6 +368,7 @@ func parseConfigCore(configJson gjson.Result, config *McpServerConfig, opts *Con
 		}
 		config.toolSet = &tsConfig
 		config.serverName = tsConfig.Name // Use toolSet name as the server name for composed server
+		config.serverVersion = normalizeServerVersion(tsConfig.Version)
 		log.Infof("Parsing toolSet configuration: %s", config.serverName)
 
 		composedServer := NewComposedMCPServer(config.serverName, tsConfig.ServerTools, opts.ToolRegistry)
@@ -363,6 +381,7 @@ func parseConfigCore(configJson gjson.Result, config *McpServerConfig, opts *Con
 		if config.serverName == "" {
 			return errors.New("server.name field is missing for single server config")
 		}
+		config.serverVersion = normalizeServerVersion(serverJson.Get("version").String())
 		// This is the config for the specific server being defined (e.g. REST server's own config)
 		serverConfigJsonForInstance = serverJson.Get("config").Raw
 		log.Infof("Parsing single server configuration: %s", config.serverName)
@@ -495,6 +514,7 @@ func parseConfigCore(configJson gjson.Result, config *McpServerConfig, opts *Con
 	config.methodHandlers = make(utils.MethodHandlers)
 	// Use config.serverName which is now reliably set
 	currentServerNameForHandlers := config.serverName
+	currentServerVersionForHandlers := config.serverVersion
 
 	config.methodHandlers["ping"] = func(ctx wrapper.HttpContext, id utils.JsonRpcID, params gjson.Result) error {
 		utils.OnMCPResponseSuccess(ctx, map[string]any{}, fmt.Sprintf("mcp:%s:ping", currentServerNameForHandlers))
@@ -534,7 +554,7 @@ func parseConfigCore(configJson gjson.Result, config *McpServerConfig, opts *Con
 			},
 			"serverInfo": map[string]any{
 				"name":    currentServerNameForHandlers, // Use the actual server name (single or composed)
-				"version": "1.0.0",
+				"version": currentServerVersionForHandlers,
 			},
 		}, fmt.Sprintf("mcp:%s:initialize", currentServerNameForHandlers))
 		return nil

--- a/plugins/wasm-go/pkg/mcp/server/plugin_test.go
+++ b/plugins/wasm-go/pkg/mcp/server/plugin_test.go
@@ -432,6 +432,75 @@ func TestParseConfigCore_McpProxy_HappyPath_NoTools(t *testing.T) {
 	assert.NotNil(t, c.methodHandlers["tools/call"])
 }
 
+func TestParseConfigCore_ServerVersion(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{
+			name: "defaults when missing",
+			raw: `{
+				"server":{
+					"name":"p",
+					"type":"mcp-proxy",
+					"transport":"http",
+					"mcpServerURL":"http://b"
+				}
+			}`,
+			want: DefaultServerVersion,
+		},
+		{
+			name: "uses configured server version",
+			raw: `{
+				"server":{
+					"name":"p",
+					"version":"2.3.4",
+					"type":"mcp-proxy",
+					"transport":"http",
+					"mcpServerURL":"http://b"
+				}
+			}`,
+			want: "2.3.4",
+		},
+		{
+			name: "trims configured server version",
+			raw: `{
+				"server":{
+					"name":"p",
+					"version":" 2.3.4 ",
+					"type":"mcp-proxy",
+					"transport":"http",
+					"mcpServerURL":"http://b"
+				}
+			}`,
+			want: "2.3.4",
+		},
+		{
+			name: "blank configured server version falls back to default",
+			raw: `{
+				"server":{
+					"name":"p",
+					"version":" ",
+					"type":"mcp-proxy",
+					"transport":"http",
+					"mcpServerURL":"http://b"
+				}
+			}`,
+			want: DefaultServerVersion,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &McpServerConfig{}
+			err := ParseConfigCore(gjson.Parse(tt.raw), c, newValidationOpts())
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, c.GetServerVersion())
+		})
+	}
+}
+
 func TestParseConfigCore_McpProxy_BadProxyToolJson(t *testing.T) {
 	c := &McpServerConfig{}
 	err := ParseConfigCore(gjson.Parse(`{
@@ -566,6 +635,25 @@ func TestParseConfigCore_ToolSet_HappyPath(t *testing.T) {
 	assert.True(t, c.GetIsComposed(), "toolSet must produce a composed server")
 	assert.Equal(t, "compound", c.GetServerName(), "composed server uses toolSet.name as serverName")
 	require.NotNil(t, c.server)
+}
+
+func TestParseConfigCore_ToolSetVersion(t *testing.T) {
+	opts := newValidationOpts()
+	opts.ToolRegistry.RegisterTool("alpha", "search", &stubTool{
+		desc:  "alpha search",
+		input: map[string]any{"type": "object"},
+	})
+
+	c := &McpServerConfig{}
+	err := ParseConfigCore(gjson.Parse(`{
+		"toolSet":{
+			"name":"compound",
+			"version":"3.0.1",
+			"serverTools":[{"serverName":"alpha","tools":["search"]}]
+		}
+	}`), c, opts)
+	require.NoError(t, err)
+	assert.Equal(t, "3.0.1", c.GetServerVersion())
 }
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
## What changed

- Added an optional MCP server version field parsed from `server.version` for single servers and `toolSet.version` for composed servers.
- Kept the existing default `serverInfo.version` as `1.0.0` when the field is omitted or blank.
- Returned the configured version in the MCP `initialize` response under `serverInfo.version` instead of always returning `1.0.0`.
- Documented `server.version` in the mcp-server README.

Fixes #4056.

## Validation

- `go test ./server -count=1` from `plugins/wasm-go/pkg/mcp`
- `go test . -run '^TestRestMCPServerBasicFlow$' -count=1` from `plugins/wasm-go/extensions/mcp-server`
- `git diff --check`

Note: local `go test . -count=1` in `plugins/wasm-go/extensions/mcp-server` was also attempted. It reached the existing REST tool-call branch after the new initialize version test had passed, then crashed with a Go runtime `SIGBUS`; no assertion failure was reported before the runtime crash.
