### PR TITLE
fix(mcp): pass through REST authorization header

### DIFF
--- a/plugins/wasm-go/pkg/mcp/server/rest_server.go
+++ b/plugins/wasm-go/pkg/mcp/server/rest_server.go
@@ -26,8 +26,8 @@ import (
 	"github.com/higress-group/proxy-wasm-go-sdk/proxywasm"
 	"github.com/tidwall/sjson"
 
-	"github.com/higress-group/wasm-go/pkg/log"
 	"github.com/alibaba/higress/plugins/wasm-go/pkg/mcp/utils"
+	"github.com/higress-group/wasm-go/pkg/log"
 	"github.com/higress-group/wasm-go/pkg/wrapper"
 )
 
@@ -356,10 +356,13 @@ func (s *RestMCPServer) GetConfig(v any) {
 // Clone implements Server interface
 func (s *RestMCPServer) Clone() Server {
 	newServer := &RestMCPServer{
-		name:            s.name,
-		base:            s.base.CloneBase(),
-		toolsConfig:     make(map[string]RestTool),
-		securitySchemes: make(map[string]SecurityScheme), // Initialize the map
+		name:                      s.name,
+		base:                      s.base.CloneBase(),
+		toolsConfig:               make(map[string]RestTool),
+		securitySchemes:           make(map[string]SecurityScheme), // Initialize the map
+		defaultDownstreamSecurity: s.defaultDownstreamSecurity,
+		defaultUpstreamSecurity:   s.defaultUpstreamSecurity,
+		passthroughAuthHeader:     s.passthroughAuthHeader,
 	}
 	for k, v := range s.toolsConfig {
 		newServer.toolsConfig[k] = v
@@ -628,11 +631,14 @@ func (t *RestMCPTool) Call(httpCtx HttpContext, server Server) error {
 		headers = append(headers, [2]string{header.Key, value})
 	}
 
-	// Authorization or specific API key headers are handled by extractAndRemoveIncomingCredential if tool-level security is defined.
-	// If no tool-level security is defined, this generic RemoveHttpRequestHeader("Authorization") acts as a fallback.
-	// Unless passthroughAuthHeader is explicitly set to true.
-	if t.toolConfig.Security.ID == "" {
-		if !restServer.GetPassthroughAuthHeader() {
+	// Authorization or specific API key headers are handled by extractAndRemoveIncomingCredential if downstream security is defined.
+	// If no downstream security is defined, RemoveHttpRequestHeader("Authorization") acts as a fallback unless
+	// passthroughAuthHeader is explicitly set to true.
+	if downstreamSecurity.ID == "" {
+		if restServer.GetPassthroughAuthHeader() {
+			authHeader, _ := proxywasm.GetHttpRequestHeader("Authorization")
+			appendPassthroughAuthHeader(&headers, authHeader)
+		} else {
 			proxywasm.RemoveHttpRequestHeader("Authorization") // Remove if not handled by specific scheme
 		}
 	}
@@ -1012,6 +1018,13 @@ func (t *RestMCPTool) InputSchema() map[string]any {
 // OutputSchema implements Tool interface (MCP Protocol Version 2025-06-18)
 func (t *RestMCPTool) OutputSchema() map[string]any {
 	return t.toolConfig.OutputSchema
+}
+
+func appendPassthroughAuthHeader(headers *[][2]string, authHeader string) {
+	if authHeader == "" {
+		return
+	}
+	setOrReplaceHeader(headers, "Authorization", authHeader)
 }
 
 func convertHeaders(responseHeaders [][2]string) map[string]string {

--- a/plugins/wasm-go/pkg/mcp/server/rest_server_test.go
+++ b/plugins/wasm-go/pkg/mcp/server/rest_server_test.go
@@ -1059,12 +1059,12 @@ func TestParseTemplates_HeaderWithEmptyKeySkipped(t *testing.T) {
 
 func TestParseTemplates_PopulatesArgPositions(t *testing.T) {
 	tool := RestTool{
-		RequestTemplate: RestToolRequestTemplate{URL: "http://x", Method: "GET"},
+		RequestTemplate:  RestToolRequestTemplate{URL: "http://x", Method: "GET"},
 		ResponseTemplate: RestToolResponseTemplate{Body: "{{.}}"},
 		Args: []RestToolArg{
-			{Name: "q", Position: "QUERY"},  // lower-cased in argPositions
+			{Name: "q", Position: "QUERY"}, // lower-cased in argPositions
 			{Name: "h", Position: "Header"},
-			{Name: "noPos"},                   // no position → not stored
+			{Name: "noPos"}, // no position → not stored
 		},
 	}
 	require := assert.New(t)
@@ -1142,6 +1142,8 @@ func TestRestServer_GetToolConfig(t *testing.T) {
 func TestRestServer_Clone_Independence(t *testing.T) {
 	orig := NewRestMCPServer("rest")
 	orig.SetPassthroughAuthHeader(true)
+	orig.SetDefaultDownstreamSecurity(SecurityRequirement{ID: "K", Passthrough: true})
+	orig.SetDefaultUpstreamSecurity(SecurityRequirement{ID: "K", Credential: "server-token"})
 	orig.SetConfig([]byte(`{"v":1}`))
 	orig.AddSecurityScheme(SecurityScheme{ID: "K", Type: "apiKey", In: "header", Name: "X"})
 	require.NoError(t, orig.AddRestTool(RestTool{
@@ -1153,6 +1155,10 @@ func TestRestServer_Clone_Independence(t *testing.T) {
 	require.NotNil(t, clonedI)
 	cloned, ok := clonedI.(*RestMCPServer)
 	require.True(t, ok)
+
+	assert.True(t, cloned.GetPassthroughAuthHeader())
+	assert.Equal(t, orig.GetDefaultDownstreamSecurity(), cloned.GetDefaultDownstreamSecurity())
+	assert.Equal(t, orig.GetDefaultUpstreamSecurity(), cloned.GetDefaultUpstreamSecurity())
 
 	// Mutate the original: cloned must not see the change.
 	orig.AddSecurityScheme(SecurityScheme{ID: "K2", Type: "apiKey", In: "header", Name: "Y"})
@@ -1273,6 +1279,42 @@ func TestRestMCPTool_Create_MalformedJSONStillProducesTool(t *testing.T) {
 	// Bad JSON is logged + ignored; defaults still applied.
 	created := tool.Create([]byte("{not json")).(*RestMCPTool)
 	assert.Equal(t, 7, created.arguments["d"], "default still applied when params unparseable")
+}
+
+func TestAppendPassthroughAuthHeader(t *testing.T) {
+	t.Run("appends authorization header", func(t *testing.T) {
+		headers := [][2]string{{"Accept", "*/*"}}
+
+		appendPassthroughAuthHeader(&headers, "Bearer client-token")
+
+		value, ok := findHeader(headers, "Authorization")
+		require.True(t, ok)
+		assert.Equal(t, "Bearer client-token", value)
+		assert.Equal(t, 1, countHeader(headers, "Authorization"))
+	})
+
+	t.Run("replaces existing authorization header", func(t *testing.T) {
+		headers := [][2]string{
+			{"Authorization", "Bearer configured-token"},
+			{"Accept", "*/*"},
+		}
+
+		appendPassthroughAuthHeader(&headers, "Bearer client-token")
+
+		value, ok := findHeader(headers, "Authorization")
+		require.True(t, ok)
+		assert.Equal(t, "Bearer client-token", value)
+		assert.Equal(t, 1, countHeader(headers, "Authorization"))
+	})
+
+	t.Run("ignores empty authorization header", func(t *testing.T) {
+		headers := [][2]string{{"Accept", "*/*"}}
+
+		appendPassthroughAuthHeader(&headers, "")
+
+		_, ok := findHeader(headers, "Authorization")
+		assert.False(t, ok)
+	})
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
### What this PR does

Fixes #4221.

This fixes `server.passthroughAuthHeader` for REST-to-MCP tools:

- when no downstream security is configured and `passthroughAuthHeader` is enabled, the incoming `Authorization` header is copied into the REST tool outbound request headers
- when passthrough is disabled, the existing fallback still removes the incoming `Authorization` header
- `RestMCPServer.Clone()` now preserves `passthroughAuthHeader` and default security settings so cloned REST servers do not lose the parsed auth behavior

### Validation

```bash
go test ./server -run 'TestAppendPassthroughAuthHeader|TestRestServer_Clone_Independence' -count=1 -v
go test ./server -count=1
go test ./... -count=1
git diff --check
```
