### PR TITLE
bugfix: preserve resourceVersion when hgctl updates an existing profile ConfigMap

### DIFF
--- a/hgctl/pkg/installer/profile_store.go
+++ b/hgctl/pkg/installer/profile_store.go
@@ -217,13 +217,14 @@ func (c *ConfigmapProfileStore) listConfigmaps(name string, namespace string, si
 }
 
 func (c *ConfigmapProfileStore) applyConfigmap(configmap *corev1.ConfigMap) error {
-	_, err := c.kubeCli.KubernetesInterface().CoreV1().ConfigMaps(configmap.Namespace).Get(context.Background(), configmap.Name, metav1.GetOptions{})
+	existing, err := c.kubeCli.KubernetesInterface().CoreV1().ConfigMaps(configmap.Namespace).Get(context.Background(), configmap.Name, metav1.GetOptions{})
 	if err != nil && errors.IsNotFound(err) {
 		_, err = c.kubeCli.KubernetesInterface().CoreV1().ConfigMaps(configmap.Namespace).Create(context.Background(), configmap, metav1.CreateOptions{})
 		return err
 	} else if err != nil {
 		return err
 	} else {
+		configmap.ResourceVersion = existing.ResourceVersion
 		_, err = c.kubeCli.KubernetesInterface().CoreV1().ConfigMaps(configmap.Namespace).Update(context.Background(), configmap, metav1.UpdateOptions{})
 		return err
 	}

--- a/hgctl/pkg/installer/profile_store_test.go
+++ b/hgctl/pkg/installer/profile_store_test.go
@@ -1,0 +1,250 @@
+// Copyright (c) 2022 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package installer
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/alibaba/higress/hgctl/pkg/helm"
+	hgctlkubernetes "github.com/alibaba/higress/hgctl/pkg/kubernetes"
+	"github.com/alibaba/higress/hgctl/pkg/util"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+// fakeCLIClient is a minimal kubernetes.CLIClient stub. Only
+// KubernetesInterface is implemented because ConfigmapProfileStore.Save never
+// calls any other CLIClient method.
+type fakeCLIClient struct {
+	hgctlkubernetes.CLIClient
+	kube kubernetes.Interface
+}
+
+func (f *fakeCLIClient) KubernetesInterface() kubernetes.Interface {
+	return f.kube
+}
+
+func newTestProfile() *helm.Profile {
+	return &helm.Profile{
+		Profile:        "test",
+		HigressVersion: "2.1.0-test",
+		Global: helm.ProfileGlobal{
+			Install:      helm.InstallK8s,
+			Namespace:    "higress-system",
+			IngressClass: "higress",
+		},
+	}
+}
+
+func newConfigmapProfileStore(t *testing.T, objects ...runtime.Object) (ProfileStore, *fake.Clientset) {
+	t.Helper()
+	clientset := fake.NewSimpleClientset(objects...)
+	store, err := NewConfigmapProfileStore(&fakeCLIClient{kube: clientset})
+	if err != nil {
+		t.Fatalf("NewConfigmapProfileStore() error = %v, want nil", err)
+	}
+	return store, clientset
+}
+
+func actionsForVerb(clientset *fake.Clientset, verb string) []k8stesting.Action {
+	matched := make([]k8stesting.Action, 0)
+	for _, action := range clientset.Actions() {
+		if action.GetVerb() == verb {
+			matched = append(matched, action)
+		}
+	}
+	return matched
+}
+
+func wantProfileAnnotation(t *testing.T, profile *helm.Profile) string {
+	t.Helper()
+	bytes, err := json.Marshal(profile)
+	if err != nil {
+		t.Fatalf("json.Marshal(profile) error = %v, want nil", err)
+	}
+	return string(bytes)
+}
+
+func TestConfigmapProfileStoreSaveCreatesAbsentConfigmap(t *testing.T) {
+	store, clientset := newConfigmapProfileStore(t)
+	profile := newTestProfile()
+
+	name, err := store.Save(profile)
+	if err != nil {
+		t.Fatalf("Save() error = %v, want nil", err)
+	}
+	wantName := fmt.Sprintf("%s/%s", profile.Global.Namespace, ProfileConfigmapName)
+	if name != wantName {
+		t.Errorf("Save() name = %q, want %q", name, wantName)
+	}
+
+	creates := actionsForVerb(clientset, "create")
+	if len(creates) != 1 {
+		t.Fatalf("Save() performed %d create actions, want exactly 1 (all actions: %v)", len(creates), clientset.Actions())
+	}
+	if updates := actionsForVerb(clientset, "update"); len(updates) != 0 {
+		t.Errorf("Save() performed %d update actions, want 0 for an absent ConfigMap", len(updates))
+	}
+
+	createAction, ok := creates[0].(k8stesting.CreateAction)
+	if !ok {
+		t.Fatalf("create action has type %T, want testing.CreateAction", creates[0])
+	}
+	created, ok := createAction.GetObject().(*corev1.ConfigMap)
+	if !ok {
+		t.Fatalf("created object has type %T, want *corev1.ConfigMap", createAction.GetObject())
+	}
+	if created.Name != ProfileConfigmapName {
+		t.Errorf("created ConfigMap name = %q, want %q", created.Name, ProfileConfigmapName)
+	}
+	if created.Namespace != profile.Global.Namespace {
+		t.Errorf("created ConfigMap namespace = %q, want %q", created.Namespace, profile.Global.Namespace)
+	}
+	if wantData := util.ToYAML(profile); created.Data[ProfileConfigmapKey] != wantData {
+		t.Errorf("created ConfigMap Data[%q] = %q, want %q", ProfileConfigmapKey, created.Data[ProfileConfigmapKey], wantData)
+	}
+	if wantAnnotation := wantProfileAnnotation(t, profile); created.Annotations[ProfileConfigmapAnnotation] != wantAnnotation {
+		t.Errorf("created ConfigMap Annotations[%q] = %q, want %q", ProfileConfigmapAnnotation, created.Annotations[ProfileConfigmapAnnotation], wantAnnotation)
+	}
+}
+
+func TestConfigmapProfileStoreSaveUpdatesExistingConfigmapWithResourceVersion(t *testing.T) {
+	const existingResourceVersion = "12345"
+	existing := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:       "higress-system",
+			Name:            ProfileConfigmapName,
+			ResourceVersion: existingResourceVersion,
+		},
+	}
+	store, clientset := newConfigmapProfileStore(t, existing)
+
+	// The pinned k8s.io/client-go v0.34.1 fake clientset neither validates nor
+	// bumps resourceVersion on update, so the object handed to Update is
+	// captured with a reactor to assert the resourceVersion contract directly.
+	var updated *corev1.ConfigMap
+	clientset.PrependReactor("update", "configmaps", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		updateAction, ok := action.(k8stesting.UpdateAction)
+		if !ok {
+			t.Fatalf("update action has type %T, want testing.UpdateAction", action)
+		}
+		configmap, ok := updateAction.GetObject().(*corev1.ConfigMap)
+		if !ok {
+			t.Fatalf("updated object has type %T, want *corev1.ConfigMap", updateAction.GetObject())
+		}
+		updated = configmap
+		return false, nil, nil
+	})
+
+	profile := newTestProfile()
+	name, err := store.Save(profile)
+	if err != nil {
+		t.Fatalf("Save() error = %v, want nil", err)
+	}
+	wantName := fmt.Sprintf("%s/%s", profile.Global.Namespace, ProfileConfigmapName)
+	if name != wantName {
+		t.Errorf("Save() name = %q, want %q", name, wantName)
+	}
+
+	if creates := actionsForVerb(clientset, "create"); len(creates) != 0 {
+		t.Errorf("Save() performed %d create actions, want 0 for an existing ConfigMap", len(creates))
+	}
+	if updated == nil {
+		t.Fatal("Save() did not update the existing ConfigMap, want exactly one update")
+	}
+	if updated.ResourceVersion != existingResourceVersion {
+		t.Errorf("updated ConfigMap resourceVersion = %q, want existing resourceVersion %q", updated.ResourceVersion, existingResourceVersion)
+	}
+	if updated.Name != ProfileConfigmapName {
+		t.Errorf("updated ConfigMap name = %q, want %q", updated.Name, ProfileConfigmapName)
+	}
+	if updated.Namespace != profile.Global.Namespace {
+		t.Errorf("updated ConfigMap namespace = %q, want %q", updated.Namespace, profile.Global.Namespace)
+	}
+	if wantData := util.ToYAML(profile); updated.Data[ProfileConfigmapKey] != wantData {
+		t.Errorf("updated ConfigMap Data[%q] = %q, want %q", ProfileConfigmapKey, updated.Data[ProfileConfigmapKey], wantData)
+	}
+	if wantAnnotation := wantProfileAnnotation(t, profile); updated.Annotations[ProfileConfigmapAnnotation] != wantAnnotation {
+		t.Errorf("updated ConfigMap Annotations[%q] = %q, want %q", ProfileConfigmapAnnotation, updated.Annotations[ProfileConfigmapAnnotation], wantAnnotation)
+	}
+}
+
+func TestConfigmapProfileStoreSaveReturnsGetErrorWithoutWrite(t *testing.T) {
+	store, clientset := newConfigmapProfileStore(t)
+	getErr := apierrors.NewInternalError(fmt.Errorf("boom"))
+	clientset.PrependReactor("get", "configmaps", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, getErr
+	})
+
+	name, err := store.Save(newTestProfile())
+	if err == nil {
+		t.Fatal("Save() error = nil, want the Get error to be returned")
+	}
+	if err != getErr {
+		t.Errorf("Save() error = %v, want the Get error %v returned unchanged", err, getErr)
+	}
+	if name != "" {
+		t.Errorf("Save() name = %q, want empty on error", name)
+	}
+	if creates := actionsForVerb(clientset, "create"); len(creates) != 0 {
+		t.Errorf("Save() performed %d create actions after a non-NotFound Get error, want 0", len(creates))
+	}
+	if updates := actionsForVerb(clientset, "update"); len(updates) != 0 {
+		t.Errorf("Save() performed %d update actions after a non-NotFound Get error, want 0", len(updates))
+	}
+}
+
+func TestConfigmapProfileStoreSavePropagatesUpdateConflictWithoutRetry(t *testing.T) {
+	existing := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:       "higress-system",
+			Name:            ProfileConfigmapName,
+			ResourceVersion: "12345",
+		},
+	}
+	store, clientset := newConfigmapProfileStore(t, existing)
+
+	updateCalls := 0
+	conflictErr := apierrors.NewConflict(schema.GroupResource{Resource: "configmaps"}, ProfileConfigmapName, fmt.Errorf("conflict"))
+	clientset.PrependReactor("update", "configmaps", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		updateCalls++
+		return true, nil, conflictErr
+	})
+
+	name, err := store.Save(newTestProfile())
+	if err == nil {
+		t.Fatal("Save() error = nil, want the Update Conflict to be returned")
+	}
+	if err != conflictErr {
+		t.Errorf("Save() error = %v, want the Conflict error %v returned unchanged", err, conflictErr)
+	}
+	if !apierrors.IsConflict(err) {
+		t.Errorf("Save() error = %v, want an error for which IsConflict reports true", err)
+	}
+	if name != "" {
+		t.Errorf("Save() name = %q, want empty on error", name)
+	}
+	if updateCalls != 1 {
+		t.Errorf("Save() attempted %d update calls, want exactly 1 (no Conflict retry)", updateCalls)
+	}
+}


