### PR TITLE
hgctl: preserve profile ConfigMap resourceVersion

### DIFF
--- a/hgctl/pkg/installer/profile_store.go
+++ b/hgctl/pkg/installer/profile_store.go
@@ -217,13 +217,14 @@ func (c *ConfigmapProfileStore) listConfigmaps(name string, namespace string, si
 }
 
 func (c *ConfigmapProfileStore) applyConfigmap(configmap *corev1.ConfigMap) error {
-	_, err := c.kubeCli.KubernetesInterface().CoreV1().ConfigMaps(configmap.Namespace).Get(context.Background(), configmap.Name, metav1.GetOptions{})
+	existing, err := c.kubeCli.KubernetesInterface().CoreV1().ConfigMaps(configmap.Namespace).Get(context.Background(), configmap.Name, metav1.GetOptions{})
 	if err != nil && errors.IsNotFound(err) {
 		_, err = c.kubeCli.KubernetesInterface().CoreV1().ConfigMaps(configmap.Namespace).Create(context.Background(), configmap, metav1.CreateOptions{})
 		return err
 	} else if err != nil {
 		return err
 	} else {
+		configmap.ResourceVersion = existing.ResourceVersion
 		_, err = c.kubeCli.KubernetesInterface().CoreV1().ConfigMaps(configmap.Namespace).Update(context.Background(), configmap, metav1.UpdateOptions{})
 		return err
 	}

--- a/hgctl/pkg/installer/profile_store_test.go
+++ b/hgctl/pkg/installer/profile_store_test.go
@@ -1,0 +1,268 @@
+// Copyright (c) 2022 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package installer
+
+import (
+	"encoding/json"
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/alibaba/higress/hgctl/pkg/helm"
+	higresskube "github.com/alibaba/higress/hgctl/pkg/kubernetes"
+	"github.com/alibaba/higress/hgctl/pkg/util"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/rest"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+func TestConfigmapProfileStoreSaveCreatesConfigMapWhenAbsent(t *testing.T) {
+	profile := testProfile()
+	client := fake.NewSimpleClientset()
+	store := newTestConfigmapProfileStore(client)
+
+	var created *corev1.ConfigMap
+	createCount := 0
+	updateCount := 0
+	client.PrependReactor("create", "configmaps", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		createCount++
+		createAction := action.(k8stesting.CreateAction)
+		created = createAction.GetObject().(*corev1.ConfigMap).DeepCopy()
+		return false, nil, nil
+	})
+	client.PrependReactor("update", "configmaps", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		updateCount++
+		return false, nil, nil
+	})
+
+	name, err := store.Save(profile)
+	if err != nil {
+		t.Fatalf("Save() error = %v", err)
+	}
+	if name != "higress-system/higress-profile" {
+		t.Fatalf("Save() name = %q, want %q", name, "higress-system/higress-profile")
+	}
+	if createCount != 1 {
+		t.Fatalf("create count = %d, want 1", createCount)
+	}
+	if updateCount != 0 {
+		t.Fatalf("update count = %d, want 0", updateCount)
+	}
+	if created == nil {
+		t.Fatal("expected create to receive a ConfigMap")
+	}
+	assertDesiredConfigMap(t, created, profile)
+	if created.ResourceVersion != "" {
+		t.Fatalf("created ConfigMap resourceVersion = %q, want empty", created.ResourceVersion)
+	}
+}
+
+func TestConfigmapProfileStoreSaveUpdatesExistingConfigMapWithResourceVersion(t *testing.T) {
+	profile := testProfile()
+	existing := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:       profile.Global.Namespace,
+			Name:            ProfileConfigmapName,
+			ResourceVersion: "rv-123",
+		},
+	}
+	client := fake.NewSimpleClientset(existing)
+	store := newTestConfigmapProfileStore(client)
+
+	var updated *corev1.ConfigMap
+	updateCount := 0
+	client.PrependReactor("update", "configmaps", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		updateCount++
+		updateAction := action.(k8stesting.UpdateAction)
+		updated = updateAction.GetObject().(*corev1.ConfigMap).DeepCopy()
+		return false, nil, nil
+	})
+
+	name, err := store.Save(profile)
+	if err != nil {
+		t.Fatalf("Save() error = %v", err)
+	}
+	if name != "higress-system/higress-profile" {
+		t.Fatalf("Save() name = %q, want %q", name, "higress-system/higress-profile")
+	}
+	if updateCount != 1 {
+		t.Fatalf("update count = %d, want 1", updateCount)
+	}
+	if updated == nil {
+		t.Fatal("expected update to receive a ConfigMap")
+	}
+	assertDesiredConfigMap(t, updated, profile)
+	if updated.ResourceVersion != existing.ResourceVersion {
+		t.Fatalf("updated ConfigMap resourceVersion = %q, want %q", updated.ResourceVersion, existing.ResourceVersion)
+	}
+}
+
+func TestConfigmapProfileStoreSaveReturnsGetErrorWithoutWriting(t *testing.T) {
+	profile := testProfile()
+	client := fake.NewSimpleClientset()
+	store := newTestConfigmapProfileStore(client)
+
+	wantErr := errors.New("get failed")
+	createCount := 0
+	updateCount := 0
+	client.PrependReactor("get", "configmaps", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, wantErr
+	})
+	client.PrependReactor("create", "configmaps", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		createCount++
+		return false, nil, nil
+	})
+	client.PrependReactor("update", "configmaps", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		updateCount++
+		return false, nil, nil
+	})
+
+	name, err := store.Save(profile)
+	if err != wantErr {
+		t.Fatalf("Save() error = %v, want %v", err, wantErr)
+	}
+	if name != "" {
+		t.Fatalf("Save() name = %q, want empty", name)
+	}
+	if createCount != 0 {
+		t.Fatalf("create count = %d, want 0", createCount)
+	}
+	if updateCount != 0 {
+		t.Fatalf("update count = %d, want 0", updateCount)
+	}
+}
+
+func TestConfigmapProfileStoreSaveReturnsUpdateConflictWithoutRetry(t *testing.T) {
+	profile := testProfile()
+	existing := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:       profile.Global.Namespace,
+			Name:            ProfileConfigmapName,
+			ResourceVersion: "rv-123",
+		},
+	}
+	client := fake.NewSimpleClientset(existing)
+	store := newTestConfigmapProfileStore(client)
+
+	updateCount := 0
+	wantErr := apierrors.NewConflict(schema.GroupResource{Resource: "configmaps"}, ProfileConfigmapName, errors.New("conflict"))
+	client.PrependReactor("update", "configmaps", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		updateCount++
+		return true, nil, wantErr
+	})
+
+	name, err := store.Save(profile)
+	if err != wantErr {
+		t.Fatalf("Save() error = %v, want %v", err, wantErr)
+	}
+	if name != "" {
+		t.Fatalf("Save() name = %q, want empty", name)
+	}
+	if updateCount != 1 {
+		t.Fatalf("update count = %d, want 1", updateCount)
+	}
+}
+
+func testProfile() *helm.Profile {
+	return &helm.Profile{
+		HigressVersion: "1.0.0",
+		Global: helm.ProfileGlobal{
+			Install:      helm.InstallK8s,
+			Namespace:    "higress-system",
+			IngressClass: "higress",
+		},
+	}
+}
+
+func newTestConfigmapProfileStore(client kubernetes.Interface) *ConfigmapProfileStore {
+	return &ConfigmapProfileStore{
+		kubeCli: &fakeCLIClient{kube: client},
+	}
+}
+
+func assertDesiredConfigMap(t *testing.T, configmap *corev1.ConfigMap, profile *helm.Profile) {
+	t.Helper()
+
+	if configmap.Namespace != profile.Global.Namespace {
+		t.Fatalf("ConfigMap namespace = %q, want %q", configmap.Namespace, profile.Global.Namespace)
+	}
+	if configmap.Name != ProfileConfigmapName {
+		t.Fatalf("ConfigMap name = %q, want %q", configmap.Name, ProfileConfigmapName)
+	}
+
+	wantData := map[string]string{
+		ProfileConfigmapKey: util.ToYAML(profile),
+	}
+	if !reflect.DeepEqual(configmap.Data, wantData) {
+		t.Fatalf("ConfigMap data = %#v, want %#v", configmap.Data, wantData)
+	}
+
+	profileJSON, err := json.Marshal(profile)
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+	wantAnnotations := map[string]string{
+		ProfileConfigmapAnnotation: string(profileJSON),
+	}
+	if !reflect.DeepEqual(configmap.Annotations, wantAnnotations) {
+		t.Fatalf("ConfigMap annotations = %#v, want %#v", configmap.Annotations, wantAnnotations)
+	}
+}
+
+type fakeCLIClient struct {
+	kube kubernetes.Interface
+}
+
+func (f *fakeCLIClient) RESTConfig() *rest.Config {
+	return nil
+}
+
+func (f *fakeCLIClient) Pod(types.NamespacedName) (*corev1.Pod, error) {
+	return nil, nil
+}
+
+func (f *fakeCLIClient) PodsForSelector(string, ...string) (*corev1.PodList, error) {
+	return nil, nil
+}
+
+func (f *fakeCLIClient) PodExec(types.NamespacedName, string, string) (string, string, error) {
+	return "", "", nil
+}
+
+func (f *fakeCLIClient) ApplyObject(*unstructured.Unstructured) error {
+	return nil
+}
+
+func (f *fakeCLIClient) DeleteObject(*unstructured.Unstructured) error {
+	return nil
+}
+
+func (f *fakeCLIClient) CreateNamespace(string) error {
+	return nil
+}
+
+func (f *fakeCLIClient) KubernetesInterface() kubernetes.Interface {
+	return f.kube
+}
+
+var _ higresskube.CLIClient = (*fakeCLIClient)(nil)


