### PR TITLE
bugfix(mcp-session): require Redis only when user-level servers are enabled

### DIFF
--- a/plugins/golang-filter/mcp-session/config.go
+++ b/plugins/golang-filter/mcp-session/config.go
@@ -77,9 +77,9 @@ func (p *Parser) Parse(any *anypb.Any, callbacks api.ConfigCallbackHandler) (int
 	enableUserLevelServer, ok := v.AsMap()["enable_user_level_server"].(bool)
 	if !ok {
 		enableUserLevelServer = false
-		if conf.redisClient == nil {
-			return nil, fmt.Errorf("redis configuration is not provided, enable_user_level_server is true")
-		}
+	}
+	if enableUserLevelServer && conf.redisClient == nil {
+		return nil, fmt.Errorf("redis configuration is not provided, enable_user_level_server is true")
 	}
 	conf.enableUserLevelServer = enableUserLevelServer
 

--- a/plugins/golang-filter/mcp-session/config_test.go
+++ b/plugins/golang-filter/mcp-session/config_test.go
@@ -1,0 +1,102 @@
+// Copyright (c) 2026 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mcp_session
+
+import (
+	"strings"
+	"testing"
+
+	xds "github.com/cncf/xds/go/xds/type/v3"
+	"github.com/envoyproxy/envoy/contrib/golang/common/go/api"
+	"google.golang.org/protobuf/types/known/anypb"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+type configTestCommonCAPI struct{}
+
+func (configTestCommonCAPI) Log(api.LogType, string) {}
+
+func (configTestCommonCAPI) LogLevel() api.LogType {
+	return api.Debug
+}
+
+func TestParserParseRequiresRedisOnlyForUserLevelServer(t *testing.T) {
+	api.SetCommonCAPI(configTestCommonCAPI{})
+
+	tests := []struct {
+		name                  string
+		enableUserLevelServer any
+		wantErr               bool
+	}{
+		{
+			name:    "missing flag",
+			wantErr: false,
+		},
+		{
+			name:                  "explicitly disabled",
+			enableUserLevelServer: false,
+			wantErr:               false,
+		},
+		{
+			name:                  "enabled",
+			enableUserLevelServer: true,
+			wantErr:               true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			value := map[string]any{
+				"sse_path_suffix": "/sse",
+			}
+			if tt.enableUserLevelServer != nil {
+				value["enable_user_level_server"] = tt.enableUserLevelServer
+			}
+
+			configAny := newMCPConfigAny(t, value)
+			parsed, err := (&Parser{}).Parse(configAny, nil)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("Parse() error = nil, want Redis requirement error")
+				}
+				if !strings.Contains(err.Error(), "redis configuration is not provided") {
+					t.Fatalf("Parse() error = %q, want Redis requirement error", err)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("Parse() unexpected error: %v", err)
+			}
+			if parsed.(*config).enableUserLevelServer {
+				t.Fatal("enableUserLevelServer = true, want false")
+			}
+		})
+	}
+}
+
+func newMCPConfigAny(t *testing.T, value map[string]any) *anypb.Any {
+	t.Helper()
+
+	configValue, err := structpb.NewStruct(value)
+	if err != nil {
+		t.Fatalf("create config struct: %v", err)
+	}
+	configAny, err := anypb.New(&xds.TypedStruct{Value: configValue})
+	if err != nil {
+		t.Fatalf("create config any: %v", err)
+	}
+	return configAny
+}


### PR DESCRIPTION
<!-- issue-spec-inflight-disclosure:v1 -->
## I. Summary

This is a reporting-only update for an in-flight, materially agent-assisted contribution opened before Higress adopted the issue-spec gate. The implementation summary and original verification record are preserved verbatim in Section VIII. No code, commit, or review head is changed by this disclosure update.

## II. Related issue

Fixes #4340

Reproduction and problem statement: https://github.com/higress-group/higress/issues/4340

## III. Change type

- [x] Bug fix
- [ ] Feature or enhancement
- [ ] Documentation or configuration only
- [ ] Refactoring, tests, or maintenance

## IV. Agent participation and issue-spec gate

- [ ] **No agent participation:** This PR is human-only.
- [ ] **Trivial agent-use exception:** Agent use was limited to spelling, punctuation, whitespace, or formatting with no substantive choice or behavioral effect; the explanation is below.
- [x] **Material agent participation:** An AI or coding agent materially participated in analysis, design, implementation, testing, or PR preparation.

For material participation, check each timed obligation:

- [ ] **Before implementation began:** A Higress maintainer had approved the Proposal and Design Issues, and authorized implementation TASKs linked the work to the applicable SPECs.
- [ ] **Before verification began:** The Design contained a concrete Verification Plan.
- [ ] **Before requesting maintainer review or acceptance:** Applicable implementation and verification TASKs were `done` with exact commands, results, evidence links, and hashes.

Then choose exactly one overall gate status:

- [ ] Complete: all three timed obligations above were satisfied.
- [x] Noncompliant: one or more obligations were not satisfied; explain below.
- [ ] N/A because the PR is human-only or qualifies for the trivial exception.

**Gate-status explanation (or N/A):**

