### PR TITLE
fix(ai-agent): format path arguments safely

### DIFF
--- a/plugins/wasm-go/extensions/ai-agent/main.go
+++ b/plugins/wasm-go/extensions/ai-agent/main.go
@@ -446,7 +446,7 @@ func toolsCall(ctx wrapper.HttpContext, llmClient wrapper.HttpClient, llmInfo LL
 									// 删除已经使用过的
 									delete(data, param)
 									// 替换模板中的占位符
-									urlParts[i] = url.QueryEscape(value.(string))
+									urlParts[i] = url.QueryEscape(fmt.Sprintf("%v", value))
 								}
 							}
 						}

--- a/plugins/wasm-go/extensions/ai-agent/main_test.go
+++ b/plugins/wasm-go/extensions/ai-agent/main_test.go
@@ -660,6 +660,106 @@ func TestOnHttpRequestBody(t *testing.T) {
 
 func TestOnHttpResponseBody(t *testing.T) {
 	test.RunTest(t, func(t *testing.T) {
+		t.Run("tool call with non-string path parameter", func(t *testing.T) {
+			pathParamConfig := func() json.RawMessage {
+				data, _ := json.Marshal(map[string]interface{}{
+					"returnResponseTemplate": `{"id":"error","choices":[{"index":0,"message":{"role":"assistant","content":"%s"},"finish_reason":"stop"}],"model":"gpt-4o","object":"chat.completion","usage":{"prompt_tokens":0,"completion_tokens":0,"total_tokens":0}}`,
+					"llm": map[string]interface{}{
+						"apiKey":      "test-api-key",
+						"serviceName": "llm-service",
+						"servicePort": 8080,
+						"domain":      "llm.example.com",
+						"path":        "/v1/chat/completions",
+						"model":       "qwen-turbo",
+					},
+					"apis": []map[string]interface{}{
+						{
+							"apiProvider": map[string]interface{}{
+								"serviceName": "api-service",
+								"servicePort": 9090,
+								"domain":      "api.example.com",
+							},
+							"api": `openapi: 3.0.0
+info:
+  title: Test API
+  version: 1.0.0
+servers:
+  - url: https://api.example.com
+paths:
+  /users/{id}:
+    get:
+      operationId: getUser
+      summary: Get user
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+        - name: active
+          in: query
+          required: false
+          schema:
+            type: boolean`,
+						},
+					},
+					"promptTemplate": map[string]interface{}{
+						"language": "EN",
+					},
+				})
+				return data
+			}()
+
+			host, status := test.NewTestHost(pathParamConfig)
+			defer host.Reset()
+			require.Equal(t, types.OnPluginStartStatusOK, status)
+
+			host.CallOnHttpRequestHeaders([][2]string{
+				{":authority", "example.com"},
+				{":path", "/api/chat"},
+				{":method", "POST"},
+				{"content-type", "application/json"},
+			})
+
+			requestBody := `{
+				"model": "qwen-turbo",
+				"messages": [
+					{
+						"role": "user",
+						"content": "查询用户"
+					}
+				],
+				"stream": false
+			}`
+			host.CallOnHttpRequestBody([]byte(requestBody))
+
+			llmResponse := `{
+				"id": "chatcmpl-123",
+				"choices": [
+					{
+						"index": 0,
+						"message": {
+							"role": "assistant",
+							"content": "{\"action\": \"getUser\", \"action_input\": \"{\\\"id\\\": 123, \\\"active\\\": true}\"}"
+						},
+						"finish_reason": "stop"
+					}
+				],
+				"created": 1677652288,
+				"model": "qwen-turbo",
+				"object": "chat.completion",
+				"usage": {
+					"prompt_tokens": 10,
+					"completion_tokens": 20,
+					"total_tokens": 30
+				}
+			}`
+
+			action := host.CallOnHttpResponseBody([]byte(llmResponse))
+
+			require.Equal(t, types.ActionPause, action)
+		})
+
 		t.Run("valid LLM response with content", func(t *testing.T) {
 			host, status := test.NewTestHost(httpTestConfig)
 			defer host.Reset()


### PR DESCRIPTION
### What this PR does

Fixes #4299.

This updates `ai-agent` tool path parameter substitution so JSON arguments are formatted the same way as query parameters before URL escaping. Non-string values such as numbers and booleans no longer panic request processing.

### Validation

```bash
go test . -run '^TestOnHttpResponseBody$' -count=1 -v
go test . -count=1
git diff --check
```
