### PR TITLE
fix(response-cache): validate Redis timeout and port

### DIFF
--- a/plugins/wasm-go/extensions/response-cache/cache/provider.go
+++ b/plugins/wasm-go/extensions/response-cache/cache/provider.go
@@ -2,6 +2,7 @@ package cache
 
 import (
 	"errors"
+	"math"
 	"strings"
 
 	"github.com/higress-group/wasm-go/pkg/wrapper"
@@ -45,7 +46,7 @@ type ProviderConfig struct {
 	password string
 	// @Title zh-CN 请求超时
 	// @Description zh-CN 请求缓存服务的超时时间，单位为毫秒。默认值是10000，即10秒
-	timeout uint32
+	timeout int64
 	// @Title zh-CN 缓存过期时间
 	// @Description zh-CN 缓存过期时间，单位为秒。默认值是0，即永不过期
 	cacheTTL int
@@ -73,7 +74,7 @@ func (c *ProviderConfig) FromJson(json gjson.Result) {
 	c.serviceHost = json.Get("serviceHost").String()
 	c.username = json.Get("username").String()
 	c.password = json.Get("password").String()
-	c.timeout = uint32(json.Get("timeout").Int())
+	c.timeout = json.Get("timeout").Int()
 	if !json.Get("timeout").Exists() {
 		c.timeout = 10000
 	}
@@ -96,6 +97,12 @@ func (c *ProviderConfig) Validate() error {
 	}
 	if c.serviceName == "" {
 		return errors.New("cache service name is required")
+	}
+	if c.servicePort <= 0 {
+		return errors.New("cache service port must be greater than 0")
+	}
+	if c.timeout <= 0 || c.timeout > math.MaxUint32 {
+		return errors.New("cache service timeout must be between 1 and 4294967295 milliseconds")
 	}
 	if c.cacheTTL < 0 {
 		return errors.New("cache TTL must be greater than or equal to 0")

--- a/plugins/wasm-go/extensions/response-cache/cache/provider_test.go
+++ b/plugins/wasm-go/extensions/response-cache/cache/provider_test.go
@@ -1,0 +1,109 @@
+package cache
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+func TestProviderConfigTimeout(t *testing.T) {
+	tests := []struct {
+		name        string
+		config      string
+		wantTimeout int64
+		wantErr     string
+	}{
+		{
+			name:        "use default when omitted",
+			config:      `{"type":"redis","serviceName":"redis.static"}`,
+			wantTimeout: 10000,
+		},
+		{
+			name:        "accept minimum",
+			config:      `{"type":"redis","serviceName":"redis.static","timeout":1}`,
+			wantTimeout: 1,
+		},
+		{
+			name:        "accept maximum",
+			config:      `{"type":"redis","serviceName":"redis.static","timeout":4294967295}`,
+			wantTimeout: math.MaxUint32,
+		},
+		{
+			name:    "reject zero",
+			config:  `{"type":"redis","serviceName":"redis.static","timeout":0}`,
+			wantErr: "cache service timeout must be between 1 and 4294967295 milliseconds",
+		},
+		{
+			name:    "reject negative",
+			config:  `{"type":"redis","serviceName":"redis.static","timeout":-1}`,
+			wantErr: "cache service timeout must be between 1 and 4294967295 milliseconds",
+		},
+		{
+			name:    "reject uint32 overflow",
+			config:  `{"type":"redis","serviceName":"redis.static","timeout":4294967296}`,
+			wantErr: "cache service timeout must be between 1 and 4294967295 milliseconds",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var config ProviderConfig
+			config.FromJson(gjson.Parse(tt.config))
+
+			err := config.Validate()
+			if tt.wantErr != "" {
+				require.EqualError(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.wantTimeout, int64(config.timeout))
+		})
+	}
+}
+
+func TestProviderConfigServicePort(t *testing.T) {
+	tests := []struct {
+		name     string
+		config   string
+		wantPort int
+		wantErr  string
+	}{
+		{
+			name:     "use static service default when omitted",
+			config:   `{"type":"redis","serviceName":"redis.static"}`,
+			wantPort: 80,
+		},
+		{
+			name:     "accept positive port",
+			config:   `{"type":"redis","serviceName":"redis.static","servicePort":6379}`,
+			wantPort: 6379,
+		},
+		{
+			name:    "reject zero",
+			config:  `{"type":"redis","serviceName":"redis.static","servicePort":0}`,
+			wantErr: "cache service port must be greater than 0",
+		},
+		{
+			name:    "reject negative",
+			config:  `{"type":"redis","serviceName":"redis.static","servicePort":-1}`,
+			wantErr: "cache service port must be greater than 0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var config ProviderConfig
+			config.FromJson(gjson.Parse(tt.config))
+
+			err := config.Validate()
+			if tt.wantErr != "" {
+				require.EqualError(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.wantPort, config.servicePort)
+		})
+	}
+}

--- a/plugins/wasm-go/extensions/response-cache/cache/redis.go
+++ b/plugins/wasm-go/extensions/response-cache/cache/redis.go
@@ -25,7 +25,7 @@ func (r *redisProviderInitializer) CreateProvider(cf ProviderConfig) (Provider, 
 			Host: cf.serviceHost,
 			Port: int64(cf.servicePort)}),
 	}
-	err := rp.Init(cf.username, cf.password, cf.timeout)
+	err := rp.Init(cf.username, cf.password, uint32(cf.timeout))
 	return &rp, err
 }
 


### PR DESCRIPTION
<!-- issue-spec-inflight-disclosure:v1 -->
## I. Summary

This is a reporting-only update for an in-flight, materially agent-assisted contribution opened before Higress adopted the issue-spec gate. The implementation summary and original verification record are preserved verbatim in Section VIII. No code, commit, or review head is changed by this disclosure update.

## II. Related issue

Fixes #4358

Reproduction and problem statement: https://github.com/higress-group/higress/issues/4358

## III. Change type

- [x] Bug fix
- [ ] Feature or enhancement
- [ ] Documentation or configuration only
- [ ] Refactoring, tests, or maintenance

## IV. Agent participation and issue-spec gate

- [ ] **No agent participation:** This PR is human-only.
- [ ] **Trivial agent-use exception:** Agent use was limited to spelling, punctuation, whitespace, or formatting with no substantive choice or behavioral effect; the explanation is below.
- [x] **Material agent participation:** An AI or coding agent materially participated in analysis, design, implementation, testing, or PR preparation.

For material participation, check each timed obligation:

- [ ] **Before implementation began:** A Higress maintainer had approved the Proposal and Design Issues, and authorized implementation TASKs linked the work to the applicable SPECs.
- [ ] **Before verification began:** The Design contained a concrete Verification Plan.
- [ ] **Before requesting maintainer review or acceptance:** Applicable implementation and verification TASKs were `done` with exact commands, results, evidence links, and hashes.

Then choose exactly one overall gate status:

- [ ] Complete: all three timed obligations above were satisfied.
- [x] Noncompliant: one or more obligations were not satisfied; explain below.
- [ ] N/A because the PR is human-only or qualifies for the trivial exception.

**Gate-status explanation (or N/A):**

This PR was opened at 2026-08-08T10:22:11Z, before policy commit [`13d2c5446ed232eb439b682bbf1abc22433e81a9`](https://github.com/higress-group/higress/commit/13d2c5446ed232eb439b682bbf1abc22433e81a9) merged on 2026-08-08T11:05:38Z. It is an in-flight materially agent-assisted contribution. Retroactive Proposal/Design approval does not exist and is not fabricated; this PR is explicitly marked Noncompliant while adding best-effort traceability and evidence.

**Trivial-exception explanation (or N/A):**

N/A — material agent participation is declared above.

**Approved Proposal Issue URL (or N/A with explanation):**

N/A — https://github.com/higress-group/higress/issues/4358 is a reproduction/tracking issue, not an approved issue-spec Proposal.

**Approved Design Issue URL (or N/A with explanation):**

N/A — no retroactive Design artifact or approval is claimed.

**Maintainer approval link(s) (or N/A with explanation):**

N/A — no retroactive Proposal/Design approval is claimed.

**Authorized implementation TASK link(s) (or N/A with explanation):**

N/A — no retroactive TASK authorization is claimed.

**Verification Plan and verification TASK/evidence link(s) (or N/A with explanation):**

N/A — no pre-approved Verification Plan or verification TASK exists. Best-effort verification is preserved in Section VIII without representing it as issue-spec evidence.

## V. Testing and verification

**Test and deterministic rerun commands (or N/A with explanation):**

```text
See Section VIII, "Describe how to verify it." This body-only update does not claim that tests were rerun.
```

**Environment and configuration (or N/A with explanation):**

N/A — the original submission did not record a complete OS, architecture, and toolchain matrix; that omission remains explicit.

**Exact tested revision, version, image tag/digest, manifests, and values (or N/A with explanation):**

Current PR head is [`3677e4f50e2c563a38b9d9b1e95ba75158303efa`](https://github.com/higress-group/higress/commit/3677e4f50e2c563a38b9d9b1e95ba75158303efa). Section VIII preserves the focused verification originally reported for this revision. N/A for unrecorded image digest, manifests, or values.

**Baseline reproduction evidence for bug fixes (or N/A with explanation):**

The reproducible problem statement is recorded in https://github.com/higress-group/higress/issues/4358. This is an ordinary tracking/reproduction issue, not an approved issue-spec Proposal; policy-required same-input pre-fix runtime output was not collected.

**Fixed-version verification evidence for bug fixes (or N/A with explanation):**

Section VIII preserves the focused verification originally reported for [`3677e4f50e2c563a38b9d9b1e95ba75158303efa`](https://github.com/higress-group/higress/commit/3677e4f50e2c563a38b9d9b1e95ba75158303efa). Policy-required production-path red/green runtime evidence was not collected and remains an explicit evidence gap.

**Wasm source revision and SHA-256 (or N/A with explanation):**

Source revision: [`3677e4f50e2c563a38b9d9b1e95ba75158303efa`](https://github.com/higress-group/higress/commit/3677e4f50e2c563a38b9d9b1e95ba75158303efa). SHA-256: not available because no Wasm module was built and no digest was recorded; this remains an explicit runtime-evidence gap.

## VI. Special notes for reviewers

- This update only brings the PR report into the current template and records the issue-spec status honestly.
- It does not claim gate completion, maintainer acceptance, or stronger verification than the original submission.

## VII. AI coding disclosure

**Tool(s) used (or N/A):**

Codex using the GitHub five-PR contribution workflow.

### Prompts or instructions

The original prompt is preserved verbatim in Section VIII. Current instruction: audit and revise the August 8–9 Higress PR reports to reflect the maintainer's issue-spec requirements, without updating the skill or fabricating approvals.

### AI-assisted work summary

PR-body reporting only. The code, branch, commits, and original verification text are unchanged. The issue-spec status and missing runtime evidence are now explicit.

## VIII. Original submission details (preserved verbatim)

<!-- original-submission-body:start -->
## Ⅰ. Describe what this PR did

- Keeps the response-cache Redis timeout as `int64` until validation, preventing premature uint32 wraparound.
- Requires explicit timeouts to be within `1..math.MaxUint32` and service ports to be positive.
- Adds table-driven provider configuration tests for defaults, boundaries, and invalid values.

## Ⅱ. Does this pull request fix one issue?

Fixes #4358

## Ⅲ. Why don't you add test cases (unit test/integration test)?

Direct provider configuration regression tests are included.

## Ⅳ. Describe how to verify it

```bash
cd plugins/wasm-go/extensions/response-cache
go test ./... -count=1
```

## Ⅴ. Special notes for reviews

The public provider initializer API remains `uint32`; conversion now occurs only after validation. No container or Redis integration test was run.

## Ⅵ. AI Coding Tool Usage Checklist (if applicable)

- [x] **For regular updates/changes** (not new plugins):
  - [x] I have provided the prompts/instructions I gave to the AI Coding tool below
  - [x] I have included the AI Coding summary below

### AI Coding Prompts (for regular updates)

> Scan Higress for nine independent small issues. For response-cache, reproduce negative/overflowing Redis timeout acceptance, preserve defaults, validate before narrowing, add table-driven tests, and run local module tests only.

### AI Coding Summary

- Confirmed timeout wraparound occurred before validation.
- Deferred narrowing until provider creation and added range checks.
- Added default/min/max/invalid timeout and port coverage.
- Did not run containers, Redis integration, Kubernetes, or E2E.
<!-- original-submission-body:end -->
