### PR TITLE
fix(frontend-gray): handle 404 fallback without content type

### DIFF
--- a/plugins/wasm-go/extensions/frontend-gray/main.go
+++ b/plugins/wasm-go/extensions/frontend-gray/main.go
@@ -168,8 +168,8 @@ func onHttpResponseHeader(ctx wrapper.HttpContext, grayConfig config.GrayConfig)
 			responseHeaders, _ := proxywasm.GetHttpResponseHeaders()
 			headersMap := util.ConvertHeaders(responseHeaders)
 			delete(headersMap, "content-length")
-			headersMap[":status"][0] = "200"
-			headersMap["content-type"][0] = "text/html"
+			headersMap[":status"] = []string{"200"}
+			headersMap["content-type"] = []string{"text/html"}
 			ctx.BufferResponseBody()
 			proxywasm.ReplaceHttpResponseHeaders(util.ReconvertHeaders(headersMap))
 		} else {

--- a/plugins/wasm-go/extensions/frontend-gray/main_test.go
+++ b/plugins/wasm-go/extensions/frontend-gray/main_test.go
@@ -64,6 +64,19 @@ var basicGrayConfig = func() json.RawMessage {
 	return data
 }()
 
+// 测试配置：带 404 HTML 回退页面的配置
+var htmlFallbackConfig = func() json.RawMessage {
+	data, _ := json.Marshal(map[string]interface{}{
+		"grayKey": "userid",
+		"html":    "<html><body>fallback</body></html>",
+		"baseDeployment": map[string]interface{}{
+			"version":        "base",
+			"backendVersion": "base-backend",
+		},
+	})
+	return data
+}()
+
 // 测试配置：按比例灰度配置
 var weightGrayConfig = func() json.RawMessage {
 	data, _ := json.Marshal(map[string]interface{}{
@@ -446,6 +459,34 @@ func TestOnHttpResponseHeader(t *testing.T) {
 			})
 
 			require.Equal(t, types.ActionContinue, action)
+
+			host.CompleteHttp()
+		})
+
+		// 上游 404 响应可能不携带 content-type，回退页面仍应正常生效。
+		t.Run("404 html fallback without content type", func(t *testing.T) {
+			host, status := test.NewTestHost(htmlFallbackConfig)
+			defer host.Reset()
+			require.Equal(t, types.OnPluginStartStatusOK, status)
+
+			host.CallOnHttpRequestHeaders([][2]string{
+				{":authority", "example.com"},
+				{":path", "/"},
+				{":method", "GET"},
+				{"cookie", "userid=00000001"},
+			})
+
+			var action types.Action
+			require.NotPanics(t, func() {
+				action = host.CallOnHttpResponseHeaders([][2]string{
+					{":status", "404"},
+				})
+			})
+			require.Equal(t, types.ActionContinue, action)
+
+			responseHeaders := host.GetResponseHeaders()
+			require.True(t, test.HasHeaderWithValue(responseHeaders, ":status", "200"))
+			require.True(t, test.HasHeaderWithValue(responseHeaders, "content-type", "text/html"))
 
 			host.CompleteHttp()
 		})


### PR DESCRIPTION
<!-- issue-spec-inflight-disclosure:v1 -->
## I. Summary

This is a reporting-only update for an in-flight, materially agent-assisted contribution opened before Higress adopted the issue-spec gate. The implementation summary and original verification record are preserved verbatim in Section VIII. No code, commit, or review head is changed by this disclosure update.

## II. Related issue

Fixes #4354

Reproduction and problem statement: https://github.com/higress-group/higress/issues/4354

## III. Change type

- [x] Bug fix
- [ ] Feature or enhancement
- [ ] Documentation or configuration only
- [ ] Refactoring, tests, or maintenance

## IV. Agent participation and issue-spec gate

- [ ] **No agent participation:** This PR is human-only.
- [ ] **Trivial agent-use exception:** Agent use was limited to spelling, punctuation, whitespace, or formatting with no substantive choice or behavioral effect; the explanation is below.
- [x] **Material agent participation:** An AI or coding agent materially participated in analysis, design, implementation, testing, or PR preparation.

For material participation, check each timed obligation:

- [ ] **Before implementation began:** A Higress maintainer had approved the Proposal and Design Issues, and authorized implementation TASKs linked the work to the applicable SPECs.
- [ ] **Before verification began:** The Design contained a concrete Verification Plan.
- [ ] **Before requesting maintainer review or acceptance:** Applicable implementation and verification TASKs were `done` with exact commands, results, evidence links, and hashes.

Then choose exactly one overall gate status:

- [ ] Complete: all three timed obligations above were satisfied.
- [x] Noncompliant: one or more obligations were not satisfied; explain below.
- [ ] N/A because the PR is human-only or qualifies for the trivial exception.

**Gate-status explanation (or N/A):**

This PR was opened at 2026-08-08T10:21:58Z, before policy commit [`13d2c5446ed232eb439b682bbf1abc22433e81a9`](https://github.com/higress-group/higress/commit/13d2c5446ed232eb439b682bbf1abc22433e81a9) merged on 2026-08-08T11:05:38Z. It is an in-flight materially agent-assisted contribution. Retroactive Proposal/Design approval does not exist and is not fabricated; this PR is explicitly marked Noncompliant while adding best-effort traceability and evidence.

**Trivial-exception explanation (or N/A):**

N/A — material agent participation is declared above.

**Approved Proposal Issue URL (or N/A with explanation):**

N/A — https://github.com/higress-group/higress/issues/4354 is a reproduction/tracking issue, not an approved issue-spec Proposal.

**Approved Design Issue URL (or N/A with explanation):**

N/A — no retroactive Design artifact or approval is claimed.

**Maintainer approval link(s) (or N/A with explanation):**

N/A — no retroactive Proposal/Design approval is claimed.

**Authorized implementation TASK link(s) (or N/A with explanation):**

N/A — no retroactive TASK authorization is claimed.

**Verification Plan and verification TASK/evidence link(s) (or N/A with explanation):**

N/A — no pre-approved Verification Plan or verification TASK exists. Best-effort verification is preserved in Section VIII without representing it as issue-spec evidence.

## V. Testing and verification

**Test and deterministic rerun commands (or N/A with explanation):**

```text
See Section VIII, "Describe how to verify it." This body-only update does not claim that tests were rerun.
```

**Environment and configuration (or N/A with explanation):**

N/A — the original submission did not record a complete OS, architecture, and toolchain matrix; that omission remains explicit.

**Exact tested revision, version, image tag/digest, manifests, and values (or N/A with explanation):**

Current PR head is [`9d8874008d4fab0e922e77f1d99e35ebe0c4c910`](https://github.com/higress-group/higress/commit/9d8874008d4fab0e922e77f1d99e35ebe0c4c910). Section VIII preserves the focused verification originally reported for this revision. N/A for unrecorded image digest, manifests, or values.

**Baseline reproduction evidence for bug fixes (or N/A with explanation):**

The reproducible problem statement is recorded in https://github.com/higress-group/higress/issues/4354. This is an ordinary tracking/reproduction issue, not an approved issue-spec Proposal; policy-required same-input pre-fix runtime output was not collected.

**Fixed-version verification evidence for bug fixes (or N/A with explanation):**

Section VIII preserves the focused verification originally reported for [`9d8874008d4fab0e922e77f1d99e35ebe0c4c910`](https://github.com/higress-group/higress/commit/9d8874008d4fab0e922e77f1d99e35ebe0c4c910). Policy-required production-path red/green runtime evidence was not collected and remains an explicit evidence gap.

**Wasm source revision and SHA-256 (or N/A with explanation):**

Source revision: [`9d8874008d4fab0e922e77f1d99e35ebe0c4c910`](https://github.com/higress-group/higress/commit/9d8874008d4fab0e922e77f1d99e35ebe0c4c910). SHA-256: not available because no Wasm module was built and no digest was recorded; this remains an explicit runtime-evidence gap.

## VI. Special notes for reviewers

- This update only brings the PR report into the current template and records the issue-spec status honestly.
- It does not claim gate completion, maintainer acceptance, or stronger verification than the original submission.

## VII. AI coding disclosure

**Tool(s) used (or N/A):**

Codex using the GitHub five-PR contribution workflow.

### Prompts or instructions

The original prompt is preserved verbatim in Section VIII. Current instruction: audit and revise the August 8–9 Higress PR reports to reflect the maintainer's issue-spec requirements, without updating the skill or fabricating approvals.

### AI-assisted work summary

PR-body reporting only. The code, branch, commits, and original verification text are unchanged. The issue-spec status and missing runtime evidence are now explicit.

## VIII. Original submission details (preserved verbatim)

<!-- original-submission-body:start -->
## Ⅰ. Describe what this PR did

- Makes the frontend-gray HTML fallback create complete `:status` and `content-type` slices instead of indexing headers that may be absent.
- Adds a regression case for an upstream 404 response without `content-type`.

## Ⅱ. Does this pull request fix one issue?

Fixes #4354

## Ⅲ. Why don't you add test cases (unit test/integration test)?

A wasm-go unit regression test is included.

## Ⅳ. Describe how to verify it

```bash
cd plugins/wasm-go/extensions/frontend-gray
go test ./... -count=1
```

## Ⅴ. Special notes for reviews

The fallback still removes `content-length`; this change only makes replacement safe when headers are missing. No container or cluster E2E was run.

## Ⅵ. AI Coding Tool Usage Checklist (if applicable)

- [x] **For regular updates/changes** (not new plugins):
  - [x] I have provided the prompts/instructions I gave to the AI Coding tool below
  - [x] I have included the AI Coding summary below

### AI Coding Prompts (for regular updates)

> Scan Higress for nine independent small issues. For frontend-gray, reproduce the 404 fallback failure without Content-Type, add a regression test, implement the smallest fix under 400 changed lines, and run local module tests only.

### AI Coding Summary

- Reproduced the missing-header path with the wasm-go test host.
- Replaced indexed slice writes with complete slice assignment.
- Added header assertions and ran all tests in the plugin module.
- Did not run WASM image builds, containers, Kubernetes, or E2E.
<!-- original-submission-body:end -->
