### PR TITLE
fix(replay-protection): validate configuration ranges

### DIFF
--- a/plugins/wasm-go/extensions/replay-protection/config/config.go
+++ b/plugins/wasm-go/extensions/replay-protection/config/config.go
@@ -37,8 +37,12 @@ func ParseConfig(json gjson.Result, config *ReplayProtectionConfig) error {
 		return fmt.Errorf("redis service name is required")
 	}
 
-	servicePort := redisConfig.Get("service_port").Int()
-	if servicePort == 0 {
+	servicePortConfig := redisConfig.Get("service_port")
+	servicePort := servicePortConfig.Int()
+	if servicePortConfig.Exists() && servicePort <= 0 {
+		return fmt.Errorf("redis service port must be greater than 0")
+	}
+	if !servicePortConfig.Exists() {
 		if strings.HasSuffix(serviceName, ".static") {
 			servicePort = 80 // default logic port for static service
 		} else {
@@ -48,8 +52,12 @@ func ParseConfig(json gjson.Result, config *ReplayProtectionConfig) error {
 
 	username := redisConfig.Get("username").String()
 	password := redisConfig.Get("password").String()
-	timeout := redisConfig.Get("timeout").Int()
-	if timeout == 0 {
+	timeoutConfig := redisConfig.Get("timeout")
+	timeout := timeoutConfig.Int()
+	if timeoutConfig.Exists() && timeout <= 0 {
+		return fmt.Errorf("redis timeout must be greater than 0")
+	}
+	if !timeoutConfig.Exists() {
 		timeout = 1000
 	}
 
@@ -76,8 +84,14 @@ func ParseConfig(json gjson.Result, config *ReplayProtectionConfig) error {
 
 	config.ValidateBase64 = json.Get("validate_base64").Bool()
 
-	config.RejectCode = uint32(json.Get("reject_code").Int())
-	if config.RejectCode == 0 {
+	rejectCode := json.Get("reject_code")
+	if rejectCode.Exists() {
+		code := rejectCode.Int()
+		if code < 100 || code > 599 {
+			return fmt.Errorf("reject code must be between 100 and 599")
+		}
+		config.RejectCode = uint32(code)
+	} else {
 		config.RejectCode = 429
 	}
 
@@ -88,19 +102,37 @@ func ParseConfig(json gjson.Result, config *ReplayProtectionConfig) error {
 
 	config.ForceNonce = json.Get("force_nonce").Bool()
 
-	config.NonceTTL = int(json.Get("nonce_ttl").Int())
-	if config.NonceTTL == 0 {
+	nonceTTL := json.Get("nonce_ttl")
+	if nonceTTL.Exists() {
+		config.NonceTTL = int(nonceTTL.Int())
+		if config.NonceTTL <= 0 {
+			return fmt.Errorf("nonce ttl must be greater than 0")
+		}
+	} else {
 		config.NonceTTL = 900
 	}
 
-	config.NonceMinLen = int(json.Get("nonce_min_length").Int())
-	if config.NonceMinLen == 0 {
+	nonceMinLength := json.Get("nonce_min_length")
+	if nonceMinLength.Exists() {
+		config.NonceMinLen = int(nonceMinLength.Int())
+		if config.NonceMinLen <= 0 {
+			return fmt.Errorf("nonce min length must be greater than 0")
+		}
+	} else {
 		config.NonceMinLen = 8
 	}
 
-	config.NonceMaxLen = int(json.Get("nonce_max_length").Int())
-	if config.NonceMaxLen == 0 {
+	nonceMaxLength := json.Get("nonce_max_length")
+	if nonceMaxLength.Exists() {
+		config.NonceMaxLen = int(nonceMaxLength.Int())
+		if config.NonceMaxLen <= 0 {
+			return fmt.Errorf("nonce max length must be greater than 0")
+		}
+	} else {
 		config.NonceMaxLen = 128
+	}
+	if config.NonceMinLen > config.NonceMaxLen {
+		return fmt.Errorf("nonce min length must not exceed nonce max length")
 	}
 
 	return nil

--- a/plugins/wasm-go/extensions/replay-protection/main_test.go
+++ b/plugins/wasm-go/extensions/replay-protection/main_test.go
@@ -146,6 +146,53 @@ func TestParseConfig(t *testing.T) {
 	})
 }
 
+func TestParseConfigRejectsInvalidRanges(t *testing.T) {
+	test.RunGoTest(t, func(t *testing.T) {
+		tests := []struct {
+			name        string
+			values      map[string]interface{}
+			redisValues map[string]interface{}
+		}{
+			{name: "zero nonce ttl", values: map[string]interface{}{"nonce_ttl": 0}},
+			{name: "negative nonce ttl", values: map[string]interface{}{"nonce_ttl": -1}},
+			{name: "zero nonce min length", values: map[string]interface{}{"nonce_min_length": 0}},
+			{name: "negative nonce min length", values: map[string]interface{}{"nonce_min_length": -1}},
+			{name: "zero nonce max length", values: map[string]interface{}{"nonce_max_length": 0}},
+			{name: "negative nonce max length", values: map[string]interface{}{"nonce_max_length": -1}},
+			{
+				name: "nonce min length exceeds max length",
+				values: map[string]interface{}{
+					"nonce_min_length": 129,
+					"nonce_max_length": 128,
+				},
+			},
+			{name: "reject code below HTTP range", values: map[string]interface{}{"reject_code": 99}},
+			{name: "reject code above HTTP range", values: map[string]interface{}{"reject_code": 600}},
+			{name: "zero redis timeout", redisValues: map[string]interface{}{"timeout": 0}},
+			{name: "negative redis port", redisValues: map[string]interface{}{"service_port": -1}},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				redisConfig := map[string]interface{}{"service_name": "redis.static"}
+				for key, value := range tt.redisValues {
+					redisConfig[key] = value
+				}
+				config := map[string]interface{}{"redis": redisConfig}
+				for key, value := range tt.values {
+					config[key] = value
+				}
+
+				data, err := json.Marshal(config)
+				require.NoError(t, err)
+				host, status := test.NewTestHost(data)
+				defer host.Reset()
+				require.Equal(t, types.OnPluginStartStatusFailed, status)
+			})
+		}
+	})
+}
+
 func TestOnHttpRequestHeaders(t *testing.T) {
 	test.RunTest(t, func(t *testing.T) {
 		// 测试强制 nonce 模式 - 缺少 nonce 头


### PR DESCRIPTION
<!-- issue-spec-inflight-disclosure:v1 -->
## I. Summary

This is a reporting-only update for an in-flight, materially agent-assisted contribution opened before Higress adopted the issue-spec gate. The implementation summary and original verification record are preserved verbatim in Section VIII. No code, commit, or review head is changed by this disclosure update.

## II. Related issue

Fixes #4360

Reproduction and problem statement: https://github.com/higress-group/higress/issues/4360

## III. Change type

- [x] Bug fix
- [ ] Feature or enhancement
- [ ] Documentation or configuration only
- [ ] Refactoring, tests, or maintenance

## IV. Agent participation and issue-spec gate

- [ ] **No agent participation:** This PR is human-only.
- [ ] **Trivial agent-use exception:** Agent use was limited to spelling, punctuation, whitespace, or formatting with no substantive choice or behavioral effect; the explanation is below.
- [x] **Material agent participation:** An AI or coding agent materially participated in analysis, design, implementation, testing, or PR preparation.

For material participation, check each timed obligation:

- [ ] **Before implementation began:** A Higress maintainer had approved the Proposal and Design Issues, and authorized implementation TASKs linked the work to the applicable SPECs.
- [ ] **Before verification began:** The Design contained a concrete Verification Plan.
- [ ] **Before requesting maintainer review or acceptance:** Applicable implementation and verification TASKs were `done` with exact commands, results, evidence links, and hashes.

Then choose exactly one overall gate status:

- [ ] Complete: all three timed obligations above were satisfied.
- [x] Noncompliant: one or more obligations were not satisfied; explain below.
- [ ] N/A because the PR is human-only or qualifies for the trivial exception.

**Gate-status explanation (or N/A):**

This PR was opened at 2026-08-08T10:22:17Z, before policy commit [`13d2c5446ed232eb439b682bbf1abc22433e81a9`](https://github.com/higress-group/higress/commit/13d2c5446ed232eb439b682bbf1abc22433e81a9) merged on 2026-08-08T11:05:38Z. It is an in-flight materially agent-assisted contribution. Retroactive Proposal/Design approval does not exist and is not fabricated; this PR is explicitly marked Noncompliant while adding best-effort traceability and evidence.

**Trivial-exception explanation (or N/A):**

N/A — material agent participation is declared above.

**Approved Proposal Issue URL (or N/A with explanation):**

N/A — https://github.com/higress-group/higress/issues/4360 is a reproduction/tracking issue, not an approved issue-spec Proposal.

**Approved Design Issue URL (or N/A with explanation):**

N/A — no retroactive Design artifact or approval is claimed.

**Maintainer approval link(s) (or N/A with explanation):**

N/A — no retroactive Proposal/Design approval is claimed.

**Authorized implementation TASK link(s) (or N/A with explanation):**

N/A — no retroactive TASK authorization is claimed.

**Verification Plan and verification TASK/evidence link(s) (or N/A with explanation):**

N/A — no pre-approved Verification Plan or verification TASK exists. Best-effort verification is preserved in Section VIII without representing it as issue-spec evidence.

## V. Testing and verification

**Test and deterministic rerun commands (or N/A with explanation):**

```text
See Section VIII, "Describe how to verify it." This body-only update does not claim that tests were rerun.
```

**Environment and configuration (or N/A with explanation):**

N/A — the original submission did not record a complete OS, architecture, and toolchain matrix; that omission remains explicit.

**Exact tested revision, version, image tag/digest, manifests, and values (or N/A with explanation):**

Current PR head is [`6551553c75040e248e21a9e354805d410204c935`](https://github.com/higress-group/higress/commit/6551553c75040e248e21a9e354805d410204c935). Section VIII preserves the focused verification originally reported for this revision. N/A for unrecorded image digest, manifests, or values.

**Baseline reproduction evidence for bug fixes (or N/A with explanation):**

The reproducible problem statement is recorded in https://github.com/higress-group/higress/issues/4360. This is an ordinary tracking/reproduction issue, not an approved issue-spec Proposal; policy-required same-input pre-fix runtime output was not collected.

**Fixed-version verification evidence for bug fixes (or N/A with explanation):**

Section VIII preserves the focused verification originally reported for [`6551553c75040e248e21a9e354805d410204c935`](https://github.com/higress-group/higress/commit/6551553c75040e248e21a9e354805d410204c935). Policy-required production-path red/green runtime evidence was not collected and remains an explicit evidence gap.

**Wasm source revision and SHA-256 (or N/A with explanation):**

Source revision: [`6551553c75040e248e21a9e354805d410204c935`](https://github.com/higress-group/higress/commit/6551553c75040e248e21a9e354805d410204c935). SHA-256: not available because no Wasm module was built and no digest was recorded; this remains an explicit runtime-evidence gap.

## VI. Special notes for reviewers

- This update only brings the PR report into the current template and records the issue-spec status honestly.
- It does not claim gate completion, maintainer acceptance, or stronger verification than the original submission.

## VII. AI coding disclosure

**Tool(s) used (or N/A):**

Codex using the GitHub five-PR contribution workflow.

### Prompts or instructions

The original prompt is preserved verbatim in Section VIII. Current instruction: audit and revise the August 8–9 Higress PR reports to reflect the maintainer's issue-spec requirements, without updating the skill or fabricating approvals.

### AI-assisted work summary

PR-body reporting only. The code, branch, commits, and original verification text are unchanged. The issue-spec status and missing runtime evidence are now explicit.

## VIII. Original submission details (preserved verbatim)

<!-- original-submission-body:start -->
## Ⅰ. Describe what this PR did

- Distinguishes omitted replay-protection numeric fields from explicit zero values.
- Validates positive nonce TTL/length and Redis port/timeout settings, nonce minimum/maximum ordering, and HTTP reject-code range.
- Adds table-driven plugin-start regression cases for invalid configurations.

## Ⅱ. Does this pull request fix one issue?

Fixes #4360

## Ⅲ. Why don't you add test cases (unit test/integration test)?

Wasm-go plugin-start regression tests are included.

## Ⅳ. Describe how to verify it

```bash
cd plugins/wasm-go/extensions/replay-protection
go test ./... -count=1
```

## Ⅴ. Special notes for reviews

Omitted settings retain the existing defaults. No Redis integration, container, or cluster E2E was run.

## Ⅵ. AI Coding Tool Usage Checklist (if applicable)

- [x] **For regular updates/changes** (not new plugins):
  - [x] I have provided the prompts/instructions I gave to the AI Coding tool below
  - [x] I have included the AI Coding summary below

### AI Coding Prompts (for regular updates)

> Scan Higress for nine independent small issues. For replay-protection, reproduce invalid nonce range acceptance, distinguish omitted fields from explicit zero, validate related numeric ranges, add table-driven startup tests, and run local module tests only.

### AI Coding Summary

- Identified zero-as-default handling and missing relation/range checks.
- Added explicit field-presence and numeric validation.
- Covered eleven invalid configuration cases through plugin startup.
- Did not run Redis integration, WASM image builds, containers, Kubernetes, or E2E.
<!-- original-submission-body:end -->