### PR DESCRIPTION
## I. Summary

`ConfigmapProfileStore.applyConfigmap` discarded the object returned by `Get` and called `Update` with a newly built ConfigMap carrying no `metadata.resourceVersion`, so a real Kubernetes API server rejects the update — repeated profile saves and upgrade flows fail once the `higress-profile` ConfigMap exists. This change copies only the `ResourceVersion` from the just-read existing ConfigMap onto the desired object before `Update`. Create behavior, non-NotFound `Get` error propagation, and Conflict-without-retry semantics are unchanged. No schema, CLI, or migration impact; file-backed profile storage untouched.

## II. Related issue

Closes #4384

Related to #570 — intentionally does **not** close #570: its remaining `hgctl upgrade --from-helm` capability is out of scope per approved Design #4385 (draft PR #824 is to be evaluated by a future separate proposal).

## III. Change type

- [x] Bug fix

## IV. Agent participation and issue-spec gate

- [x] **Material agent participation:** An AI or coding agent materially participated in analysis, design, implementation, testing, and PR preparation.

Timed obligations:

- [x] **Before implementation began:** maintainer approved Proposal #4384 and Design #4385 and authorized TASK-4385001 / TASK-4385002.
- [x] **Before verification began:** Design #4385 contains a concrete Verification Plan (unit red/green + pinned kind baseline/fixed comparison + real hgctl call-path acceptance).
- [ ] **Before requesting maintainer review or acceptance:** TASK-4385001 is `done` (unit red/green evidence below). TASK-4385002 runtime evidence is being produced against this exact head and will be attached here before this PR leaves draft.

