### PR TITLE
bugfix(hgctl): persist validated resource defaults

### DIFF
--- a/hgctl/pkg/helm/profile.go
+++ b/hgctl/pkg/helm/profile.go
@@ -100,7 +100,7 @@ func (p ProfileConsole) SetFlags(install InstallMode) ([]string, error) {
 	return sets, nil
 }
 
-func (p ProfileConsole) Validate(install InstallMode) []error {
+func (p *ProfileConsole) Validate(install InstallMode) []error {
 	errs := make([]error, 0)
 	if install == InstallK8s || install == InstallLocalK8s {
 		if p.Replicas <= 0 {
@@ -149,7 +149,7 @@ func (p ProfileGateway) SetFlags(install InstallMode) ([]string, error) {
 	return sets, nil
 }
 
-func (p ProfileGateway) Validate(install InstallMode) []error {
+func (p *ProfileGateway) Validate(install InstallMode) []error {
 	errs := make([]error, 0)
 	if install == InstallK8s || install == InstallLocalK8s {
 		if p.Replicas <= 0 {
@@ -201,7 +201,7 @@ func (p ProfileController) SetFlags(install InstallMode) ([]string, error) {
 	return sets, nil
 }
 
-func (p ProfileController) Validate(install InstallMode) []error {
+func (p *ProfileController) Validate(install InstallMode) []error {
 	errs := make([]error, 0)
 	if install == InstallK8s || install == InstallLocalK8s {
 		if p.Replicas <= 0 {
@@ -461,7 +461,7 @@ type Limits struct {
 	Memory string `json:"memory,omitempty"`
 }
 
-func (r Resource) Validate() []error {
+func (r *Resource) Validate() []error {
 	errs := make([]error, 0)
 
 	r.Requests.CPU = strings.ReplaceAll(r.Requests.CPU, " ", "")

--- a/hgctl/pkg/helm/profile_test.go
+++ b/hgctl/pkg/helm/profile_test.go
@@ -1,0 +1,145 @@
+// Copyright (c) 2022 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package helm
+
+import (
+	"reflect"
+	"testing"
+
+	"sigs.k8s.io/yaml"
+)
+
+func TestProfileValidatePersistsResources(t *testing.T) {
+	defaultProfile := validK8sProfile()
+	spacedProfile := validK8sProfile()
+	spacedResources := Resource{
+		Requests: Requests{CPU: " 2 5 0 m ", Memory: " 5 1 2 M i "},
+		Limits:   Limits{CPU: " 2 0 0 0 m ", Memory: " 2 0 4 8 M i "},
+	}
+	spacedProfile.Console.Resources = spacedResources
+	spacedProfile.Gateway.Resources = spacedResources
+	spacedProfile.Controller.Resources = spacedResources
+	normalizedResources := Resource{
+		Requests: Requests{CPU: "250m", Memory: "512Mi"},
+		Limits:   Limits{CPU: "2000m", Memory: "2048Mi"},
+	}
+
+	tests := []struct {
+		name    string
+		profile Profile
+		want    profileResources
+	}{
+		{
+			name:    "defaults",
+			profile: defaultProfile,
+			want: profileResources{
+				Console: normalizedResources,
+				Gateway: Resource{
+					Requests: Requests{CPU: "2000m", Memory: "2048Mi"},
+					Limits:   Limits{CPU: "2000m", Memory: "2048Mi"},
+				},
+				Controller: Resource{
+					Requests: Requests{CPU: "500m", Memory: "2048Mi"},
+					Limits:   Limits{CPU: "1000m", Memory: "2048Mi"},
+				},
+			},
+		},
+		{
+			name:    "whitespace normalization",
+			profile: spacedProfile,
+			want: profileResources{
+				Console:    normalizedResources,
+				Gateway:    normalizedResources,
+				Controller: normalizedResources,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := tt.profile.Validate(); err != nil {
+				t.Fatalf("Validate() returned an unexpected error: %v", err)
+			}
+
+			got := resourcesFromProfile(&tt.profile)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("resources after Validate() = %#v, want %#v", got, tt.want)
+			}
+
+			valuesYAML, err := tt.profile.ValuesYaml()
+			if err != nil {
+				t.Fatalf("ValuesYaml() returned an unexpected error: %v", err)
+			}
+			got, err = resourcesFromValuesYAML(valuesYAML)
+			if err != nil {
+				t.Fatalf("failed to parse ValuesYaml() output: %v", err)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("resources in ValuesYaml() = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}
+
+type profileResources struct {
+	Console    Resource
+	Gateway    Resource
+	Controller Resource
+}
+
+func validK8sProfile() Profile {
+	return Profile{
+		Global: ProfileGlobal{
+			Install:      InstallK8s,
+			IngressClass: "higress",
+			Namespace:    "higress-system",
+		},
+		Console:    ProfileConsole{Replicas: 1},
+		Gateway:    ProfileGateway{Replicas: 1},
+		Controller: ProfileController{Replicas: 1},
+	}
+}
+
+func resourcesFromProfile(profile *Profile) profileResources {
+	return profileResources{
+		Console:    profile.Console.Resources,
+		Gateway:    profile.Gateway.Resources,
+		Controller: profile.Controller.Resources,
+	}
+}
+
+func resourcesFromValuesYAML(valuesYAML string) (profileResources, error) {
+	var values struct {
+		HigressCore struct {
+			Controller struct {
+				Resources Resource `json:"resources"`
+			} `json:"controller"`
+			Gateway struct {
+				Resources Resource `json:"resources"`
+			} `json:"gateway"`
+		} `json:"higress-core"`
+		HigressConsole struct {
+			Resources Resource `json:"resources"`
+		} `json:"higress-console"`
+	}
+	if err := yaml.Unmarshal([]byte(valuesYAML), &values); err != nil {
+		return profileResources{}, err
+	}
+	return profileResources{
+		Console:    values.HigressConsole.Resources,
+		Gateway:    values.HigressCore.Gateway.Resources,
+		Controller: values.HigressCore.Controller.Resources,
+	}, nil
+}


### PR DESCRIPTION
<!-- issue-spec-inflight-disclosure:v1 -->
## I. Summary

This is a reporting-only update for an in-flight, materially agent-assisted contribution opened before Higress adopted the issue-spec gate. The implementation summary and original verification record are preserved verbatim in Section VIII. No code, commit, or review head is changed by this disclosure update.

## II. Related issue

Fixes #4338

Reproduction and problem statement: https://github.com/higress-group/higress/issues/4338

## III. Change type

- [x] Bug fix
- [ ] Feature or enhancement
- [ ] Documentation or configuration only
- [ ] Refactoring, tests, or maintenance

## IV. Agent participation and issue-spec gate

- [ ] **No agent participation:** This PR is human-only.
- [ ] **Trivial agent-use exception:** Agent use was limited to spelling, punctuation, whitespace, or formatting with no substantive choice or behavioral effect; the explanation is below.
- [x] **Material agent participation:** An AI or coding agent materially participated in analysis, design, implementation, testing, or PR preparation.

For material participation, check each timed obligation:

- [ ] **Before implementation began:** A Higress maintainer had approved the Proposal and Design Issues, and authorized implementation TASKs linked the work to the applicable SPECs.
- [ ] **Before verification began:** The Design contained a concrete Verification Plan.
- [ ] **Before requesting maintainer review or acceptance:** Applicable implementation and verification TASKs were `done` with exact commands, results, evidence links, and hashes.

Then choose exactly one overall gate status:

- [ ] Complete: all three timed obligations above were satisfied.
- [x] Noncompliant: one or more obligations were not satisfied; explain below.
- [ ] N/A because the PR is human-only or qualifies for the trivial exception.

**Gate-status explanation (or N/A):**

This PR was opened at 2026-08-08T06:35:11Z, before policy commit [`13d2c5446ed232eb439b682bbf1abc22433e81a9`](https://github.com/higress-group/higress/commit/13d2c5446ed232eb439b682bbf1abc22433e81a9) merged on 2026-08-08T11:05:38Z. It is an in-flight materially agent-assisted contribution. Retroactive Proposal/Design approval does not exist and is not fabricated; this PR is explicitly marked Noncompliant while adding best-effort traceability and evidence.

**Trivial-exception explanation (or N/A):**

N/A — material agent participation is declared above.

**Approved Proposal Issue URL (or N/A with explanation):**

N/A — https://github.com/higress-group/higress/issues/4338 is a reproduction/tracking issue, not an approved issue-spec Proposal.

**Approved Design Issue URL (or N/A with explanation):**

N/A — no retroactive Design artifact or approval is claimed.

**Maintainer approval link(s) (or N/A with explanation):**

N/A — no retroactive Proposal/Design approval is claimed.

**Authorized implementation TASK link(s) (or N/A with explanation):**

N/A — no retroactive TASK authorization is claimed.

**Verification Plan and verification TASK/evidence link(s) (or N/A with explanation):**

N/A — no pre-approved Verification Plan or verification TASK exists. Best-effort verification is preserved in Section VIII without representing it as issue-spec evidence.

## V. Testing and verification

**Test and deterministic rerun commands (or N/A with explanation):**

```text
See Section VIII, "Describe how to verify it." This body-only update does not claim that tests were rerun.
```

**Environment and configuration (or N/A with explanation):**

N/A — the original submission did not record a complete OS, architecture, and toolchain matrix; that omission remains explicit.

**Exact tested revision, version, image tag/digest, manifests, and values (or N/A with explanation):**

Current PR head is [`10984e1388757fd64a81386b78129653ad2123d5`](https://github.com/higress-group/higress/commit/10984e1388757fd64a81386b78129653ad2123d5). Section VIII preserves the focused verification originally reported for this revision. N/A for unrecorded image digest, manifests, or values.

**Baseline reproduction evidence for bug fixes (or N/A with explanation):**

The reproducible problem statement is recorded in https://github.com/higress-group/higress/issues/4338. This is an ordinary tracking/reproduction issue, not an approved issue-spec Proposal; policy-required same-input pre-fix runtime output was not collected.

**Fixed-version verification evidence for bug fixes (or N/A with explanation):**

Section VIII preserves the focused verification originally reported for [`10984e1388757fd64a81386b78129653ad2123d5`](https://github.com/higress-group/higress/commit/10984e1388757fd64a81386b78129653ad2123d5). Policy-required production-path red/green runtime evidence was not collected and remains an explicit evidence gap.

**Wasm source revision and SHA-256 (or N/A with explanation):**

N/A — this PR does not deliver a Wasm module.

## VI. Special notes for reviewers

- This update only brings the PR report into the current template and records the issue-spec status honestly.
- It does not claim gate completion, maintainer acceptance, or stronger verification than the original submission.

## VII. AI coding disclosure

**Tool(s) used (or N/A):**

Codex using the GitHub five-PR contribution workflow.

### Prompts or instructions

The original prompt is preserved verbatim in Section VIII. Current instruction: audit and revise the August 8–9 Higress PR reports to reflect the maintainer's issue-spec requirements, without updating the skill or fabricating approvals.

### AI-assisted work summary

PR-body reporting only. The code, branch, commits, and original verification text are unchanged. The issue-spec status and missing runtime evidence are now explicit.

## VIII. Original submission details (preserved verbatim)

<!-- original-submission-body:start -->
## Ⅰ. Describe what this PR did

Resource defaults and whitespace normalization performed by `hgctl` profile validation now persist on the profile used to generate Helm values. The affected validators use pointer receivers, and regression tests verify both the validated object and generated `ValuesYaml` output.

## Ⅱ. Does this pull request fix one issue?

No existing issue. Repository audit found that value receivers modified copies, so validation succeeded while generated values still contained empty or unnormalized resources.

## Ⅲ. Why don't you add test cases (unit test/integration test)?

Table-driven regression tests cover default resources and whitespace normalization for console, gateway, and controller.

## Ⅳ. Describe how to verify it

- `cd hgctl && go test ./pkg/helm -count=1 -cover`
- `gofmt -d pkg/helm/profile.go pkg/helm/profile_test.go`
- `git diff --check`

The targeted package passed with 22.6% package coverage. Docker, Kubernetes, E2E, and full repository builds were not run locally; GitHub CI will validate heavier paths.

## Ⅴ. Special notes for reviews

All in-repository calls use addressable profile fields or `*Profile`, so Go's automatic address-taking preserves call compatibility.

## Ⅵ. AI Coding Tool Usage Checklist (if applicable)

- [x] **For regular updates/changes**
  - [x] I have provided the prompts/instructions below
  - [x] I have included the AI Coding summary below

### AI Coding Prompts

Trace why validated hgctl resource defaults and normalized quantities are not present in generated Helm values, reproduce with focused tests, and implement the smallest fix under 400 changed lines.

### AI Coding Summary

- Key decision: mutate the existing profile rather than duplicating defaulting in YAML generation.
- Main changes: switch four validators to pointer receivers and test persisted/defaulted output.
- Limitation: broader root-module compilation requires uninitialized external submodules; the affected hgctl package tests passed locally.
<!-- original-submission-body:end -->
