### PR TITLE
fix(qwen3guard): validate uint32 configuration limits

### DIFF
--- a/plugins/wasm-go/extensions/qwen3guard/config.go
+++ b/plugins/wasm-go/extensions/qwen3guard/config.go
@@ -3,6 +3,8 @@ package main
 import (
 	"errors"
 	"fmt"
+	"math"
+	"strconv"
 	"strings"
 
 	"github.com/higress-group/wasm-go/pkg/log"
@@ -88,19 +90,11 @@ func parseConfig(json gjson.Result, c *pluginConfig, log log.Log) error {
 		return err
 	}
 	setString(json, "deny_message", "denyMessage", &c.denyMessage)
-	timeout, timeoutSet := getPositiveInt(json, "timeout_ms", "timeoutMs")
-	if timeoutSet {
-		if timeout <= 0 {
-			return errors.New("timeout_ms must be greater than 0")
-		}
-		c.timeoutMS = uint32(timeout)
+	if err := setPositiveUint32(json, "timeout_ms", "timeoutMs", &c.timeoutMS); err != nil {
+		return err
 	}
-	maxBodyBytes, maxBodyBytesSet := getPositiveInt(json, "max_body_bytes", "maxBodyBytes")
-	if maxBodyBytesSet {
-		if maxBodyBytes <= 0 {
-			return errors.New("max_body_bytes must be greater than 0")
-		}
-		c.maxBodyBytes = uint32(maxBodyBytes)
+	if err := setPositiveUint32(json, "max_body_bytes", "maxBodyBytes", &c.maxBodyBytes); err != nil {
+		return err
 	}
 	if riskLevelBar := strings.TrimSpace(json.Get("risk_level_bar").String()); riskLevelBar != "" {
 		normalized, ok := normalizeRiskLevelBar(riskLevelBar)
@@ -243,6 +237,27 @@ func setPositiveInt(json gjson.Result, snakeKey string, camelKey string, target 
 		return fmt.Errorf("%s must be greater than 0", snakeKey)
 	}
 	*target = value
+	return nil
+}
+
+func setPositiveUint32(json gjson.Result, snakeKey string, camelKey string, target *uint32) error {
+	value := json.Get(snakeKey)
+	if !value.Exists() {
+		value = json.Get(camelKey)
+	}
+	if !value.Exists() {
+		return nil
+	}
+
+	rawValue := value.Raw
+	if value.Type == gjson.String {
+		rawValue = value.String()
+	}
+	parsed, err := strconv.ParseUint(rawValue, 10, 32)
+	if err != nil || parsed == 0 {
+		return fmt.Errorf("%s must be between 1 and %d", snakeKey, uint64(math.MaxUint32))
+	}
+	*target = uint32(parsed)
 	return nil
 }
 

--- a/plugins/wasm-go/extensions/qwen3guard/qwen3guard_test.go
+++ b/plugins/wasm-go/extensions/qwen3guard/qwen3guard_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
+	"math"
 	"strings"
 	"testing"
 
@@ -113,6 +115,19 @@ func TestParseConfigValidation(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			var config pluginConfig
 			require.Error(t, parseConfig(gjson.Parse(tt.raw), &config, nil))
+		})
+	}
+}
+
+func TestParseConfigRejectsOversizedUint32Values(t *testing.T) {
+	oversizedValue := uint64(math.MaxUint32) + 100
+	for _, key := range []string{"timeout_ms", "timeoutMs", "max_body_bytes", "maxBodyBytes"} {
+		t.Run(key, func(t *testing.T) {
+			raw := fmt.Sprintf(`{"serviceSource":"k8s","serviceName":"qwen3guard","servicePort":8000,%q:%d}`, key, oversizedValue)
+			var config pluginConfig
+
+			// parseConfig 的错误会使包装器拒绝插件启动。
+			require.Error(t, parseConfig(gjson.Parse(raw), &config, nil))
 		})
 	}
 }


### PR DESCRIPTION
<!-- issue-spec-inflight-disclosure:v1 -->
## I. Summary

This is a reporting-only update for an in-flight, materially agent-assisted contribution opened before Higress adopted the issue-spec gate. The implementation summary and original verification record are preserved verbatim in Section VIII. No code, commit, or review head is changed by this disclosure update.

## II. Related issue

Fixes #4357

Reproduction and problem statement: https://github.com/higress-group/higress/issues/4357

## III. Change type

- [x] Bug fix
- [ ] Feature or enhancement
- [ ] Documentation or configuration only
- [ ] Refactoring, tests, or maintenance

## IV. Agent participation and issue-spec gate

- [ ] **No agent participation:** This PR is human-only.
- [ ] **Trivial agent-use exception:** Agent use was limited to spelling, punctuation, whitespace, or formatting with no substantive choice or behavioral effect; the explanation is below.
- [x] **Material agent participation:** An AI or coding agent materially participated in analysis, design, implementation, testing, or PR preparation.

For material participation, check each timed obligation:

- [ ] **Before implementation began:** A Higress maintainer had approved the Proposal and Design Issues, and authorized implementation TASKs linked the work to the applicable SPECs.
- [ ] **Before verification began:** The Design contained a concrete Verification Plan.
- [ ] **Before requesting maintainer review or acceptance:** Applicable implementation and verification TASKs were `done` with exact commands, results, evidence links, and hashes.

Then choose exactly one overall gate status:

- [ ] Complete: all three timed obligations above were satisfied.
- [x] Noncompliant: one or more obligations were not satisfied; explain below.
- [ ] N/A because the PR is human-only or qualifies for the trivial exception.

