### PR TITLE
bugfix: fix unsafe type assertion in ai-agent toolsCall ToolCallsCount context

### DIFF
--- a/plugins/wasm-go/extensions/ai-agent/main.go
+++ b/plugins/wasm-go/extensions/ai-agent/main.go
@@ -396,7 +396,10 @@ func toolsCall(ctx wrapper.HttpContext, llmClient wrapper.HttpClient, llmInfo LL
 	if action == "Final Answer" {
 		return types.ActionContinue, actionInput
 	}
-	count := ctx.GetContext(ToolCallsCount).(int)
+	count, ok := ctx.GetContext(ToolCallsCount).(int)
+	if !ok {
+		count = 0
+	}
 	count++
 	log.Debugf("toolCallsCount:%d, config.LLMInfo.MaxIterations=%d", count, llmInfo.MaxIterations)
 	// 函数递归调用次数，达到了预设的循环次数，强制结束


### PR DESCRIPTION
## I. What does this PR do

Fixes an unsafe type assertion in the `toolsCall` function of `plugins/wasm-go/extensions/ai-agent/main.go` that can cause a Wasm plugin panic if the context value is missing or has an unexpected type.

### Root Cause

The `toolsCall` function uses a bare type assertion on `ctx.GetContext(ToolCallsCount).(int)`. While `ToolCallsCount` is set to `0` (int) in `onHttpRequestBody`, `toolsCall` is called from HTTP callout callbacks (the LLM Post callback in `toolsCallResult` → `toolsCall`). If the callback executes without `onHttpRequestBody` having been called first, the context value is `nil` and the bare `.(int)` assertion panics.

This is especially dangerous because `toolsCall` is called from an HTTP callout callback — if it panics, the agent's tool-calling loop fails silently and the original request hangs.

### Fix

Replace the bare assertion with the comma-ok pattern:
```go
count, ok := ctx.GetContext(ToolCallsCount).(int)
if !ok {
    count = 0
}
```

When the context value is missing or invalid, the function uses `0` as the default — the same value set in `onHttpRequestBody` initialization.

## II. Fixes Issue

Fixes #4376

## III. Why no test cases

The `toolsCall` path requires a full Wasm runtime environment with HTTP callout callbacks and LLM integration. The fix is a straightforward comma-ok pattern replacement that prevents panics in edge cases. Existing tests continue to pass.

## IV. How to verify

- `cd plugins/wasm-go/extensions/ai-agent && GOOS=wasip1 GOARCH=wasm go build ./...` — compiles successfully
- `cd plugins/wasm-go/extensions/ai-agent && go test ./... -count=1` — all tests pass

## V. Special notes for reviewers

- Same defensive pattern as approved in #4226 (WAF plugin) and #4224 (ai-load-balancer)
- When the context value is missing, the default `0` is used — same as the initialization value in `onHttpRequestBody`
- The `ok` variable is scoped to the `toolsCall` function and does not conflict with any existing declarations
- Note: competitor PR #4311 by yuluo-yx touches the same file (ai-agent/main.go) but addresses a different issue (OpenAPI server config validation), so there should be no merge conflict

## VI. AI Coding Tool Usage Checklist

- [x] Used AI coding tools: Yes (AI-assisted code analysis and fix generation)
- [ ] New standalone plugin scenario: N/A (bug fix in existing code)
- [x] Regular modification scenario: AI analyzed the toolsCall callback flow to identify the unsafe type assertion