### PR TITLE
docs: correct E2E conformance test paths

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -38,17 +38,17 @@ It can be divided into below steps:
 4. kube-load-image: load dev higress-controller image it into kind cluster.
 5. install-dev: install higress-controller with dev image, and latest higress-gateway, istiod with helm.
 6. run-e2e-test:
-    1. Setup conformance suite, like define what conformance tests we want to run, in `e2e_test.go` / `higressTests Slice`. Each case we choose to open is defined in `test/ingress/conformance/tests`.
+    1. Load the conformance tests registered in `test/e2e/conformance/tests` into the global `ConformanceTests` slice.
     2. Prepare resources and install them into cluster, like backend services/deployments.
-    3. Load conformance tests we choose to open in `e2e_test.go` / `higressTests Slice`, and run them one by one, fail if it is not expected.
+    3. Run the registered conformance tests one by one and fail on unexpected results.
 
 ### How to write a test case
 
-To add a new test case, you firstly need to add `xxx.go` and `xxx.yaml` in `test/ingress/conformance/tests`. `xxx.yaml` is the Ingress resource you need to apply in the cluster, `xxx.go` defines the HigressConformanceTest.
+To add a new test case, first add a matching `xxx.go` and `xxx.yaml` pair in `test/e2e/conformance/tests`. `xxx.yaml` contains the resources applied to the cluster, and `xxx.go` defines the `HigressConformanceTest`.
 
-And after that, you should add your defined HigressConformanceTest to `e2e_test.go` / `higressTests Slice`.
+Register the test from its `xxx.go` file by calling `Register(YOUR_TEST_CASE)` in `init()`. The E2E runner executes the resulting `ConformanceTests` slice, so no manual edit to `e2e_test.go` is required.
 
-You can understand it quickly just by looking at codes in `test/ingress/conformance/tests/httproute-simple-same-namespace.go` and `test/ingress/conformance/tests/httproute-simple-same-namespace.yaml`, and try to write one.
+See `test/e2e/conformance/tests/httproute-simple-same-namespace.go` and `test/e2e/conformance/tests/httproute-simple-same-namespace.yaml` for a complete example.
 
 ### How to Implement Test Environment Reusability
 

--- a/test/README_CN.md
+++ b/test/README_CN.md
@@ -37,17 +37,17 @@ Higress 提供了运行 Ingress API 一致性测试和 wasmplugin 测试的 make
 4. kube-load-image: 将 dev higress-controller 镜像加载到 kind 集群中。
 5. install-dev: 使用 helm 安装带有 dev 镜像的 higress-controller，并安装最新的 higress-gateway、istiod。
 6. run-e2e-test:
-    1. 所有测试都在 `test/e2e/conformance/tests` 中定义，并在初始化阶段被注册到`ConformanceTests`中。`ConformanceTests` 是一个全局变量，用于存储所有的一致性测试用例。
+    1. 所有测试都在 `test/e2e/conformance/tests` 中定义，并在初始化阶段被注册到 `ConformanceTests` 中。`ConformanceTests` 是存储所有一致性测试用例的全局变量。
     2. 准备资源并将它们安装到集群中，例如后端服务/部署。
     3. 加载选择打开的一致性测试，并逐个运行它们，如果不符合预期，则失败。
 
 ### 如何编写测试用例
 
-要添加新的测试用例，首先需要在 `test/ingress/conformance/tests` 中添加 `xxx.go` 和 `xxx.yaml`。`xxx.yaml` 是您需要在集群中应用的 Ingress 资源，`xxx.go` 定义了 HigressConformanceTest。
+要添加新的测试用例，首先需要在 `test/e2e/conformance/tests` 中添加配对的 `xxx.go` 和 `xxx.yaml`。`xxx.yaml` 包含需要在集群中应用的资源，`xxx.go` 定义 `HigressConformanceTest`。
 
-然后，您应该将您定义的测试用例注册到`ConformanceTests`中，方法是在xxx.go中使用`init()` 函数调用`Register(YOUR_PLUGIN_SHORT_NAME)`。
+然后，在 `xxx.go` 的 `init()` 函数中调用 `Register(YOUR_TEST_CASE)`，将测试用例注册到 `ConformanceTests`。E2E 入口会直接运行该列表，无需手动修改 `e2e_test.go`。
 
-通过查看 `test/ingress/conformance/tests/httproute-simple-same-namespace.go` 和 `test/ingress/conformance/tests/httproute-simple-same-namespace.yaml` 中的代码，您可以快速了解并尝试编写一个测试用例。
+可以参考 `test/e2e/conformance/tests/httproute-simple-same-namespace.go` 和 `test/e2e/conformance/tests/httproute-simple-same-namespace.yaml` 中的完整示例。
 
 ### 如何实现测试环境的复用
 


### PR DESCRIPTION
<!-- issue-spec-inflight-disclosure:v1 -->
## I. Summary

This is a reporting-only update for an in-flight, materially agent-assisted contribution opened before Higress adopted the issue-spec gate. The implementation summary and original verification record are preserved verbatim in Section VIII. No code, commit, or review head is changed by this disclosure update.

## II. Related issue

Fixes #4362

Reproduction and problem statement: https://github.com/higress-group/higress/issues/4362

## III. Change type

- [ ] Bug fix
- [ ] Feature or enhancement
- [x] Documentation or configuration only
- [ ] Refactoring, tests, or maintenance

## IV. Agent participation and issue-spec gate

- [ ] **No agent participation:** This PR is human-only.
- [ ] **Trivial agent-use exception:** Agent use was limited to spelling, punctuation, whitespace, or formatting with no substantive choice or behavioral effect; the explanation is below.
- [x] **Material agent participation:** An AI or coding agent materially participated in analysis, design, implementation, testing, or PR preparation.

