### PR TITLE
bugfix(wasm-rust): run tests for targeted plugin builds

### DIFF
--- a/tools/hack/build-wasm-plugins.sh
+++ b/tools/hack/build-wasm-plugins.sh
@@ -50,6 +50,7 @@ then
     else
         echo "🚀 Build Rust WasmPlugin: $INNER_PLUGIN_NAME"
         PLUGIN_NAME=${INNER_PLUGIN_NAME} make lint 
+        PLUGIN_NAME=${INNER_PLUGIN_NAME} make test
         PLUGIN_NAME=${INNER_PLUGIN_NAME} make build
     fi
 else

--- a/tools/hack/build-wasm-plugins_test.sh
+++ b/tools/hack/build-wasm-plugins_test.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2026 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR/../.." && pwd)
+MAKE_LOG=$(mktemp)
+trap 'rm -f "$MAKE_LOG"' EXIT
+export MAKE_LOG
+
+# 用 make 桩记录调用，避免测试触发真实的 Rust、WASM 或镜像构建。
+make() {
+    printf '%s:%s\n' "${PLUGIN_NAME-}" "$*" >> "$MAKE_LOG"
+}
+export -f make
+
+(
+    cd "$REPO_ROOT"
+    PLUGIN_TYPE=RUST PLUGIN_NAME=test-plugin \
+        bash tools/hack/build-wasm-plugins.sh >/dev/null
+)
+
+actual=$(<"$MAKE_LOG")
+expected=$'test-plugin:lint-base\ntest-plugin:test-base\ntest-plugin:lint\ntest-plugin:test\ntest-plugin:build'
+if [[ "$actual" != "$expected" ]]; then
+    printf 'unexpected make call sequence:\n%s\n' "$actual" >&2
+    printf 'expected:\n%s\n' "$expected" >&2
+    exit 1
+fi


### PR DESCRIPTION
<!-- issue-spec-inflight-disclosure:v1 -->
## I. Summary

This is a reporting-only update for an in-flight, materially agent-assisted contribution opened before Higress adopted the issue-spec gate. The implementation summary and original verification record are preserved verbatim in Section VIII. No code, commit, or review head is changed by this disclosure update.

## II. Related issue

Fixes #4337

Reproduction and problem statement: https://github.com/higress-group/higress/issues/4337

## III. Change type

- [x] Bug fix
- [ ] Feature or enhancement
- [ ] Documentation or configuration only
- [ ] Refactoring, tests, or maintenance

## IV. Agent participation and issue-spec gate

- [ ] **No agent participation:** This PR is human-only.
- [ ] **Trivial agent-use exception:** Agent use was limited to spelling, punctuation, whitespace, or formatting with no substantive choice or behavioral effect; the explanation is below.
- [x] **Material agent participation:** An AI or coding agent materially participated in analysis, design, implementation, testing, or PR preparation.

For material participation, check each timed obligation:

- [ ] **Before implementation began:** A Higress maintainer had approved the Proposal and Design Issues, and authorized implementation TASKs linked the work to the applicable SPECs.
- [ ] **Before verification began:** The Design contained a concrete Verification Plan.
- [ ] **Before requesting maintainer review or acceptance:** Applicable implementation and verification TASKs were `done` with exact commands, results, evidence links, and hashes.

Then choose exactly one overall gate status:

- [ ] Complete: all three timed obligations above were satisfied.
- [x] Noncompliant: one or more obligations were not satisfied; explain below.
- [ ] N/A because the PR is human-only or qualifies for the trivial exception.

**Gate-status explanation (or N/A):**