### PR DESCRIPTION
## I. Summary

This draft preserves the existing profile ConfigMap's
`metadata.resourceVersion` when `hgctl` performs an update. Focused tests cover
create, update, non-NotFound Get errors, and one-attempt Conflict propagation.

Runtime verification disproved the original bug premise: on standard Kubernetes,
the baseline RV-less ConfigMap update succeeds as an allowed unconditional
update. The code therefore changes concurrency semantics from unconditional
last-write-wins to optimistic concurrency; it does not make a previously invalid
update valid.

This PR remains draft and blocked pending a maintainer decision to amend and
reapprove the Proposal/Design for that actual behavior or withdraw the change.

## II. Related issue

Closes #4384

Related to #570. This PR does not close #570 and does not include
`upgrade --from-helm` work.

## III. Change type

- [ ] Bug fix
- [ ] Feature or enhancement
- [ ] Documentation or configuration only
- [x] Refactoring, tests, or maintenance

## IV. Agent participation and issue-spec gate

- [ ] **No agent participation:** This PR is human-only.
- [ ] **Trivial agent-use exception:** Agent use was limited to spelling,
      punctuation, whitespace, or formatting with no substantive choice or
      behavioral effect; the explanation is below.
- [x] **Material agent participation:** An AI or coding agent materially
      participated in analysis, design, implementation, testing, or PR
      preparation.

