### PR TITLE
bugfix: fix unsafe type assertion in ai-proxy retryCall retryCount context

### DIFF
--- a/plugins/wasm-go/extensions/ai-proxy/provider/retry.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/retry.go
@@ -7,9 +7,9 @@ import (
 	"net/http"
 
 	"github.com/alibaba/higress/plugins/wasm-go/extensions/ai-proxy/util"
+	"github.com/higress-group/proxy-wasm-go-sdk/proxywasm"
 	"github.com/higress-group/wasm-go/pkg/log"
 	"github.com/higress-group/wasm-go/pkg/wrapper"
-	"github.com/higress-group/proxy-wasm-go-sdk/proxywasm"
 	"github.com/tidwall/gjson"
 )
 
@@ -81,9 +81,14 @@ func (c *ProviderConfig) retryCall(
 	ctx wrapper.HttpContext, activeProvider Provider,
 	apiName ApiName, statusCode int, responseHeaders http.Header, responseBody []byte,
 	retryClient *wrapper.ClusterClient[wrapper.RouteCluster],
-	apiTokenInUse string, apiTokens []string) {
-
-	retryCount := ctx.GetContext(ctxRetryCount).(int)
+	apiTokenInUse string, apiTokens []string,
+) {
+	retryCount, ok := ctx.GetContext(ctxRetryCount).(int)
+	if !ok {
+		log.Errorf("retryCount context value missing or invalid, aborting retry")
+		proxywasm.ResumeHttpResponse()
+		return
+	}
 	log.Infof("Sent retry request: %d/%d", retryCount, c.retryOnFailure.maxRetries)
 
 	if statusCode == 200 {
@@ -114,8 +119,8 @@ func (c *ProviderConfig) retryCall(
 func (c *ProviderConfig) sendRetryRequest(
 	ctx wrapper.HttpContext, apiName ApiName, activeProvider Provider,
 	retryClient *wrapper.ClusterClient[wrapper.RouteCluster],
-	apiTokenInUse string, apiTokens []string) error {
-
+	apiTokenInUse string, apiTokens []string,
+) error {
 	// Remove last failed token from retry apiTokens list
 	apiTokens = removeApiTokenFromRetryList(apiTokens, apiTokenInUse)
 	if len(apiTokens) == 0 {


### PR DESCRIPTION
## I. What does this PR do

Fixes an unsafe type assertion in the `retryCall` function of `plugins/wasm-go/extensions/ai-proxy/provider/retry.go` that can cause a Wasm plugin panic if the context value is missing or has an unexpected type.

### Root Cause

The `retryCall` function uses a bare type assertion on `ctx.GetContext(ctxRetryCount).(int)`. While `ctxRetryCount` is set to `1` (int) in `retryFailedRequest` before calling `sendRetryRequest`, the bare assertion panics if the context value is corrupted or missing (e.g. by a plugin interaction or race condition).

This is especially dangerous because `retryCall` is called from an HTTP callout callback — if it panics, the retry mechanism fails silently and the original request may hang.

### Fix

Replace the bare assertion with the comma-ok pattern:
```go
retryCount, ok := ctx.GetContext(ctxRetryCount).(int)
if !ok {
    log.Errorf("retryCount context value missing or invalid, aborting retry")
    proxywasm.ResumeHttpResponse()
    return
}
```

When the context value is missing or invalid, the function logs the error and resumes the HTTP response (returning the original upstream response to the client) instead of panicking.

## II. Fixes Issue

Fixes #4373

## III. Why no test cases

The retry path requires a full Wasm runtime environment with HTTP callout callbacks. The fix is a straightforward comma-ok pattern replacement that prevents panics in edge cases. Existing provider tests continue to pass.

## IV. How to verify

- `cd plugins/wasm-go/extensions/ai-proxy && GOOS=wasip1 GOARCH=wasm go build . ./provider/` — compiles successfully
- `cd plugins/wasm-go/extensions/ai-proxy && go test ./provider/ -count=1` — all tests pass

## V. Special notes for reviewers

- Same defensive pattern as approved in #4226 (WAF plugin) and #4224 (ai-load-balancer)
- When the context value is missing, the function calls `proxywasm.ResumeHttpResponse()` to return the original upstream response to the client, rather than hanging
- The `ok` variable is scoped to the `retryCall` function and does not conflict with any existing declarations

## VI. AI Coding Tool Usage Checklist

- [x] Used AI coding tools: Yes (AI-assisted code analysis and fix generation)
- [ ] New standalone plugin scenario: N/A (bug fix in existing code)
- [x] Regular modification scenario: AI analyzed the retryCall callback flow to identify the unsafe type assertion