For material participation, check each timed obligation:

- [ ] **Before implementation began:** A Higress maintainer had approved the Proposal and Design Issues, and authorized implementation TASKs linked the work to the applicable SPECs.
- [ ] **Before verification began:** The Design contained a concrete Verification Plan.
- [ ] **Before requesting maintainer review or acceptance:** Applicable implementation and verification TASKs were `done` with exact commands, results, evidence links, and hashes.

Then choose exactly one overall gate status:

- [ ] Complete: all three timed obligations above were satisfied.
- [x] Noncompliant: one or more obligations were not satisfied; explain below.
- [ ] N/A because the PR is human-only or qualifies for the trivial exception.

**Gate-status explanation (or N/A):**

This PR was opened at 2026-08-08T10:22:23Z, before policy commit [`13d2c5446ed232eb439b682bbf1abc22433e81a9`](https://github.com/higress-group/higress/commit/13d2c5446ed232eb439b682bbf1abc22433e81a9) merged on 2026-08-08T11:05:38Z. It is an in-flight materially agent-assisted contribution. Retroactive Proposal/Design approval does not exist and is not fabricated; this PR is explicitly marked Noncompliant while adding best-effort traceability and evidence.

**Trivial-exception explanation (or N/A):**

N/A — material agent participation is declared above.

**Approved Proposal Issue URL (or N/A with explanation):**

N/A — https://github.com/higress-group/higress/issues/4362 is a reproduction/tracking issue, not an approved issue-spec Proposal.

**Approved Design Issue URL (or N/A with explanation):**

N/A — no retroactive Design artifact or approval is claimed.

**Maintainer approval link(s) (or N/A with explanation):**

N/A — no retroactive Proposal/Design approval is claimed.

**Authorized implementation TASK link(s) (or N/A with explanation):**

N/A — no retroactive TASK authorization is claimed.

**Verification Plan and verification TASK/evidence link(s) (or N/A with explanation):**

N/A — no pre-approved Verification Plan or verification TASK exists. Best-effort verification is preserved in Section VIII without representing it as issue-spec evidence.

## V. Testing and verification

**Test and deterministic rerun commands (or N/A with explanation):**

```text
See Section VIII, "Describe how to verify it." This body-only update does not claim that tests were rerun.
```

**Environment and configuration (or N/A with explanation):**

N/A — the original submission did not record a complete OS, architecture, and toolchain matrix; that omission remains explicit.

**Exact tested revision, version, image tag/digest, manifests, and values (or N/A with explanation):**

Current PR head is [`6dfde6daf4ff3b2df4bc7d1343daf63ab5755352`](https://github.com/higress-group/higress/commit/6dfde6daf4ff3b2df4bc7d1343daf63ab5755352). Section VIII preserves the focused verification originally reported for this revision. N/A for unrecorded image digest, manifests, or values.

**Baseline reproduction evidence for bug fixes (or N/A with explanation):**

N/A — this is documentation-only; the reporting issue is https://github.com/higress-group/higress/issues/4362.

**Fixed-version verification evidence for bug fixes (or N/A with explanation):**

N/A — documentation-only change; no runtime behavior is claimed.

**Wasm source revision and SHA-256 (or N/A with explanation):**

N/A — this PR does not deliver a Wasm module.

## VI. Special notes for reviewers

- This update only brings the PR report into the current template and records the issue-spec status honestly.
- It does not claim gate completion, maintainer acceptance, or stronger verification than the original submission.

## VII. AI coding disclosure

**Tool(s) used (or N/A):**

Codex using the GitHub five-PR contribution workflow.

### Prompts or instructions

The original prompt is preserved verbatim in Section VIII. Current instruction: audit and revise the August 8–9 Higress PR reports to reflect the maintainer's issue-spec requirements, without updating the skill or fabricating approvals.

### AI-assisted work summary

PR-body reporting only. The code, branch, commits, and original verification text are unchanged. The issue-spec status and missing runtime evidence are now explicit.

## VIII. Original submission details (preserved verbatim)

<!-- original-submission-body:start -->
## Ⅰ. Describe what this PR did

- Corrects the English and Chinese E2E guides to use `test/e2e/conformance/tests`.
- Documents matching `.go`/`.yaml` files and `init()` plus `Register` registration.
- Removes instructions to edit the obsolete `higressTests` slice.

## Ⅱ. Does this pull request fix one issue?

Fixes #4362

## Ⅲ. Why don't you add test cases (unit test/integration test)?

This is documentation-only. All referenced relative paths were checked locally, and stale path/registration terms were scanned out.

## Ⅳ. Describe how to verify it

```bash
rg -n 'test/ingress/conformance/tests|higressTests Slice' test/README.md test/README_CN.md
test -e test/e2e/conformance/tests/httproute-simple-same-namespace.go
test -e test/e2e/conformance/tests/httproute-simple-same-namespace.yaml
```

The `rg` command should return no matches; both path checks should pass.

## Ⅴ. Special notes for reviews

The English and Chinese guides were updated together to keep them consistent. No E2E test was run.

## Ⅵ. AI Coding Tool Usage Checklist (if applicable)

- [x] **For regular updates/changes** (not new plugins):
  - [x] I have provided the prompts/instructions I gave to the AI Coding tool below
  - [x] I have included the AI Coding summary below

### AI Coding Prompts (for regular updates)

> Scan Higress for nine independent small issues. Correct stale E2E contributor paths and registration instructions in both language guides, verify every referenced local path, and keep the documentation-only patch small.

### AI Coding Summary

- Compared both guides with the current E2E package and runner.
- Replaced removed paths and obsolete manual registration instructions.
- Verified example paths and scanned for stale references.
- Did not run E2E because runtime behavior is unchanged.
<!-- original-submission-body:end -->