For material participation, check each timed obligation:

- [x] **Before implementation began:** A Higress maintainer had approved the
      Proposal and Design Issues, and authorized implementation TASKs linked the
      work to the applicable SPECs.
- [x] **Before verification began:** The Design contained a concrete
      Verification Plan.
- [ ] **Before requesting maintainer review or acceptance:** Applicable
      implementation and verification TASKs were `done` with exact commands,
      results, evidence links, and hashes.

Then choose exactly one overall gate status:

- [ ] Complete: all three timed obligations above were satisfied.
- [ ] Noncompliant: one or more obligations were not satisfied; explain below.
- [ ] N/A because the PR is human-only or qualifies for the trivial exception.

**Gate-status explanation (or N/A):**

No review is requested. TASK-4385002 is blocked because the approved runtime
baseline failure is contradicted by real-cluster evidence and Kubernetes source.

**Trivial-exception explanation (or N/A):**

N/A; participation was material and is declared above.

**Approved Proposal Issue URL (or N/A with explanation):**

https://github.com/higress-group/higress/issues/4384

**Approved Design Issue URL (or N/A with explanation):**

https://github.com/higress-group/higress/issues/4385

**Maintainer approval link(s) (or N/A with explanation):**

https://github.com/higress-group/higress/issues/4385#issuecomment-5232405027