**Gate-status explanation (or N/A):**

This PR was opened at 2026-08-08T10:22:08Z, before policy commit [`13d2c5446ed232eb439b682bbf1abc22433e81a9`](https://github.com/higress-group/higress/commit/13d2c5446ed232eb439b682bbf1abc22433e81a9) merged on 2026-08-08T11:05:38Z. It is an in-flight materially agent-assisted contribution. Retroactive Proposal/Design approval does not exist and is not fabricated; this PR is explicitly marked Noncompliant while adding best-effort traceability and evidence.

**Trivial-exception explanation (or N/A):**

N/A — material agent participation is declared above.

**Approved Proposal Issue URL (or N/A with explanation):**

N/A — https://github.com/higress-group/higress/issues/4357 is a reproduction/tracking issue, not an approved issue-spec Proposal.

**Approved Design Issue URL (or N/A with explanation):**

N/A — no retroactive Design artifact or approval is claimed.

**Maintainer approval link(s) (or N/A with explanation):**

N/A — no retroactive Proposal/Design approval is claimed.

**Authorized implementation TASK link(s) (or N/A with explanation):**

N/A — no retroactive TASK authorization is claimed.

**Verification Plan and verification TASK/evidence link(s) (or N/A with explanation):**

N/A — no pre-approved Verification Plan or verification TASK exists. Best-effort verification is preserved in Section VIII without representing it as issue-spec evidence.

## V. Testing and verification

**Test and deterministic rerun commands (or N/A with explanation):**

```text
See Section VIII, "Describe how to verify it." This body-only update does not claim that tests were rerun.
```

**Environment and configuration (or N/A with explanation):**

N/A — the original submission did not record a complete OS, architecture, and toolchain matrix; that omission remains explicit.

**Exact tested revision, version, image tag/digest, manifests, and values (or N/A with explanation):**

Current PR head is [`dd4798f9cdd5c5a478f67af556aea3ae99a43c41`](https://github.com/higress-group/higress/commit/dd4798f9cdd5c5a478f67af556aea3ae99a43c41). Section VIII preserves the focused verification originally reported for this revision. N/A for unrecorded image digest, manifests, or values.

**Baseline reproduction evidence for bug fixes (or N/A with explanation):**

The reproducible problem statement is recorded in https://github.com/higress-group/higress/issues/4357. This is an ordinary tracking/reproduction issue, not an approved issue-spec Proposal; policy-required same-input pre-fix runtime output was not collected.

**Fixed-version verification evidence for bug fixes (or N/A with explanation):**

Section VIII preserves the focused verification originally reported for [`dd4798f9cdd5c5a478f67af556aea3ae99a43c41`](https://github.com/higress-group/higress/commit/dd4798f9cdd5c5a478f67af556aea3ae99a43c41). Policy-required production-path red/green runtime evidence was not collected and remains an explicit evidence gap.

**Wasm source revision and SHA-256 (or N/A with explanation):**

Source revision: [`dd4798f9cdd5c5a478f67af556aea3ae99a43c41`](https://github.com/higress-group/higress/commit/dd4798f9cdd5c5a478f67af556aea3ae99a43c41). SHA-256: not available because no Wasm module was built and no digest was recorded; this remains an explicit runtime-evidence gap.

## VI. Special notes for reviewers

- This update only brings the PR report into the current template and records the issue-spec status honestly.
- It does not claim gate completion, maintainer acceptance, or stronger verification than the original submission.

## VII. AI coding disclosure

**Tool(s) used (or N/A):**

Codex using the GitHub five-PR contribution workflow.

### Prompts or instructions

The original prompt is preserved verbatim in Section VIII. Current instruction: audit and revise the August 8–9 Higress PR reports to reflect the maintainer's issue-spec requirements, without updating the skill or fabricating approvals.

### AI-assisted work summary

PR-body reporting only. The code, branch, commits, and original verification text are unchanged. The issue-spec status and missing runtime evidence are now explicit.

## VIII. Original submission details (preserved verbatim)

<!-- original-submission-body:start -->
## Ⅰ. Describe what this PR did

- Validates qwen3guard timeout and maximum-body settings with a 32-bit unsigned parse before assignment.
- Covers both snake_case and camelCase field names with oversized-value regression tests.

## Ⅱ. Does this pull request fix one issue?

Fixes #4357

## Ⅲ. Why don't you add test cases (unit test/integration test)?

Unit regression tests are included.

## Ⅳ. Describe how to verify it

```bash
cd plugins/wasm-go/extensions/qwen3guard
go test ./... -count=1
```

## Ⅴ. Special notes for reviews

Omitted fields keep their existing defaults. Explicit values must fit in `1..math.MaxUint32`. No container or cluster E2E was run.

## Ⅵ. AI Coding Tool Usage Checklist (if applicable)

- [x] **For regular updates/changes** (not new plugins):
  - [x] I have provided the prompts/instructions I gave to the AI Coding tool below
  - [x] I have included the AI Coding summary below

### AI Coding Prompts (for regular updates)

> Scan Higress for nine independent small issues. For qwen3guard, reproduce uint32 truncation in timeout/body limits, validate before conversion, cover both supported key styles, and run local module tests only.

### AI Coding Summary

- Reproduced an oversized positive value being narrowed after validation.
- Added a shared positive-uint32 setter based on `strconv.ParseUint`.
- Added four field-name regression cases and ran module tests.
- Did not run WASM image builds, containers, Kubernetes, or E2E.
<!-- original-submission-body:end -->
