### PR TITLE
fix(basic-auth): authenticate complete configured credentials

### DIFF
--- a/plugins/wasm-go/extensions/basic-auth/main.go
+++ b/plugins/wasm-go/extensions/basic-auth/main.go
@@ -86,7 +86,6 @@ type BasicAuthConfig struct {
 	allow []string `yaml:"allow"`
 
 	credential2Name map[string]string `yaml:"-"`
-	username2Passwd map[string]string `yaml:"-"`
 }
 
 type Consumer struct {
@@ -113,7 +112,6 @@ func parseGlobalConfig(json gjson.Result, global *BasicAuthConfig, log log.Log) 
 	// log.Debug("global config")
 	ruleSet = false
 	global.credential2Name = make(map[string]string)
-	global.username2Passwd = make(map[string]string)
 
 	consumers := json.Get("consumers")
 	if !consumers.Exists() {
@@ -135,8 +133,7 @@ func parseGlobalConfig(json gjson.Result, global *BasicAuthConfig, log log.Log) 
 		if _, ok := global.credential2Name[credential.String()]; ok {
 			return errors.Errorf("duplicate consumer credential: %s", credential.String())
 		}
-		userAndPasswd := strings.Split(credential.String(), ":")
-		if len(userAndPasswd) != 2 {
+		if _, _, found := strings.Cut(credential.String(), ":"); !found {
 			return errors.Errorf("invalid credential format: %s", credential.String())
 		}
 
@@ -146,7 +143,6 @@ func parseGlobalConfig(json gjson.Result, global *BasicAuthConfig, log log.Log) 
 		}
 		global.consumers = append(global.consumers, consumer)
 		global.credential2Name[consumer.credential] = consumer.name
-		global.username2Passwd[userAndPasswd[0]] = userAndPasswd[1]
 	}
 
 	globalAuth := json.Get("global_auth")
@@ -235,28 +231,15 @@ func onHttpRequestHeaders(ctx wrapper.HttpContext, config BasicAuthConfig, log l
 	}
 
 	credential := string(credentialByte)
-	userAndPasswd := strings.Split(credential, ":")
-	if len(userAndPasswd) != 2 {
+	if _, _, found := strings.Cut(credential, ":"); !found {
 		log.Warnf("invalid credential format: %s", credential)
 		return deniedInvalidCredentials()
 	}
 
-	user, passwd := userAndPasswd[0], userAndPasswd[1]
-	if correctPasswd, ok := config.username2Passwd[user]; !ok {
-		log.Warnf("credential username %q is not configured", user)
-		return deniedInvalidCredentials()
-	} else {
-		if passwd != correctPasswd {
-			log.Warnf("credential password is not correct for username %q", user)
-			return deniedInvalidCredentials()
-		}
-	}
-
-	// 以下为 username 和 password 正确的情况：
 	name, ok := config.credential2Name[credential]
-	if !ok { // 理论上该分支永远不可达，因为 username 和 password 都是从 credential 中获取的
+	if !ok {
 		log.Warnf("credential %q is not configured", credential)
-		return deniedUnauthorizedConsumer()
+		return deniedInvalidCredentials()
 	}
 
 	// 全局生效：

--- a/plugins/wasm-go/extensions/basic-auth/main_test.go
+++ b/plugins/wasm-go/extensions/basic-auth/main_test.go
@@ -60,6 +60,38 @@ var globalAuthTrueConfig = func() json.RawMessage {
 	return data
 }()
 
+// 测试配置：同一用户名对应多个完整凭证
+var sharedUsernameConfig = func() json.RawMessage {
+	data, _ := json.Marshal(map[string]interface{}{
+		"consumers": []map[string]interface{}{
+			{
+				"name":       "consumer1",
+				"credential": "shared:first",
+			},
+			{
+				"name":       "consumer2",
+				"credential": "shared:second",
+			},
+		},
+		"global_auth": true,
+	})
+	return data
+}()
+
+// 测试配置：密码中包含冒号
+var colonPasswordConfig = func() json.RawMessage {
+	data, _ := json.Marshal(map[string]interface{}{
+		"consumers": []map[string]interface{}{
+			{
+				"name":       "consumer1",
+				"credential": "admin:first:second",
+			},
+		},
+		"global_auth": true,
+	})
+	return data
+}()
+
 // 测试配置：路由鉴权配置
 var routeAuthConfig = func() json.RawMessage {
 	data, _ := json.Marshal(map[string]interface{}{
@@ -827,6 +859,56 @@ func TestOnHttpRequestHeaders(t *testing.T) {
 
 			host.CompleteHttp()
 		})
+	})
+}
+
+func TestAuthenticateCompleteCredential(t *testing.T) {
+	test.RunTest(t, func(t *testing.T) {
+		tests := []struct {
+			name       string
+			config     json.RawMessage
+			credential string
+			consumer   string
+		}{
+			{
+				name:       "first credential for shared username",
+				config:     sharedUsernameConfig,
+				credential: "shared:first",
+				consumer:   "consumer1",
+			},
+			{
+				name:       "second credential for shared username",
+				config:     sharedUsernameConfig,
+				credential: "shared:second",
+				consumer:   "consumer2",
+			},
+			{
+				name:       "password containing colon",
+				config:     colonPasswordConfig,
+				credential: "admin:first:second",
+				consumer:   "consumer1",
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				host, status := test.NewTestHost(tt.config)
+				defer host.Reset()
+				require.Equal(t, types.OnPluginStartStatusOK, status)
+
+				authorization := "Basic " + base64.StdEncoding.EncodeToString([]byte(tt.credential))
+				action := host.CallOnHttpRequestHeaders([][2]string{
+					{":authority", "example.com"},
+					{":path", "/api/test"},
+					{":method", "GET"},
+					{"authorization", authorization},
+				})
+				require.Equal(t, types.ActionContinue, action)
+				require.True(t, test.HasHeaderWithValue(host.GetRequestHeaders(), "X-Mse-Consumer", tt.consumer))
+
+				host.CompleteHttp()
+			})
+		}
 	})
 }
 


### PR DESCRIPTION
<!-- issue-spec-inflight-disclosure:v1 -->
## I. Summary

This is a reporting-only update for an in-flight, materially agent-assisted contribution opened before Higress adopted the issue-spec gate. The implementation summary and original verification record are preserved verbatim in Section VIII. No code, commit, or review head is changed by this disclosure update.

## II. Related issue

Fixes #4355

Reproduction and problem statement: https://github.com/higress-group/higress/issues/4355

## III. Change type

- [x] Bug fix
- [ ] Feature or enhancement
- [ ] Documentation or configuration only
- [ ] Refactoring, tests, or maintenance

## IV. Agent participation and issue-spec gate

- [ ] **No agent participation:** This PR is human-only.
- [ ] **Trivial agent-use exception:** Agent use was limited to spelling, punctuation, whitespace, or formatting with no substantive choice or behavioral effect; the explanation is below.
- [x] **Material agent participation:** An AI or coding agent materially participated in analysis, design, implementation, testing, or PR preparation.

For material participation, check each timed obligation:

- [ ] **Before implementation began:** A Higress maintainer had approved the Proposal and Design Issues, and authorized implementation TASKs linked the work to the applicable SPECs.
- [ ] **Before verification began:** The Design contained a concrete Verification Plan.
- [ ] **Before requesting maintainer review or acceptance:** Applicable implementation and verification TASKs were `done` with exact commands, results, evidence links, and hashes.

Then choose exactly one overall gate status:

- [ ] Complete: all three timed obligations above were satisfied.
- [x] Noncompliant: one or more obligations were not satisfied; explain below.
- [ ] N/A because the PR is human-only or qualifies for the trivial exception.

**Gate-status explanation (or N/A):**

This PR was opened at 2026-08-08T10:22:01Z, before policy commit [`13d2c5446ed232eb439b682bbf1abc22433e81a9`](https://github.com/higress-group/higress/commit/13d2c5446ed232eb439b682bbf1abc22433e81a9) merged on 2026-08-08T11:05:38Z. It is an in-flight materially agent-assisted contribution. Retroactive Proposal/Design approval does not exist and is not fabricated; this PR is explicitly marked Noncompliant while adding best-effort traceability and evidence.

**Trivial-exception explanation (or N/A):**

N/A — material agent participation is declared above.

**Approved Proposal Issue URL (or N/A with explanation):**

N/A — https://github.com/higress-group/higress/issues/4355 is a reproduction/tracking issue, not an approved issue-spec Proposal.

**Approved Design Issue URL (or N/A with explanation):**

N/A — no retroactive Design artifact or approval is claimed.

**Maintainer approval link(s) (or N/A with explanation):**

N/A — no retroactive Proposal/Design approval is claimed.

**Authorized implementation TASK link(s) (or N/A with explanation):**

N/A — no retroactive TASK authorization is claimed.

**Verification Plan and verification TASK/evidence link(s) (or N/A with explanation):**

N/A — no pre-approved Verification Plan or verification TASK exists. Best-effort verification is preserved in Section VIII without representing it as issue-spec evidence.

## V. Testing and verification

**Test and deterministic rerun commands (or N/A with explanation):**

```text
See Section VIII, "Describe how to verify it." This body-only update does not claim that tests were rerun.
```

**Environment and configuration (or N/A with explanation):**

N/A — the original submission did not record a complete OS, architecture, and toolchain matrix; that omission remains explicit.

**Exact tested revision, version, image tag/digest, manifests, and values (or N/A with explanation):**

Current PR head is [`229a42f588e225d3c89a308fc5c776335bcea480`](https://github.com/higress-group/higress/commit/229a42f588e225d3c89a308fc5c776335bcea480). Section VIII preserves the focused verification originally reported for this revision. N/A for unrecorded image digest, manifests, or values.

**Baseline reproduction evidence for bug fixes (or N/A with explanation):**

The reproducible problem statement is recorded in https://github.com/higress-group/higress/issues/4355. This is an ordinary tracking/reproduction issue, not an approved issue-spec Proposal; policy-required same-input pre-fix runtime output was not collected.

**Fixed-version verification evidence for bug fixes (or N/A with explanation):**

Section VIII preserves the focused verification originally reported for [`229a42f588e225d3c89a308fc5c776335bcea480`](https://github.com/higress-group/higress/commit/229a42f588e225d3c89a308fc5c776335bcea480). Policy-required production-path red/green runtime evidence was not collected and remains an explicit evidence gap.

**Wasm source revision and SHA-256 (or N/A with explanation):**

Source revision: [`229a42f588e225d3c89a308fc5c776335bcea480`](https://github.com/higress-group/higress/commit/229a42f588e225d3c89a308fc5c776335bcea480). SHA-256: not available because no Wasm module was built and no digest was recorded; this remains an explicit runtime-evidence gap.

## VI. Special notes for reviewers

- This update only brings the PR report into the current template and records the issue-spec status honestly.
- It does not claim gate completion, maintainer acceptance, or stronger verification than the original submission.

## VII. AI coding disclosure

**Tool(s) used (or N/A):**

Codex using the GitHub five-PR contribution workflow.

### Prompts or instructions

The original prompt is preserved verbatim in Section VIII. Current instruction: audit and revise the August 8–9 Higress PR reports to reflect the maintainer's issue-spec requirements, without updating the skill or fabricating approvals.

### AI-assisted work summary

PR-body reporting only. The code, branch, commits, and original verification text are unchanged. The issue-spec status and missing runtime evidence are now explicit.

## VIII. Original submission details (preserved verbatim)

<!-- original-submission-body:start -->
## Ⅰ. Describe what this PR did

- Authenticates against the configured complete Basic credential instead of a lossy username-to-password map.
- Uses the first colon as the username/password separator, allowing colons inside passwords.
- Adds regression coverage for two credentials sharing a username and for a colon-containing password.

## Ⅱ. Does this pull request fix one issue?

Fixes #4355

## Ⅲ. Why don't you add test cases (unit test/integration test)?

Wasm-go unit regression tests are included.

## Ⅳ. Describe how to verify it

```bash
cd plugins/wasm-go/extensions/basic-auth
go test ./... -count=1
```

## Ⅴ. Special notes for reviews

Unknown complete credentials continue to receive the existing invalid-credentials response. No container or cluster E2E was run.

## Ⅵ. AI Coding Tool Usage Checklist (if applicable)

- [x] **For regular updates/changes** (not new plugins):
  - [x] I have provided the prompts/instructions I gave to the AI Coding tool below
  - [x] I have included the AI Coding summary below

### AI Coding Prompts (for regular updates)

> Scan Higress for nine independent small issues. For basic-auth, reproduce the configuration-order failure when consumers share a username, preserve complete credential semantics, add regression tests, and run local module tests only.

### AI Coding Summary

- Identified the overwrite in `username2Passwd`.
- Reused the existing complete-credential map and `strings.Cut`.
- Covered both configured credentials and passwords containing colons.
- Did not run WASM image builds, containers, Kubernetes, or E2E.
<!-- original-submission-body:end -->