**Authorized implementation TASK link(s) (or N/A with explanation):**

https://github.com/higress-group/higress/issues/4385#issuecomment-5229680968

**Verification Plan and verification TASK/evidence link(s) (or N/A with explanation):**

Design: https://github.com/higress-group/higress/issues/4385

Blocked TASK: https://github.com/higress-group/higress/issues/4385#issuecomment-5229682149

Immutable runtime evidence:
https://gist.github.com/Aias00/8331a78f21397f115ef637a9fba33d34/7904dd3e40de42a3467339e785e08ffddec30e0c

## V. Testing and verification

**Test and deterministic rerun commands (or N/A with explanation):**

```text
cd hgctl
go test ./pkg/installer -run '^TestConfigmapProfileStoreSaveUpdatesExistingConfigMapWithResourceVersion$' -count=1
go test ./pkg/installer -run '^TestConfigmapProfileStoreSave' -count=1
go test ./pkg/installer -count=1
```

The focused and package tests pass on the exact head. The baseline unit RED
proved that the fake-client Update object omitted `resourceVersion`; it did not
prove real API-server rejection.

The immutable evidence bundle contains the exact kind harness, real `hgctl`
commands, versions, inputs, before/after Profile and ConfigMap YAML, logs,
cleanup assertions, and hashes.

**Environment and configuration (or N/A with explanation):**

Docker/OrbStack; kind v0.18.0; Kubernetes v1.26.3; Go 1.26.3;
Helm v3.17.1; kubectl v1.34.1; Higress chart 2.2.3.

**Exact tested revision, version, image tag/digest, manifests, and values (or N/A with explanation):**

- Baseline: `b3feede3298a8bedcf8c899568eebdbb14354633`
- Fixed pushed head: `ed1580cd8cd6b131b7b13fc4478c5ef24b6fb58b`
- Node: `kindest/node:v1.26.3@sha256:61b92f38dff6ccc29969e7aa154d34e38b89443af1a2c14e6cfbd2df6419c66f`
- Chart SHA-256: `61823035af3ad5fd999dcae9f3b919039131a9cc06485075b8776a4d31b288d1`
- Input change: `gateway.replicas=1` to `gateway.replicas=2`

**Baseline reproduction evidence for bug fixes (or N/A with explanation):**

The claimed failure was not reproduced. The baseline second install returned 0,
changed RV 555 to 573, and stored replicas 2. An earlier independent baseline
run also returned 0, changed RV 552 to 572, and stored replicas 2.

**Fixed-version verification evidence for bug fixes (or N/A with explanation):**

The fixed second install returned 0, changed RV 565 to 581, and stored replicas
2. There is no runtime red/green transition. Evidence `SHA256SUMS` file SHA-256:
`b6e3e15f539948bcdd253553083e2e79665fbe320c98c6386076bc5c585626f6`.

**Wasm source revision and SHA-256 (or N/A with explanation):**

N/A; this change does not touch Wasm code or artifacts.

## VI. Special notes for reviewers

Do not review this draft as a verified missing-resourceVersion bug fix. The
remaining decision is whether optimistic-concurrency/lost-update hardening is
desirable enough to justify an amended Proposal/Design. No retry, server-side
apply, metadata merge, or `--from-helm` work is included.

## VII. AI coding disclosure

**Tool(s) used (or N/A):**

OpenAI Codex and the repository's issue-spec workflow.

### Prompts or instructions

Implement the maintainer-approved #4384/#4385 code shape with focused tests, a
DCO-signed commit, exact-head PR, and pinned real-kind baseline/fixed evidence.
Do not broaden scope or claim completion without runtime verification.

### AI-assisted work summary

- Added the approved focused implementation and fake-client tests.
- Created one DCO-signed commit and draft PR against the exact base.
- Ran an independent exact-base/head code review.
- Ran the real `hgctl install` comparison twice for the baseline and once for
  the fixed head.
- Published the contradictory runtime result, corrected the earlier causal
  claim, and blocked TASK-4385002 pending maintainer resolution.
