### PR TITLE
fix(ai-proxy): guard malformed multimodal content

### DIFF
--- a/plugins/wasm-go/extensions/ai-proxy/provider/model.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/model.go
@@ -452,10 +452,14 @@ func (m *chatMessage) ParseContent() []chatMessageContent {
 				}
 			case contentTypeImageUrl:
 				if subObj, ok := contentMap[contentTypeImageUrl].(map[string]any); ok {
+					imageUrl, ok := stringField(subObj, "url")
+					if !ok {
+						continue
+					}
 					msg := chatMessageContent{
 						Type: contentTypeImageUrl,
 						ImageUrl: &chatMessageContentImageUrl{
-							Url: subObj["url"].(string),
+							Url: imageUrl,
 						},
 					}
 					if detail, ok := subObj["detail"].(string); ok {
@@ -465,20 +469,29 @@ func (m *chatMessage) ParseContent() []chatMessageContent {
 				}
 			case contentTypeInputAudio:
 				if subObj, ok := contentMap[contentTypeInputAudio].(map[string]any); ok {
+					data, dataOk := stringField(subObj, "data")
+					format, formatOk := stringField(subObj, "format")
+					if !dataOk || !formatOk {
+						continue
+					}
 					contentList = append(contentList, chatMessageContent{
 						Type: contentTypeInputAudio,
 						InputAudio: &chatMessageContentAudio{
-							Data:   subObj["data"].(string),
-							Format: subObj["format"].(string),
+							Data:   data,
+							Format: format,
 						},
 					})
 				}
 			case contentTypeFile:
 				if subObj, ok := contentMap[contentTypeFile].(map[string]any); ok {
+					fileId, ok := stringField(subObj, "file_id")
+					if !ok {
+						continue
+					}
 					contentList = append(contentList, chatMessageContent{
 						Type: contentTypeFile,
 						File: &chatMessageContentFile{
-							FileId: subObj["file_id"].(string),
+							FileId: fileId,
 							// FileName: subObj["file_name"].(string),
 							// FileData: subObj["file_data"].(string),
 						},
@@ -489,6 +502,11 @@ func (m *chatMessage) ParseContent() []chatMessageContent {
 		return contentList
 	}
 	return nil
+}
+
+func stringField(values map[string]any, key string) (string, bool) {
+	value, ok := values[key].(string)
+	return value, ok
 }
 
 type toolCall struct {

--- a/plugins/wasm-go/extensions/ai-proxy/provider/model_test.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/model_test.go
@@ -1,0 +1,84 @@
+package provider
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestChatMessageParseContentSkipsMalformedMultimodalParts(t *testing.T) {
+	msg := &chatMessage{
+		Content: []any{
+			map[string]any{
+				"type": "text",
+				"text": "keep text",
+			},
+			map[string]any{
+				"type":      "image_url",
+				"image_url": map[string]any{},
+			},
+			map[string]any{
+				"type": "image_url",
+				"image_url": map[string]any{
+					"url": 123,
+				},
+			},
+			map[string]any{
+				"type": "image_url",
+				"image_url": map[string]any{
+					"url":    "https://example.com/image.png",
+					"detail": "high",
+				},
+			},
+			map[string]any{
+				"type": "input_audio",
+				"input_audio": map[string]any{
+					"data": "abc",
+				},
+			},
+			map[string]any{
+				"type": "input_audio",
+				"input_audio": map[string]any{
+					"data":   123,
+					"format": "wav",
+				},
+			},
+			map[string]any{
+				"type": "input_audio",
+				"input_audio": map[string]any{
+					"data":   "abc",
+					"format": "wav",
+				},
+			},
+			map[string]any{
+				"type": "file",
+				"file": map[string]any{
+					"file_id": 123,
+				},
+			},
+			map[string]any{
+				"type": "file",
+				"file": map[string]any{
+					"file_id": "file-123",
+				},
+			},
+		},
+	}
+
+	contents := msg.ParseContent()
+
+	require.Len(t, contents, 4)
+	assert.Equal(t, chatMessageContent{
+		Type: contentTypeText,
+		Text: "keep text",
+	}, contents[0])
+	require.NotNil(t, contents[1].ImageUrl)
+	assert.Equal(t, "https://example.com/image.png", contents[1].ImageUrl.Url)
+	assert.Equal(t, "high", contents[1].ImageUrl.Detail)
+	require.NotNil(t, contents[2].InputAudio)
+	assert.Equal(t, "abc", contents[2].InputAudio.Data)
+	assert.Equal(t, "wav", contents[2].InputAudio.Format)
+	require.NotNil(t, contents[3].File)
+	assert.Equal(t, "file-123", contents[3].File.FileId)
+}


### PR DESCRIPTION
### What this PR does

Fixes #4301.

This updates `chatMessage.ParseContent` so malformed multimodal content parts do not panic the ai-proxy plugin:

- skips `image_url` parts when `image_url.url` is missing or not a string
- skips `input_audio` parts when `data` or `format` is missing or not a string
- skips `file` parts when `file.file_id` is missing or not a string
- preserves valid text, image, audio, and file parts in the same message

### Validation

```bash
go test ./provider -run '^TestChatMessageParseContentSkipsMalformedMultimodalParts$' -count=1 -v
go test ./provider -count=1
git diff --check
```