This PR was opened at 2026-08-08T06:35:18Z, before policy commit [`13d2c5446ed232eb439b682bbf1abc22433e81a9`](https://github.com/higress-group/higress/commit/13d2c5446ed232eb439b682bbf1abc22433e81a9) merged on 2026-08-08T11:05:38Z. It is an in-flight materially agent-assisted contribution. Retroactive Proposal/Design approval does not exist and is not fabricated; this PR is explicitly marked Noncompliant while adding best-effort traceability and evidence.

**Trivial-exception explanation (or N/A):**

N/A — material agent participation is declared above.

**Approved Proposal Issue URL (or N/A with explanation):**

N/A — https://github.com/higress-group/higress/issues/4340 is a reproduction/tracking issue, not an approved issue-spec Proposal.

**Approved Design Issue URL (or N/A with explanation):**

N/A — no retroactive Design artifact or approval is claimed.

**Maintainer approval link(s) (or N/A with explanation):**

N/A — no retroactive Proposal/Design approval is claimed.

**Authorized implementation TASK link(s) (or N/A with explanation):**

N/A — no retroactive TASK authorization is claimed.

**Verification Plan and verification TASK/evidence link(s) (or N/A with explanation):**

N/A — no pre-approved Verification Plan or verification TASK exists. Best-effort verification is preserved in Section VIII without representing it as issue-spec evidence.

## V. Testing and verification

**Test and deterministic rerun commands (or N/A with explanation):**

```text
See Section VIII, "Describe how to verify it." This body-only update does not claim that tests were rerun.
```

**Environment and configuration (or N/A with explanation):**

N/A — the original submission did not record a complete OS, architecture, and toolchain matrix; that omission remains explicit.

**Exact tested revision, version, image tag/digest, manifests, and values (or N/A with explanation):**

Current PR head is [`08734c5dffce5d8f095229f321f4ef3f919dc960`](https://github.com/higress-group/higress/commit/08734c5dffce5d8f095229f321f4ef3f919dc960). Section VIII preserves the focused verification originally reported for this revision. N/A for unrecorded image digest, manifests, or values.

**Baseline reproduction evidence for bug fixes (or N/A with explanation):**

The reproducible problem statement is recorded in https://github.com/higress-group/higress/issues/4340. This is an ordinary tracking/reproduction issue, not an approved issue-spec Proposal; policy-required same-input pre-fix runtime output was not collected.

**Fixed-version verification evidence for bug fixes (or N/A with explanation):**

Section VIII preserves the focused verification originally reported for [`08734c5dffce5d8f095229f321f4ef3f919dc960`](https://github.com/higress-group/higress/commit/08734c5dffce5d8f095229f321f4ef3f919dc960). Policy-required production-path red/green runtime evidence was not collected and remains an explicit evidence gap.

**Wasm source revision and SHA-256 (or N/A with explanation):**

N/A — this PR does not deliver a Wasm module.

## VI. Special notes for reviewers

- This update only brings the PR report into the current template and records the issue-spec status honestly.
- It does not claim gate completion, maintainer acceptance, or stronger verification than the original submission.

## VII. AI coding disclosure

**Tool(s) used (or N/A):**

Codex using the GitHub five-PR contribution workflow.

### Prompts or instructions

The original prompt is preserved verbatim in Section VIII. Current instruction: audit and revise the August 8–9 Higress PR reports to reflect the maintainer's issue-spec requirements, without updating the skill or fabricating approvals.

### AI-assisted work summary

PR-body reporting only. The code, branch, commits, and original verification text are unchanged. The issue-spec status and missing runtime evidence are now explicit.

## VIII. Original submission details (preserved verbatim)

<!-- original-submission-body:start -->
## Ⅰ. Describe what this PR did

MCP Session configuration now requires Redis only when user-level servers are enabled. Missing or explicitly disabled `enable_user_level_server` values can start without Redis, while `true` without Redis fails configuration parsing.

## Ⅱ. Does this pull request fix one issue?

No existing issue. Repository audit found that the Redis check was nested under the missing-field branch, reversing the intended behavior.

## Ⅲ. Why don't you add test cases (unit test/integration test)?

A table-driven regression test covers missing, explicit `false`, and explicit `true` values.

## Ⅳ. Describe how to verify it

- `cd plugins/golang-filter && go test ./mcp-session -count=1 -cover`
- `gofmt -d mcp-session/config.go mcp-session/config_test.go`
- `git diff --check`

The targeted package passed with 21.5% package coverage. Docker, Envoy builds, and E2E tests were not run locally; GitHub CI will validate heavier paths.

## Ⅴ. Special notes for reviews

The request/config/rate-limit Redis paths are entered only when user-level servers are enabled, matching the new validation condition.

## Ⅵ. AI Coding Tool Usage Checklist (if applicable)

- [x] **For regular updates/changes**
  - [x] I have provided the prompts/instructions below
  - [x] I have included the AI Coding summary below

### AI Coding Prompts

Trace the MCP Session Redis dependency from configuration parsing to runtime callers, reproduce missing/false/true behavior, and implement the smallest tested correction without Docker or E2E.

### AI Coding Summary

- Key decision: default the flag first, then independently validate its Redis dependency.
- Main changes: correct the condition and add three-state regression coverage.
- Limitation: only the affected Go package was tested locally; Envoy integration remains for GitHub CI.
<!-- original-submission-body:end -->
