### PR TITLE
bugfix(build): parse image tags after registry ports

### DIFF
--- a/.github/workflows/build-image-and-push.yaml
+++ b/.github/workflows/build-image-and-push.yaml
@@ -156,7 +156,8 @@ jobs:
           for image in ${IMAGES[@]}; do
             echo "Image: $image"
             if [ "$BUILT_IMAGE" == "" ]; then
-              TAG=${image#*:}
+              IMAGE_NAME=${image##*/}
+              TAG=${IMAGE_NAME##*:}
               HUB=${image%:*}
               HUB=${HUB%/*}
               BUILT_IMAGE="$HUB/pilot:$TAG"
@@ -246,7 +247,8 @@ jobs:
           for image in ${IMAGES[@]}; do
             echo "Image: $image"
             if [ "$BUILT_IMAGE" == "" ]; then
-              TAG=${image#*:}
+              IMAGE_NAME=${image##*/}
+              TAG=${IMAGE_NAME##*:}
               HUB=${image%:*}
               HUB=${HUB%/*}
               BUILT_IMAGE="$HUB/proxyv2:$TAG"

--- a/tools/hack/build-istio-image.sh
+++ b/tools/hack/build-istio-image.sh
@@ -32,12 +32,15 @@ ORIGINAL_HUB=${HUB}
 echo "IMG_URL=$IMG_URL"
 
 if [ -n "$IMG_URL" ]; then
-  TAG=${IMG_URL#*:}
-  HUB=${IMG_URL%:*}
-  HUB=${HUB%/*}
-  if [ "$TAG" == "${IMG_URL}" ]; then
+  IMAGE_NAME=${IMG_URL##*/}
+  if [[ "$IMAGE_NAME" == *:* ]]; then
+    TAG=${IMAGE_NAME##*:}
+    HUB=${IMG_URL%:*}
+  else
     TAG=latest
+    HUB=${IMG_URL}
   fi
+  HUB=${HUB%/*}
 fi
 
 echo "HUB=$HUB"


### PR DESCRIPTION
<!-- issue-spec-inflight-disclosure:v1 -->
## I. Summary

This is a reporting-only update for an in-flight, materially agent-assisted contribution opened before Higress adopted the issue-spec gate. The implementation summary and original verification record are preserved verbatim in Section VIII. No code, commit, or review head is changed by this disclosure update.

## II. Related issue

Fixes #4339

Reproduction and problem statement: https://github.com/higress-group/higress/issues/4339

## III. Change type

- [x] Bug fix
- [ ] Feature or enhancement
- [ ] Documentation or configuration only
- [ ] Refactoring, tests, or maintenance

## IV. Agent participation and issue-spec gate

- [ ] **No agent participation:** This PR is human-only.
- [ ] **Trivial agent-use exception:** Agent use was limited to spelling, punctuation, whitespace, or formatting with no substantive choice or behavioral effect; the explanation is below.
- [x] **Material agent participation:** An AI or coding agent materially participated in analysis, design, implementation, testing, or PR preparation.

For material participation, check each timed obligation:

- [ ] **Before implementation began:** A Higress maintainer had approved the Proposal and Design Issues, and authorized implementation TASKs linked the work to the applicable SPECs.
- [ ] **Before verification began:** The Design contained a concrete Verification Plan.
- [ ] **Before requesting maintainer review or acceptance:** Applicable implementation and verification TASKs were `done` with exact commands, results, evidence links, and hashes.

Then choose exactly one overall gate status:

- [ ] Complete: all three timed obligations above were satisfied.
- [x] Noncompliant: one or more obligations were not satisfied; explain below.
- [ ] N/A because the PR is human-only or qualifies for the trivial exception.

**Gate-status explanation (or N/A):**

This PR was opened at 2026-08-08T06:35:14Z, before policy commit [`13d2c5446ed232eb439b682bbf1abc22433e81a9`](https://github.com/higress-group/higress/commit/13d2c5446ed232eb439b682bbf1abc22433e81a9) merged on 2026-08-08T11:05:38Z. It is an in-flight materially agent-assisted contribution. Retroactive Proposal/Design approval does not exist and is not fabricated; this PR is explicitly marked Noncompliant while adding best-effort traceability and evidence.

**Trivial-exception explanation (or N/A):**

N/A — material agent participation is declared above.

**Approved Proposal Issue URL (or N/A with explanation):**

N/A — https://github.com/higress-group/higress/issues/4339 is a reproduction/tracking issue, not an approved issue-spec Proposal.

**Approved Design Issue URL (or N/A with explanation):**

N/A — no retroactive Design artifact or approval is claimed.

**Maintainer approval link(s) (or N/A with explanation):**

N/A — no retroactive Proposal/Design approval is claimed.

**Authorized implementation TASK link(s) (or N/A with explanation):**

N/A — no retroactive TASK authorization is claimed.

**Verification Plan and verification TASK/evidence link(s) (or N/A with explanation):**

N/A — no pre-approved Verification Plan or verification TASK exists. Best-effort verification is preserved in Section VIII without representing it as issue-spec evidence.

## V. Testing and verification

**Test and deterministic rerun commands (or N/A with explanation):**

```text
See Section VIII, "Describe how to verify it." This body-only update does not claim that tests were rerun.
```

**Environment and configuration (or N/A with explanation):**

N/A — the original submission did not record a complete OS, architecture, and toolchain matrix; that omission remains explicit.

**Exact tested revision, version, image tag/digest, manifests, and values (or N/A with explanation):**

Current PR head is [`a432e2db5966120c3ff0832ce15d8a8edababee7`](https://github.com/higress-group/higress/commit/a432e2db5966120c3ff0832ce15d8a8edababee7). Section VIII preserves the focused verification originally reported for this revision. N/A for unrecorded image digest, manifests, or values.

**Baseline reproduction evidence for bug fixes (or N/A with explanation):**

The reproducible problem statement is recorded in https://github.com/higress-group/higress/issues/4339. This is an ordinary tracking/reproduction issue, not an approved issue-spec Proposal; policy-required same-input pre-fix runtime output was not collected.

**Fixed-version verification evidence for bug fixes (or N/A with explanation):**

Section VIII preserves the focused verification originally reported for [`a432e2db5966120c3ff0832ce15d8a8edababee7`](https://github.com/higress-group/higress/commit/a432e2db5966120c3ff0832ce15d8a8edababee7). Policy-required production-path red/green runtime evidence was not collected and remains an explicit evidence gap.

**Wasm source revision and SHA-256 (or N/A with explanation):**

N/A — this PR does not deliver a Wasm module.

## VI. Special notes for reviewers

- This update only brings the PR report into the current template and records the issue-spec status honestly.
- It does not claim gate completion, maintainer acceptance, or stronger verification than the original submission.

## VII. AI coding disclosure

**Tool(s) used (or N/A):**

Codex using the GitHub five-PR contribution workflow.

### Prompts or instructions

The original prompt is preserved verbatim in Section VIII. Current instruction: audit and revise the August 8–9 Higress PR reports to reflect the maintainer's issue-spec requirements, without updating the skill or fabricating approvals.

### AI-assisted work summary

PR-body reporting only. The code, branch, commits, and original verification text are unchanged. The issue-spec status and missing runtime evidence are now explicit.

## VIII. Original submission details (preserved verbatim)

<!-- original-submission-body:start -->
## Ⅰ. Describe what this PR did

Image tag parsing now distinguishes registry ports from image tags in both the Pilot/Gateway workflow and `build-istio-image.sh`. Tags are extracted from the final path component, so registries such as `localhost:5000` produce valid Pilot and Gateway image references.

## Ⅱ. Does this pull request fix one issue?

No existing issue. Repository audit reproduced invalid tags such as `5000/repo/higress:v1` when a custom registry included a port.

## Ⅲ. Why don't you add test cases (unit test/integration test)?

There is no existing unit-test harness for this build script/workflow. The parsing and complete `BUILT_IMAGE` chain were checked with a shell matrix covering normal registries, host-port registries, untagged inputs, and bracketed IPv6 registries.

## Ⅳ. Describe how to verify it

- `bash -n tools/hack/build-istio-image.sh`
- Shell parsing matrix for normal, `host:port`, and bracketed IPv6 image references
- `git diff --check`

The script body, Docker builds, image pushes, and workflows were not run locally; GitHub CI will validate the heavier paths.

## Ⅴ. Special notes for reviews

Digest references are not build-output tags and remain outside this script's supported input contract.

## Ⅵ. AI Coding Tool Usage Checklist (if applicable)

- [x] **For regular updates/changes**
  - [x] I have provided the prompts/instructions below
  - [x] I have included the AI Coding summary below

### AI Coding Prompts

Audit image URL parsing for registries with ports, trace the full workflow-to-build-script chain, fix every active parsing point, and validate with a lightweight shell matrix without running image builds.

### AI Coding Summary

- Key decision: identify tags only in the last path component.
- Main changes: correct two workflow parsing sites and the Istio build script parser.
- Limitation: digest references are not supported as build output names; no Docker or remote workflow was run manually.
<!-- original-submission-body:end -->
