### PR TITLE
fix(transformer): skip unmatched pattern rules

### DIFF
--- a/plugins/wasm-go/extensions/transformer/main.go
+++ b/plugins/wasm-go/extensions/transformer/main.go
@@ -934,7 +934,11 @@ func (h kvHandler) handle(host, path string, kvs map[string][]string, mapSourceD
 			for _, replace := range kvtOp.replaceKvtGroup {
 				key, newValue := replace.key, replace.newValue
 				if replace.reg != nil {
-					newValue = replace.reg.matchAndReplace(newValue, host, path)
+					var matched bool
+					newValue, matched = replace.reg.matchAndReplace(newValue, host, path)
+					if !matched {
+						continue
+					}
 				}
 				kvs[key] = []string{newValue}
 			}
@@ -946,7 +950,11 @@ func (h kvHandler) handle(host, path string, kvs map[string][]string, mapSourceD
 					continue
 				}
 				if add.reg != nil {
-					value = add.reg.matchAndReplace(value, host, path)
+					var matched bool
+					value, matched = add.reg.matchAndReplace(value, host, path)
+					if !matched {
+						continue
+					}
 				}
 				kvs[key] = []string{value}
 			}
@@ -956,7 +964,11 @@ func (h kvHandler) handle(host, path string, kvs map[string][]string, mapSourceD
 			for _, append_ := range kvtOp.appendKvtGroup {
 				key, appendValue := append_.key, append_.appendValue
 				if append_.reg != nil {
-					appendValue = append_.reg.matchAndReplace(appendValue, host, path)
+					var matched bool
+					appendValue, matched = append_.reg.matchAndReplace(appendValue, host, path)
+					if !matched {
+						continue
+					}
 				}
 				kvs[key] = append(kvs[key], appendValue)
 			}
@@ -1071,7 +1083,11 @@ func (h jsonHandler) handle(host, path string, oriData []byte, mapSourceData map
 			for _, replace := range kvtOp.replaceKvtGroup {
 				key, newValue, valueType := replace.key, replace.newValue, replace.typ
 				if valueType == "string" && replace.reg != nil {
-					newValue = replace.reg.matchAndReplace(newValue, host, path)
+					var matched bool
+					newValue, matched = replace.reg.matchAndReplace(newValue, host, path)
+					if !matched {
+						continue
+					}
 				}
 				convertedNewValue, err := convertByJsonType(valueType, newValue)
 				if err != nil {
@@ -1089,7 +1105,11 @@ func (h jsonHandler) handle(host, path string, oriData []byte, mapSourceData map
 					continue
 				}
 				if valueType == "string" && add.reg != nil {
-					value = add.reg.matchAndReplace(value, host, path)
+					var matched bool
+					value, matched = add.reg.matchAndReplace(value, host, path)
+					if !matched {
+						continue
+					}
 				}
 				convertedValue, err := convertByJsonType(valueType, value)
 				if err != nil {
@@ -1105,7 +1125,11 @@ func (h jsonHandler) handle(host, path string, oriData []byte, mapSourceData map
 			for _, append_ := range kvtOp.appendKvtGroup {
 				key, appendValue, valueType := append_.key, append_.appendValue, append_.typ
 				if valueType == "string" && append_.reg != nil {
-					appendValue = append_.reg.matchAndReplace(appendValue, host, path)
+					var matched bool
+					appendValue, matched = append_.reg.matchAndReplace(appendValue, host, path)
+					if !matched {
+						continue
+					}
 				}
 				convertedAppendValue, err := convertByJsonType(valueType, appendValue)
 				if err != nil {
@@ -1476,12 +1500,12 @@ func newReg(hostPatten, pathPatten string) (r *reg, err error) {
 	return
 }
 
-func (r reg) matchAndReplace(value, host, path string) string {
+func (r reg) matchAndReplace(value, host, path string) (string, bool) {
 	if r.hostReg != nil && r.hostReg.MatchString(host) {
-		return r.hostReg.ReplaceAllString(host, value)
+		return r.hostReg.ReplaceAllString(host, value), true
 	}
 	if r.pathReg != nil && r.pathReg.MatchString(path) {
-		return r.pathReg.ReplaceAllString(path, value)
+		return r.pathReg.ReplaceAllString(path, value), true
 	}
-	return value
+	return value, false
 }

--- a/plugins/wasm-go/extensions/transformer/main_test.go
+++ b/plugins/wasm-go/extensions/transformer/main_test.go
@@ -199,12 +199,12 @@ func TestRequest_Headers_DedupeStrategies(t *testing.T) {
 		// for SPLIT_*, input has a single value containing commas.
 		want []string
 	}{
-		{"", []string{"a", "b", "a", "c"}, []string{"a"}},                                // default = RETAIN_FIRST
-		{"RETAIN_FIRST", []string{"a", "b", "a", "c"}, []string{"a"}},                    // explicit
-		{"RETAIN_LAST", []string{"a", "b", "a", "c"}, []string{"c"}},                     // last only
-		{"RETAIN_UNIQUE", []string{"a", "b", "a", "c"}, []string{"a", "b", "c"}},         // dedup preserving order
-		{"SPLIT_AND_RETAIN_FIRST", []string{"x,y,z"}, []string{"x"}},                     // split first value, keep first part
-		{"SPLIT_AND_RETAIN_LAST", []string{"x,y,z"}, []string{"z"}},                      // split first value, keep last part
+		{"", []string{"a", "b", "a", "c"}, []string{"a"}},                        // default = RETAIN_FIRST
+		{"RETAIN_FIRST", []string{"a", "b", "a", "c"}, []string{"a"}},            // explicit
+		{"RETAIN_LAST", []string{"a", "b", "a", "c"}, []string{"c"}},             // last only
+		{"RETAIN_UNIQUE", []string{"a", "b", "a", "c"}, []string{"a", "b", "c"}}, // dedup preserving order
+		{"SPLIT_AND_RETAIN_FIRST", []string{"x,y,z"}, []string{"x"}},             // split first value, keep first part
+		{"SPLIT_AND_RETAIN_LAST", []string{"x,y,z"}, []string{"z"}},              // split first value, keep last part
 	}
 	for _, tc := range tests {
 		t.Run(tc.strategy, func(t *testing.T) {
@@ -486,7 +486,7 @@ func TestRequest_Headers_AddWithHostPattern(t *testing.T) {
 	})
 }
 
-func TestRequest_Headers_AddWithPathPattern_NoMatchKeepsValue(t *testing.T) {
+func TestRequest_Headers_AddWithPathPattern_NoMatchSkipsAdd(t *testing.T) {
 	test.RunTest(t, func(t *testing.T) {
 		host, status := test.NewTestHost(configJSON(map[string]any{
 			"reqRules": []map[string]any{
@@ -505,7 +505,31 @@ func TestRequest_Headers_AddWithPathPattern_NoMatchKeepsValue(t *testing.T) {
 		}))
 
 		got := headersToMap(host.GetRequestHeaders())
-		require.Equal(t, []string{"literal"}, got["x-v"])
+		require.NotContains(t, got, "x-v")
+		host.CompleteHttp()
+	})
+}
+
+func TestRequest_Headers_AddSameHeaderWithDifferentPathPatterns(t *testing.T) {
+	test.RunTest(t, func(t *testing.T) {
+		host, status := test.NewTestHost(configJSON(map[string]any{
+			"reqRules": []map[string]any{
+				{"operate": "add", "headers": []map[string]any{
+					{"key": "access-appId", "value": "ij2b6Nfg", "path_pattern": `^/test/.*`},
+					{"key": "access-appId", "value": "Y6JK5J7T", "path_pattern": `^/prod/.*`},
+				}},
+			},
+		}))
+		defer host.Reset()
+		require.Equal(t, types.OnPluginStartStatusOK, status)
+
+		require.Equal(t, types.ActionContinue, host.CallOnHttpRequestHeaders([][2]string{
+			{":authority", "test.com"},
+			{":path", "/prod/chat"},
+		}))
+
+		got := headersToMap(host.GetRequestHeaders())
+		require.Equal(t, []string{"Y6JK5J7T"}, got["access-appid"])
 		host.CompleteHttp()
 	})
 }


### PR DESCRIPTION
## Ⅰ. Describe what this PR did

Fixes transformer pattern-scoped operations so `host_pattern` / `path_pattern` act as match conditions. If a pattern does not match the current request host/path, the corresponding `replace`, `add`, or `append` item is skipped instead of writing its literal value.

This allows multiple same-name header rules with different path patterns to select the matching value, instead of the first item creating the header and blocking later matching items.

## Ⅱ. Does this pull request fix one issue?

fixes #4132

## Ⅲ. Why don't you add test cases (unit test/integration test)? 

Added focused transformer regression tests for unmatched path patterns and same-name headers with different path patterns.

## Ⅳ. Describe how to verify it

```bash
go test . -run '^TestRequest_Headers_AddWithPathPattern_NoMatchSkipsAdd$' -count=1 -v
go test . -run '^TestRequest_Headers_AddSameHeaderWithDifferentPathPatterns$' -count=1 -v
go test . -count=1
git diff --check
```

All commands were run from `plugins/wasm-go/extensions/transformer`.

## Ⅴ. Special notes for reviews

This changes the previous fallback behavior where an unmatched pattern still wrote the unexpanded literal value. The documented meaning of `host_pattern` / `path_pattern` is a match rule, so skipping unmatched items avoids leaking values from unrelated path-specific rules.

## Ⅵ. AI Coding Tool Usage Checklist (if applicable)

**Please check all applicable items:**

- [x] **For regular updates/changes** (not new plugins):
  - [x] I have provided the prompts/instructions I gave to the AI Coding tool below
  - [x] I have included the AI Coding summary below

### AI Coding Prompts (for regular updates)

Handle Higress issue #4132 and keep the change focused with tests and DCO.

### AI Coding Summary

- Changed transformer regex-scoped `replace`, `add`, and `append` handling to skip unmatched `host_pattern` / `path_pattern` items.
- Added regression coverage for unmatched path patterns and same-name headers with different path patterns.
- Verified the transformer package tests pass in both Go and wasm test modes.
