### PR TITLE
bugfix: fix panic in mcp-server FixedQueryToken when credential keys are missing

### DIFF
--- a/plugins/golang-filter/mcp-server/registry/remote.go
+++ b/plugins/golang-filter/mcp-server/registry/remote.go
@@ -23,7 +23,7 @@ const (
 	DEFAULT_HTTP_PATH     = "/"
 )
 
-func getHttpCredentialHandle(name string) (func(*CredentialInfo, *HttpRemoteCallHandle), error) {
+func getHttpCredentialHandle(name string) (func(*CredentialInfo, *HttpRemoteCallHandle) error, error) {
 	if name == "fixed-query-token" {
 		return FixedQueryToken, nil
 	}
@@ -46,10 +46,25 @@ type HttpRemoteCallHandle struct {
 }
 
 // http credentials handles
-func FixedQueryToken(cred *CredentialInfo, h *HttpRemoteCallHandle) {
-	key, _ := cred.Credentials[FIX_QUERY_TOKEN_KEY]
-	value, _ := cred.Credentials[FIX_QUERY_TOKEN_VALUE]
-	h.Query[key.(string)] = value.(string)
+func FixedQueryToken(cred *CredentialInfo, h *HttpRemoteCallHandle) error {
+	key, ok := cred.Credentials[FIX_QUERY_TOKEN_KEY]
+	if !ok {
+		return fmt.Errorf("missing %q in fixed-query-token credentials", FIX_QUERY_TOKEN_KEY)
+	}
+	value, ok := cred.Credentials[FIX_QUERY_TOKEN_VALUE]
+	if !ok {
+		return fmt.Errorf("missing %q in fixed-query-token credentials", FIX_QUERY_TOKEN_VALUE)
+	}
+	keyStr, ok := key.(string)
+	if !ok {
+		return fmt.Errorf("%q in fixed-query-token credentials is not a string", FIX_QUERY_TOKEN_KEY)
+	}
+	valueStr, ok := value.(string)
+	if !ok {
+		return fmt.Errorf("%q in fixed-query-token credentials is not a string", FIX_QUERY_TOKEN_VALUE)
+	}
+	h.Query[keyStr] = valueStr
+	return nil
 }
 
 func newHttpRemoteCallHandle(ctx *RpcContext) (*HttpRemoteCallHandle, error) {
@@ -87,7 +102,9 @@ func (h *HttpRemoteCallHandle) HandleToolCall(ctx *RpcContext, parameters map[st
 		if err != nil {
 			return nil, err
 		}
-		credentialHandle(ctx.Credential, h)
+		if err := credentialHandle(ctx.Credential, h); err != nil {
+			return nil, err
+		}
 	}
 
 	err := h.handleParamMapping(&ctx.ToolMeta.ParametersMapping, parameters)


### PR DESCRIPTION
## I. What does this PR do

Fixes a panic in the `FixedQueryToken` function of `plugins/golang-filter/mcp-server/registry/remote.go` that occurs when the credential map is missing the expected `key` or `value` entries.

### Root Cause

The `FixedQueryToken` function discards the `ok` flag from map lookups:
```go
key, _ := cred.Credentials[FIX_QUERY_TOKEN_KEY]
value, _ := cred.Credentials[FIX_QUERY_TOKEN_VALUE]
h.Query[key.(string)] = value.(string)
```

If `cred.Credentials` does not contain the `"key"` or `"value"` entries (e.g. due to a misconfigured MCP server credential), `key` and/or `value` will be `nil`, and the subsequent `nil.(string)` assertion panics.

This function is called directly from `HandleToolCall` in the same file, which is the per-request handler for MCP tool calls with `fixed-query-token` credential type. There is no `recover` in the call chain, so the panic crashes the tool call.

### Fix

1. Changed `FixedQueryToken` signature to return `error` instead of being void
2. Added `ok` flag checks on both map lookups with descriptive error messages
3. Added type assertion checks (`key.(string)` / `value.(string)`) with comma-ok pattern
4. Updated `getHttpCredentialHandle` return type to match
5. Updated `HandleToolCall` to propagate the error from `credentialHandle`

## II. Fixes Issue

Fixes #4378

## III. Why no test cases

The MCP server registry code requires a full Envoy golang-filter runtime environment with MCP protocol integration to test the tool call path. The fix is a straightforward defensive programming change (checking `ok` flags and using comma-ok pattern for type assertions).

## IV. How to verify

- `cd plugins/golang-filter/mcp-server/registry && go build .` — compiles successfully

## V. Special notes for reviewers

- This is a golang-filter plugin (not wasm-go), so the panic is not recovered by the wasm-go runtime — it directly crashes the Envoy worker
- The fix changes the function signature of `FixedQueryToken` and `getHttpCredentialHandle` to return `error`, which is a breaking change for any external callers — but since these are internal functions in the mcp-server package, there should be no external callers
- The error messages include the specific credential key that is missing, making it easy to diagnose configuration issues
- Same defensive pattern as approved in #4226 (WAF plugin) and #4224 (ai-load-balancer), but applied to a golang-filter instead of wasm-go

## VI. AI Coding Tool Usage Checklist

- [x] Used AI coding tools: Yes (AI-assisted code analysis and fix generation)
- [ ] New standalone plugin scenario: N/A (bug fix in existing code)
- [x] Regular modification scenario: AI analyzed the FixedQueryToken credential handling flow to identify the discarded ok flag and bare type assertions