### PR TITLE
bugfix: fix nil pointer panic in transformer plugin type assertions

### DIFF
--- a/plugins/wasm-go/extensions/transformer/main.go
+++ b/plugins/wasm-go/extensions/transformer/main.go
@@ -445,8 +445,8 @@ func onHttpRequestBody(ctx wrapper.HttpContext, config TransformerConfig, body [
 	var hs map[string][]string
 	var qs map[string][]string
 
-	hs = ctx.GetContext("headers").(map[string][]string)
-	if hs == nil {
+	hs, ok = ctx.GetContext("headers").(map[string][]string)
+	if !ok || hs == nil {
 		log.Warn("failed to get request headers")
 		return types.ActionContinue
 	}
@@ -463,8 +463,8 @@ func onHttpRequestBody(ctx wrapper.HttpContext, config TransformerConfig, body [
 		kvs:           hs,
 	}
 
-	qs = ctx.GetContext("querys").(map[string][]string)
-	if qs == nil {
+	qs, ok = ctx.GetContext("querys").(map[string][]string)
+	if !ok || qs == nil {
 		log.Warn("failed to get request querys")
 		return types.ActionContinue
 	}
@@ -633,8 +633,8 @@ func onHttpResponseBody(ctx wrapper.HttpContext, config TransformerConfig, body 
 	mapSourceData := make(map[string]MapSourceData)
 	var hs map[string][]string
 
-	hs = ctx.GetContext("headers").(map[string][]string)
-	if hs == nil {
+	hs, ok = ctx.GetContext("headers").(map[string][]string)
+	if !ok || hs == nil {
 		log.Warn("failed to get response headers")
 		return types.ActionContinue
 	}


### PR DESCRIPTION
## I. What does this PR do

Fixes unsafe type assertions in the transformer plugin (`plugins/wasm-go/extensions/transformer/main.go`) that can cause Wasm plugin panics.

### Root Cause

The transformer plugin uses bare type assertions on `ctx.GetContext()` values in `onHttpRequestBody` and `onHttpResponseBody`. These context values (`headers`, `querys`) are only set in `onHttpRequestHeaders` (lines 363-364) and `onHttpResponseHeaders` (line 560). If these header callbacks return early due to errors (e.g. failed to parse query params, failed to get request headers), the context values are `nil`, causing the bare `.(map[string][]string)` assertions to panic when the body callbacks are subsequently invoked.

### Fix

Replace 3 bare type assertions with comma-ok pattern:

- `onHttpRequestBody` line 448: `hs = ctx.GetContext("headers").(map[string][]string)` → `hs, ok = ctx.GetContext("headers").(map[string][]string)` with `!ok || hs == nil` check
- `onHttpRequestBody` line 466: `qs = ctx.GetContext("querys").(map[string][]string)` → `qs, ok = ctx.GetContext("querys").(map[string][]string)` with `!ok || qs == nil` check
- `onHttpResponseBody` line 636: `hs = ctx.GetContext("headers").(map[string][]string)` → `hs, ok = ctx.GetContext("headers").(map[string][]string)` with `!ok || hs == nil` check

The `ok` variable is already declared earlier in both functions (from `contentType, ok := ctx.GetContext("content-type").(string)`), so no new variable declaration is needed.

## II. Fixes Issue

Fixes #4350

## III. Why no test cases

The transformer plugin requires a full Wasm runtime environment with HTTP callout callbacks to test the body phase handlers. The fix is a straightforward defensive programming change (comma-ok pattern) that prevents panics in edge cases.

## IV. How to verify

- `cd plugins/wasm-go/extensions/transformer && GOOS=wasip1 GOARCH=wasm go build ./...` — compiles successfully

## V. Special notes for reviewers

- Same defensive pattern as approved in #4226 (WAF plugin) and #4224 (ai-load-balancer)
- The `ok` variable is reused from an earlier `contentType, ok := ...` declaration in the same scope
- When context values are missing, the functions return early with `types.ActionContinue` (same behavior as the existing `hs == nil` / `qs == nil` checks)

## VI. AI Coding Tool Usage Checklist

- [x] Used AI coding tools: Yes (AI-assisted code analysis and fix generation)
- [ ] New standalone plugin scenario: N/A (bug fix in existing code)
- [x] Regular modification scenario: AI analyzed the transformer callback flow to identify all unsafe type assertions