Overall gate status:

- [ ] Complete
- [x] Noncompliant — pending only the runtime-verification obligation above at PR-open time; this section will be updated to Complete with evidence links before maintainer review is requested.
- [ ] N/A

**Gate-status explanation (or N/A):** see the checked box above; no other obligation is outstanding.

**Trivial-exception explanation (or N/A):** N/A

**Approved Proposal Issue URL:** https://github.com/higress-group/higress/issues/4384

**Approved Design Issue URL:** https://github.com/higress-group/higress/issues/4385

**Maintainer approval link(s):**
- https://github.com/higress-group/higress/issues/4385#issuecomment-5230257391 (maintainer review: scope, verification requirements, #570 boundary)
- https://github.com/higress-group/higress/issues/4385#issuecomment-5231945353 (explicit approval + TASK authorization)

**Authorized implementation TASK link(s):**
- https://github.com/higress-group/higress/issues/4385#issuecomment-5229680968 (TASK-4385001, implementation)
- https://github.com/higress-group/higress/issues/4385#issuecomment-5229682149 (TASK-4385002, verification)

**Verification Plan and verification TASK/evidence link(s):** Design #4385 section "Verification Plan"; TASK-4385002 (link above). Unit evidence below; pinned kind baseline/fixed runtime evidence will be attached to this exact head before the PR leaves draft.

