### PR TITLE
bugfix: fix unsafe type assertion in ai-proxy buildEmbeddingsResponse for qwen, gemini, vertex

### DIFF
--- a/plugins/wasm-go/extensions/ai-proxy/provider/gemini.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/gemini.go
@@ -611,7 +611,6 @@ func (g *geminiProvider) baseStr2InlineData(baseStr string) *geminiInlineData {
 }
 
 func (g *geminiProvider) getImageInlineDataWithCallback(raw string, callback func(*geminiInlineData, error)) {
-
 	responseCallback := func(statusCode int, responseHeaders http.Header, responseBody []byte) {
 		if statusCode != http.StatusOK {
 			callback(nil, fmt.Errorf("get %s failed, status: %v", raw, statusCode))
@@ -839,7 +838,7 @@ func (g *geminiProvider) buildEmbeddingsResponse(ctx wrapper.HttpContext, gemini
 	response := embeddingsResponse{
 		Object: "list",
 		Data:   make([]embedding, 0, len(geminiResp.Embeddings)),
-		Model:  ctx.GetContext(ctxKeyFinalRequestModel).(string),
+		Model:  ctx.GetStringContext(ctxKeyFinalRequestModel, ""),
 		Usage: usage{
 			TotalTokens: 0,
 		},

--- a/plugins/wasm-go/extensions/ai-proxy/provider/qwen.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/qwen.go
@@ -551,7 +551,7 @@ func (m *qwenProvider) buildEmbeddingsResponse(ctx wrapper.HttpContext, qwenResp
 	return &embeddingsResponse{
 		Object: "list",
 		Data:   data,
-		Model:  ctx.GetContext(ctxKeyFinalRequestModel).(string),
+		Model:  ctx.GetStringContext(ctxKeyFinalRequestModel, ""),
 		Usage: usage{
 			PromptTokens: qwenResponse.Usage.TotalTokens,
 			TotalTokens:  qwenResponse.Usage.TotalTokens,

--- a/plugins/wasm-go/extensions/ai-proxy/provider/vertex.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/vertex.go
@@ -909,7 +909,7 @@ func (v *vertexProvider) buildEmbeddingsResponse(ctx wrapper.HttpContext, vertex
 	response := embeddingsResponse{
 		Object: "list",
 		Data:   make([]embedding, 0, len(vertexResp.Predictions)),
-		Model:  ctx.GetContext(ctxKeyFinalRequestModel).(string),
+		Model:  ctx.GetStringContext(ctxKeyFinalRequestModel, ""),
 	}
 	totalTokens := 0
 	for _, item := range vertexResp.Predictions {


### PR DESCRIPTION
## I. What does this PR do

Fixes unsafe type assertions in the `buildEmbeddingsResponse` function of three ai-proxy providers (qwen.go, gemini.go, vertex.go) that can cause Wasm plugin panics.

### Root Cause

All three providers have two response paths:
- **Chat completion path**: uses the safe API `ctx.GetStringContext(ctxKeyFinalRequestModel, "")` — ✅ safe
- **Embeddings path**: uses the bare assertion `ctx.GetContext(ctxKeyFinalRequestModel).(string)` — ❌ unsafe

The `ctxKeyFinalRequestModel` context key is set during `parseRequestAndMapModel`. If the embeddings request path does not go through `parseRequestAndMapModel` (e.g. due to `protocol: original` mode, or if the context is corrupted by a plugin interaction), the context value is `nil` and the bare `.(string)` assertion panics.

### Fix

Replace `ctx.GetContext(ctxKeyFinalRequestModel).(string)` with `ctx.GetStringContext(ctxKeyFinalRequestModel, "")` in:
- `qwen.go` — `buildEmbeddingsResponse` (1 occurrence)
- `gemini.go` — `buildEmbeddingsResponse` (1 occurrence)
- `vertex.go` — `buildEmbeddingsResponse` (1 occurrence)

`ctx.GetStringContext(key, defaultValue)` is an existing safe API on `wrapper.HttpContext` that returns the default value instead of panicking. This makes the embeddings response path consistent with the chat completion response path, which already uses this safe API.

## II. Fixes Issue

Fixes #4372

## III. Why no test cases

The embeddings response path requires a full Wasm runtime environment with upstream HTTP callout callbacks. The fix is a straightforward replacement of a bare type assertion with the existing safe API (`GetStringContext`), matching the pattern already used in the chat completion response path of the same files. Existing provider tests continue to pass.

## IV. How to verify

- `cd plugins/wasm-go/extensions/ai-proxy && GOOS=wasip1 GOARCH=wasm go build . ./provider/` — compiles successfully
- `cd plugins/wasm-go/extensions/ai-proxy && go test ./provider/ -count=1` — all tests pass

## V. Special notes for reviewers

- Same defensive pattern as approved in #4226 (WAF plugin) and #4224 (ai-load-balancer)
- The fix makes the embeddings response path consistent with the chat completion response path in the same files — `buildChatCompletionResponse` and `buildChatCompletionStreamResponse` already use `ctx.GetStringContext(ctxKeyFinalRequestModel, "")`
- When the context value is missing, the default empty string `""` is used — same behavior as the chat completion path
- `GetStringContext` is an existing API on `wrapper.HttpContext`, already used by `openai.go`, `claude.go`, and other providers

## VI. AI Coding Tool Usage Checklist

- [x] Used AI coding tools: Yes (AI-assisted code analysis and fix generation)
- [ ] New standalone plugin scenario: N/A (bug fix in existing code)
- [x] Regular modification scenario: AI analyzed the buildEmbeddingsResponse functions across qwen, gemini, and vertex providers to identify the inconsistency with buildChatCompletionResponse