### PR TITLE
bugfix: fix unsafe type assertions in certmgr OnEvent that can panic certmagic callback

### DIFF
--- a/pkg/cert/certmgr.go
+++ b/pkg/cert/certmgr.go
@@ -238,10 +238,12 @@ func (s *CertMgr) OnEvent(ctx context.Context, event string, data map[string]any
 		}
 		privateKey, err := s.cfg.Storage.Load(context.Background(), privateKeyPath)
 		if err != nil {
+			CertLog.Errorf("failed to load private key for domain %s from path %s: %v", domain, privateKeyPath, err)
 			return err
 		}
 		certificate, err := s.cfg.Storage.Load(context.Background(), certificatePath)
 		if err != nil {
+			CertLog.Errorf("failed to load certificate for domain %s from path %s: %v", domain, certificatePath, err)
 			return err
 		}
 		certChain, err := parseCertsFromPEMBundle(certificate)

--- a/pkg/cert/certmgr.go
+++ b/pkg/cert/certmgr.go
@@ -217,12 +217,33 @@ func (s *CertMgr) OnEvent(ctx context.Context, event string, data map[string]any
 	*/
 	if event == EventCertObtained {
 		// obtain certificate and update secret
-		domain := data["identifier"].(string)
-		isRenew := data["renewal"].(bool)
-		privateKeyPath := data["private_key_path"].(string)
-		certificatePath := data["certificate_path"].(string)
+		domain, ok := data["identifier"].(string)
+		if !ok {
+			CertLog.Errorf("missing or invalid identifier in cert event data: %+v", data)
+			return nil
+		}
+		isRenew, ok := data["renewal"].(bool)
+		if !ok {
+			isRenew = false
+		}
+		privateKeyPath, ok := data["private_key_path"].(string)
+		if !ok {
+			CertLog.Errorf("missing or invalid private_key_path in cert event data: %+v", data)
+			return nil
+		}
+		certificatePath, ok := data["certificate_path"].(string)
+		if !ok {
+			CertLog.Errorf("missing or invalid certificate_path in cert event data: %+v", data)
+			return nil
+		}
 		privateKey, err := s.cfg.Storage.Load(context.Background(), privateKeyPath)
+		if err != nil {
+			return err
+		}
 		certificate, err := s.cfg.Storage.Load(context.Background(), certificatePath)
+		if err != nil {
+			return err
+		}
 		certChain, err := parseCertsFromPEMBundle(certificate)
 		if err != nil {
 			return err


### PR DESCRIPTION
## I. What does this PR do

Fixes unsafe type assertions in the `OnEvent` function of `pkg/cert/certmgr.go` that can cause a panic when the certmagic event map is missing expected keys or has unexpected types.

### Root Cause

The `OnEvent` callback uses bare type assertions on `data` map lookups:
```go
domain := data["identifier"].(string)
isRenew := data["renewal"].(bool)
privateKeyPath := data["private_key_path"].(string)
certificatePath := data["certificate_path"].(string)
```

If certmagic changes its event payload structure or a key is missing, `nil.(string)` or `nil.(bool)` panics the reconcile goroutine.

Additionally, `Storage.Load` errors were silently overwritten — the first `Load` error was lost when the second `Load` was called.

### Fix

1. Replaced all 4 bare type assertions with comma-ok pattern
2. `identifier`, `private_key_path`, `certificate_path` — return nil (skip event) if missing with error log
3. `renewal` — default to `false` if missing (non-critical field)
4. Added error checks on both `Storage.Load` calls before proceeding

## II. Fixes Issue

Fixes #4382

## III. Why no test cases

The `OnEvent` callback is invoked by certmagic during certificate lifecycle events, requiring a full certmagic + K8s integration environment. The fix is a defensive programming change (comma-ok pattern + error checking). Syntax verified with `gofmt -e`.

## IV. How to verify

- `gofmt -e pkg/cert/certmgr.go` — syntax OK
- Full compilation: `go build ./pkg/cert/` (requires Istio submodules)

## V. Special notes for reviewers

- The `renewal` field defaults to `false` when missing because it is non-critical — it only affects whether the update is logged as a renewal vs. a new cert
- The `identifier`, `private_key_path`, and `certificate_path` fields are critical — if any is missing, the event is logged and skipped (return nil) rather than panicking
- Added error checks on `Storage.Load` calls that were previously silently overwritten

## VI. AI Coding Tool Usage Checklist

- [x] Used AI coding tools: Yes (AI-assisted code analysis and fix generation)
- [ ] New standalone plugin scenario: N/A (bug fix in existing code)
- [x] Regular modification scenario: AI analyzed the OnEvent callback flow to identify all unsafe type assertions and missing error checks