## V. Testing and verification

**Test and deterministic rerun commands:**

```text
# fixed unit behavior (green)
cd hgctl && go test ./pkg/installer -count=1 -v

# deterministic baseline red re-check (same test, baseline production code)
git checkout 266cedc4 -- hgctl/pkg/installer/profile_store.go
cd hgctl && go test ./pkg/installer -run TestConfigmapProfileStoreSaveUpdatesExistingConfigmapWithResourceVersion -count=1
# expected FAIL: updated ConfigMap resourceVersion = "", want existing resourceVersion "12345"
git checkout 22d419db -- hgctl/pkg/installer/profile_store.go
```

**Environment and configuration:** linux/amd64, Go 1.26.4, k8s.io/client-go v0.34.1 (its fake clientset does not validate resourceVersion, so the red test asserts the resourceVersion carried on the object passed to `Update`, captured via a reactor — it never relies on fake API-server semantics). kind/Kubernetes runtime environment: pending TASK-4385002, will be recorded with pinned versions here.

**Exact tested revision, version, image tag/digest, manifests, and values:** fixed `22d419db33b03055c945da2602a608653dda6b21`; baseline `266cedc40cca9f19a97a1877ada1684eeacdc22d` (main at Proposal time).

**Baseline reproduction evidence for bug fixes:** unit red, recorded before the production change and re-verified independently at the baseline revision:

```text
profile_store_test.go:176: updated ConfigMap resourceVersion = "", want existing resourceVersion "12345"
FAIL    github.com/alibaba/higress/hgctl/pkg/installer
```

Pinned kind baseline run (real API server rejection of the resourceVersion-less update): pending TASK-4385002.

**Fixed-version verification evidence for bug fixes:** unit green at `22d419db`: `ok github.com/alibaba/higress/hgctl/pkg/installer` (4/4 focused tests pass with `-count=1`: absent/create contract, existing/update resourceVersion carriage, non-NotFound Get error propagation with zero writes, Update Conflict returned unchanged with exactly one update attempt). Pinned kind fixed run: pending TASK-4385002. Full transcripts and SHA-256 hashes will be attached with the runtime evidence.

**Wasm source revision and SHA-256 (or N/A):** N/A — no WASM plugin changes.

## VI. Special notes for reviewers

- Only `ResourceVersion` is copied from the fetched object: the caller-built desired object stays authoritative for data/name/namespace/annotations. Replacing unmanaged metadata on the hgctl-owned `higress-profile` ConfigMap is explicitly accepted in approved Design #4385; broader merge semantics require a separate proposal.
- No Conflict retry is introduced: a racing writer still surfaces a Kubernetes Conflict, preserving optimistic concurrency.
- This PR stays draft until TASK-4385002's pinned kind baseline/fixed runtime evidence (including a real `hgctl install`/`upgrade` call path into `profileStore.Save`) is attached to this exact head.

## VII. AI coding disclosure

**Tool(s) used:** Qoder CLI acting as issue-spec Coordinator, with delegated agent roles (implementation worker, read-only reviewer, runtime verifier).

### Prompts or instructions

- Design review instruction: https://github.com/higress-group/higress/issues/4385#issuecomment-5231530492
- Authorized implementation/verification instruction: https://github.com/higress-group/higress/issues/4385#issuecomment-5231945353

### AI-assisted work summary

Investigation, Proposal/Design/SPEC/TASK authoring, read-only Design review, implementation (2 files: minimal fix + focused tests with deterministic baseline-red proof), independent code review, runtime verification, and PR preparation were agent-executed under maintainer-approved Proposal #4384 / Design #4385 and authorized TASKs. Key decisions (copy only `ResourceVersion`; no retries; no server-side apply; explicit metadata-replacement acceptance) are recorded in Design #4385. No credentials or sensitive data are included.
