### PR TITLE
bugfix: fix nil pointer panic in ai-security-guard type assertions

### DIFF
--- a/plugins/wasm-go/extensions/ai-security-guard/lvwang/common/text/openai.go
+++ b/plugins/wasm-go/extensions/ai-security-guard/lvwang/common/text/openai.go
@@ -60,7 +60,7 @@ func HandleTextGenerationStreamingResponseBody(ctx wrapper.HttpContext, config c
 		if statusCode != 200 || gjson.GetBytes(responseBody, "Code").Int() != 200 {
 			startTime, _ := ctx.GetContext(responseStartTimeCtxKey).(int64)
 			cfg.MarkGuardrailResponseError(ctx, currentSubmissionIndex, responseBody, startTime)
-			if ctx.GetContext("end_of_stream_received").(bool) {
+			if ctx.GetBoolContext("end_of_stream_received", false) {
 				proxywasm.ResumeHttpResponse()
 			}
 			ctx.SetContext("during_call", false)
@@ -72,7 +72,7 @@ func HandleTextGenerationStreamingResponseBody(ctx wrapper.HttpContext, config c
 			log.Error("failed to unmarshal aliyun content security response at response phase")
 			startTime, _ := ctx.GetContext(responseStartTimeCtxKey).(int64)
 			cfg.MarkGuardrailResponseError(ctx, currentSubmissionIndex, responseBody, startTime)
-			if ctx.GetContext("end_of_stream_received").(bool) {
+			if ctx.GetBoolContext("end_of_stream_received", false) {
 				proxywasm.ResumeHttpResponse()
 			}
 			ctx.SetContext("during_call", false)
@@ -88,7 +88,7 @@ func HandleTextGenerationStreamingResponseBody(ctx wrapper.HttpContext, config c
 				// (counter / safecheck_response_rt / safecheck_status / log / risk_detected).
 				cfg.CompleteGuardrailSubmissionEvent(ctx, currentSubmissionIndex, responseBody, cfg.GuardrailResultError)
 				log.Errorf("failed to build deny response body: %v", err)
-				endStream := ctx.GetContext("end_of_stream_received").(bool) && ctx.BufferQueueSize() == 0
+				endStream := ctx.GetBoolContext("end_of_stream_received", false) && ctx.BufferQueueSize() == 0
 				proxywasm.InjectEncodedDataToFilterChain(bytes.Join(bufferQueue, []byte("")), endStream)
 				bufferQueue = [][]byte{}
 				config.IncrementCounter("ai_sec_response_deny_buildfail", 1)
@@ -123,7 +123,7 @@ func HandleTextGenerationStreamingResponseBody(ctx wrapper.HttpContext, config c
 		}
 		cfg.CompleteGuardrailSubmissionEvent(ctx, currentSubmissionIndex, responseBody, cfg.GuardrailResultPass)
 		cfg.WriteGuardrailLog(ctx)
-		endStream := ctx.GetContext("end_of_stream_received").(bool) && ctx.BufferQueueSize() == 0
+		endStream := ctx.GetBoolContext("end_of_stream_received", false) && ctx.BufferQueueSize() == 0
 		proxywasm.InjectEncodedDataToFilterChain(bytes.Join(bufferQueue, []byte("")), endStream)
 		bufferQueue = [][]byte{}
 		if !endStream {
@@ -132,10 +132,10 @@ func HandleTextGenerationStreamingResponseBody(ctx wrapper.HttpContext, config c
 		}
 	}
 	singleCall = func() {
-		if ctx.GetContext("during_call").(bool) {
+		if ctx.GetBoolContext("during_call", false) {
 			return
 		}
-		if ctx.BufferQueueSize() >= config.BufferLimit || ctx.GetContext("end_of_stream_received").(bool) {
+		if ctx.BufferQueueSize() >= config.BufferLimit || ctx.GetBoolContext("end_of_stream_received", false) {
 			var buffer string
 			for ctx.BufferQueueSize() > 0 {
 				front := ctx.PopBuffer()
@@ -165,13 +165,13 @@ func HandleTextGenerationStreamingResponseBody(ctx wrapper.HttpContext, config c
 				log.Errorf("failed call the safe check service: %v", err)
 				startTime, _ := ctx.GetContext(responseStartTimeCtxKey).(int64)
 				cfg.MarkGuardrailResponseError(ctx, currentSubmissionIndex, nil, startTime)
-				if ctx.GetContext("end_of_stream_received").(bool) {
+				if ctx.GetBoolContext("end_of_stream_received", false) {
 					proxywasm.ResumeHttpResponse()
 				}
 			}
 		}
 	}
-	if !ctx.GetContext("risk_detected").(bool) {
+	if !ctx.GetBoolContext("risk_detected", false) {
 		unifiedChunk := wrapper.UnifySSEChunk(data)
 		hasTrailingSeparator := bytes.HasSuffix(unifiedChunk, []byte("\n\n"))
 		trimmedChunk := bytes.TrimSpace(unifiedChunk)
@@ -197,7 +197,7 @@ func HandleTextGenerationStreamingResponseBody(ctx wrapper.HttpContext, config c
 		// 	ctx.PushBuffer([]byte(string(chunk) + "\n\n"))
 		// }
 		ctx.SetContext("end_of_stream_received", endOfStream)
-		if !ctx.GetContext("during_call").(bool) {
+		if !ctx.GetBoolContext("during_call", false) {
 			singleCall()
 		}
 	} else if endOfStream {


### PR DESCRIPTION
## I. What does this PR do

Fixes unsafe type assertions in the ai-security-guard plugin (`plugins/wasm-go/extensions/ai-security-guard/lvwang/common/text/openai.go`) that can cause Wasm plugin panics.

### Root Cause

The ai-security-guard plugin uses bare type assertions on `ctx.GetContext()` values across 9 locations. These context values (`end_of_stream_received`, `during_call`, `risk_detected`) are only initialized in `HandleTextGenerationResponseHeader`. When HTTP callout callbacks execute before or without `HandleTextGenerationResponseHeader` being called (e.g. Envoy internal errors, upstream connection failures, protocol timing anomalies), these values are `nil`, causing the bare `.(bool)` assertions to panic and crash the Wasm plugin instance.

### Fix

Replace all 9 bare `ctx.GetContext(key).(bool)` assertions with `ctx.GetBoolContext(key, false)` — a safe API that returns a default value instead of panicking. This API is already used by `ai-search`, `ai-statistics`, `ai-proxy`, and other plugins.

The 3 affected context keys:
- `end_of_stream_received` — 6 occurrences (lines 63, 75, 91, 126, 138, 168)
- `during_call` — 2 occurrences (lines 135, 200)
- `risk_detected` — 1 occurrence (line 174)

When context values are missing, the functions use `false` as the default — the same value set in `HandleTextGenerationResponseHeader` initialization.

## II. Fixes Issue

Fixes #4342

## III. Why no test cases

The ai-security-guard plugin requires a full Wasm runtime environment with HTTP callout callbacks to test the streaming response paths. The fix is a straightforward defensive programming change using existing safe APIs (`GetBoolContext`). The `lvwang/common/text` package tests all pass.

## IV. How to verify

- `cd plugins/wasm-go/extensions/ai-security-guard && GOOS=wasip1 GOARCH=wasm go build ./...` — compiles successfully
- `cd plugins/wasm-go/extensions/ai-security-guard && go test ./lvwang/common/text/ -v -count=1` — all tests pass

## V. Special notes for reviewers

- `GetBoolContext(key, defaultValue)` is an existing API on `wrapper.HttpContext` interface, already used by `ai-search`, `ai-statistics`, `ai-proxy`, and other plugins
- Same defensive pattern as approved in #4226 (WAF plugin) and #4224 (ai-load-balancer)
- When context values are missing, the default `false` is used — same as the initialization value in `HandleTextGenerationResponseHeader`
- wasm-go recovers callback panics, so the practical impact is a failed security check phase with fail-open behavior — the security guard is bypassed instead of returning a controlled error

## VI. AI Coding Tool Usage Checklist

- [x] Used AI coding tools: Yes (AI-assisted code analysis and fix generation)
- [ ] New standalone plugin scenario: N/A (bug fix in existing code)
- [x] Regular modification scenario: AI analyzed the ai-security-guard callback flow to identify all unsafe type assertions