This PR was opened at 2026-08-08T06:35:08Z, before policy commit [`13d2c5446ed232eb439b682bbf1abc22433e81a9`](https://github.com/higress-group/higress/commit/13d2c5446ed232eb439b682bbf1abc22433e81a9) merged on 2026-08-08T11:05:38Z. It is an in-flight materially agent-assisted contribution. Retroactive Proposal/Design approval does not exist and is not fabricated; this PR is explicitly marked Noncompliant while adding best-effort traceability and evidence.

**Trivial-exception explanation (or N/A):**

N/A — material agent participation is declared above.

**Approved Proposal Issue URL (or N/A with explanation):**

N/A — https://github.com/higress-group/higress/issues/4337 is a reproduction/tracking issue, not an approved issue-spec Proposal.

**Approved Design Issue URL (or N/A with explanation):**

N/A — no retroactive Design artifact or approval is claimed.

**Maintainer approval link(s) (or N/A with explanation):**

N/A — no retroactive Proposal/Design approval is claimed.

**Authorized implementation TASK link(s) (or N/A with explanation):**

N/A — no retroactive TASK authorization is claimed.

**Verification Plan and verification TASK/evidence link(s) (or N/A with explanation):**

N/A — no pre-approved Verification Plan or verification TASK exists. Best-effort verification is preserved in Section VIII without representing it as issue-spec evidence.

## V. Testing and verification

**Test and deterministic rerun commands (or N/A with explanation):**

```text
See Section VIII, "Describe how to verify it." This body-only update does not claim that tests were rerun.
```

**Environment and configuration (or N/A with explanation):**

N/A — the original submission did not record a complete OS, architecture, and toolchain matrix; that omission remains explicit.

**Exact tested revision, version, image tag/digest, manifests, and values (or N/A with explanation):**

Current PR head is [`028d916512bce9c9188d1b49cc003ef5247a9db9`](https://github.com/higress-group/higress/commit/028d916512bce9c9188d1b49cc003ef5247a9db9). Section VIII preserves the focused verification originally reported for this revision. N/A for unrecorded image digest, manifests, or values.

**Baseline reproduction evidence for bug fixes (or N/A with explanation):**

The reproducible problem statement is recorded in https://github.com/higress-group/higress/issues/4337. This is an ordinary tracking/reproduction issue, not an approved issue-spec Proposal; policy-required same-input pre-fix runtime output was not collected.

**Fixed-version verification evidence for bug fixes (or N/A with explanation):**

Section VIII preserves the focused verification originally reported for [`028d916512bce9c9188d1b49cc003ef5247a9db9`](https://github.com/higress-group/higress/commit/028d916512bce9c9188d1b49cc003ef5247a9db9). Policy-required production-path red/green runtime evidence was not collected and remains an explicit evidence gap.

**Wasm source revision and SHA-256 (or N/A with explanation):**

N/A — this PR does not deliver a Wasm module.

## VI. Special notes for reviewers

- This update only brings the PR report into the current template and records the issue-spec status honestly.
- It does not claim gate completion, maintainer acceptance, or stronger verification than the original submission.

## VII. AI coding disclosure

**Tool(s) used (or N/A):**

Codex using the GitHub five-PR contribution workflow.

### Prompts or instructions

The original prompt is preserved verbatim in Section VIII. Current instruction: audit and revise the August 8–9 Higress PR reports to reflect the maintainer's issue-spec requirements, without updating the skill or fabricating approvals.

### AI-assisted work summary

PR-body reporting only. The code, branch, commits, and original verification text are unchanged. The issue-spec status and missing runtime evidence are now explicit.

## VIII. Original submission details (preserved verbatim)

<!-- original-submission-body:start -->
## Ⅰ. Describe what this PR did

Targeted Rust WASM builds now run the selected plugin's unit tests between lint and build, matching the full Rust build path. A lightweight shell regression test stubs `make` and verifies the exact command sequence without invoking Rust, WASM, Docker, or image builds.

## Ⅱ. Does this pull request fix one issue?

No existing issue. Repository audit found that `PLUGIN_TYPE=RUST PLUGIN_NAME=<name>` skipped `make test`, while the all-plugin path ran it.

## Ⅲ. Why don't you add test cases (unit test/integration test)?

A regression test is included in `tools/hack/build-wasm-plugins_test.sh`.

## Ⅳ. Describe how to verify it

- `bash tools/hack/build-wasm-plugins_test.sh`
- `bash -n tools/hack/build-wasm-plugins.sh tools/hack/build-wasm-plugins_test.sh`
- `shellcheck tools/hack/build-wasm-plugins_test.sh`
- `git diff --check`

Docker, WASM compilation, image builds, and E2E tests were intentionally not run locally; GitHub CI will validate the heavier build paths.

## Ⅴ. Special notes for reviews

The test exports a `make` shell stub and confirms the targeted sequence is `lint-base`, `test-base`, `lint`, `test`, `build`.

## Ⅵ. AI Coding Tool Usage Checklist (if applicable)

- [x] **For regular updates/changes**
  - [x] I have provided the prompts/instructions below
  - [x] I have included the AI Coding summary below

### AI Coding Prompts

Audit the targeted Rust WASM plugin build path, prove whether it runs the same tests as the full path, implement the smallest complete fix, and add a lightweight regression test without running Docker, WASM builds, or E2E tests.

### AI Coding Summary

- Key decision: preserve the existing build flow and add only the missing plugin-level test step.
- Main changes: add `make test` to the targeted Rust branch and a stub-based command-order regression test.
- Limitation: real Cargo/WASM/image builds were not run locally and remain covered by GitHub CI.
<!-- original-submission-body:end -->
