### PR TITLE
bugfix: fix concurrent map access panic in nacos MCP registry

### DIFF
--- a/plugins/golang-filter/mcp-server/registry/nacos/nacos.go
+++ b/plugins/golang-filter/mcp-server/registry/nacos/nacos.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+	"sync"
 
 	"github.com/alibaba/higress/plugins/golang-filter/mcp-server/registry"
 	"github.com/envoyproxy/envoy/contrib/golang/common/go/api"
@@ -18,6 +19,7 @@ type NacosMcpRegistry struct {
 	serviceMatcher           map[string]string
 	configClient             config_client.IConfigClient
 	namingClient             naming_client.INamingClient
+	toolsMutex               sync.RWMutex
 	toolsDescription         map[string]*registry.ToolDescription
 	toolsRpcContext          map[string]*registry.RpcContext
 	toolChangeEventListeners []registry.ToolChangeEventListener
@@ -30,30 +32,42 @@ const (
 )
 
 func (n *NacosMcpRegistry) ListToolsDescription() []*registry.ToolDescription {
+	n.toolsMutex.RLock()
 	if n.toolsDescription == nil {
+		n.toolsMutex.RUnlock()
 		n.refreshToolsList()
+		n.toolsMutex.RLock()
 	}
 
 	result := []*registry.ToolDescription{}
 	for _, tool := range n.toolsDescription {
 		result = append(result, tool)
 	}
+	n.toolsMutex.RUnlock()
 	return result
 }
 
 func (n *NacosMcpRegistry) GetToolRpcContext(toolName string) (*registry.RpcContext, bool) {
+	n.toolsMutex.RLock()
 	if n.toolsRpcContext == nil {
+		n.toolsMutex.RUnlock()
 		n.refreshToolsList()
+		n.toolsMutex.RLock()
 	}
 	tool, ok := n.toolsRpcContext[toolName]
+	n.toolsMutex.RUnlock()
 	return tool, ok
 }
 
 func (n *NacosMcpRegistry) RegisterToolChangeEventListener(listener registry.ToolChangeEventListener) {
+	n.toolsMutex.Lock()
+	defer n.toolsMutex.Unlock()
 	n.toolChangeEventListeners = append(n.toolChangeEventListeners, listener)
 }
 
 func (n *NacosMcpRegistry) refreshToolsList() bool {
+	n.toolsMutex.Lock()
+	defer n.toolsMutex.Unlock()
 	changed := false
 	for group, serviceMatcher := range n.serviceMatcher {
 		if n.refreshToolsListForGroup(group, serviceMatcher) {
@@ -272,7 +286,9 @@ func (n *NacosMcpRegistry) listenToService(group string, service string) {
 		DataId: makeToolsConfigId(service),
 		Group:  group,
 		OnChange: func(namespace, group, dataId, data string) {
+			n.toolsMutex.Lock()
 			n.refreshToolsListForServiceWithContent(group, service, &data, nil)
+			n.toolsMutex.Unlock()
 			for _, listener := range n.toolChangeEventListeners {
 				listener.OnToolChanged(n)
 			}
@@ -286,7 +302,9 @@ func (n *NacosMcpRegistry) listenToService(group string, service string) {
 		ServiceName: service,
 		GroupName:   group,
 		SubscribeCallback: func(services []model.Instance, err error) {
+			n.toolsMutex.Lock()
 			n.refreshToolsListForServiceWithContent(group, service, nil, &services)
+			n.toolsMutex.Unlock()
 			for _, listener := range n.toolChangeEventListeners {
 				listener.OnToolChanged(n)
 			}

--- a/plugins/golang-filter/mcp-server/registry/nacos/server.go
+++ b/plugins/golang-filter/mcp-server/registry/nacos/server.go
@@ -141,7 +141,11 @@ func (c *NacosConfig) ParseConfig(config map[string]any) error {
 
 	matchers := map[string]string{}
 	for key, value := range serviceMatcher {
-		matchers[key] = value.(string)
+		strValue, ok := value.(string)
+		if !ok {
+			return fmt.Errorf("serviceMatcher value for key %s is not a string", key)
+		}
+		matchers[key] = strValue
 	}
 
 	c.ServiceMatcher = &matchers


### PR DESCRIPTION
## Ⅰ. Describe what this PR does

Fix concurrent map access in the Nacos MCP registry that causes a fatal `concurrent map read and map write` panic, crashing the Envoy worker process.

The `NacosMcpRegistry` struct maintains three maps (`toolsDescription`, `toolsRpcContext`, `currentServiceSet`) accessed by multiple goroutines without synchronization:
- **Background refresh goroutine** (every 3s): writes to all maps via `refreshToolsList()`
- **Nacos SDK ListenConfig/Subscribe callbacks**: write to maps from separate goroutines
- **Request handlers**: read maps via `ListToolsDescription()` and `GetToolRpcContext()`

This PR adds a `sync.RWMutex` to protect all map operations:
- Read paths (`ListToolsDescription`, `GetToolRpcContext`) use `RLock`
- Write paths (`refreshToolsList`, callback handlers) use `Lock`
- `RegisterToolChangeEventListener` uses `Lock` (called before goroutines start, but protected for safety)

Also fixes a naked type assertion `value.(string)` in `server.go` `ParseConfig` that panics when a `serviceMatcher` config value is not a string.

## Ⅱ. Does this PR fix any issue

fixes #4405

## Ⅲ. Why not add test cases

The golang-filter module runs inside Envoy and requires a full Nacos + MCP server environment to test. Unit testing concurrent map access would require mocking the Nacos SDK clients and is not feasible in isolation. The fix is straightforward synchronization using standard Go primitives.

## Ⅳ. How to verify

1. `go build ./...` passes in the `plugins/golang-filter/mcp-server/registry/nacos/` directory
2. `gofmt` passes (no formatting issues)
3. Manual verification: Under concurrent MCP tool list requests with a Nacos registry configured, the Envoy worker no longer crashes with `concurrent map read and map write`

## Ⅴ. Special notes for reviewers

- The `toolsMutex` is named descriptively (not `mu` or `lock`) per Go conventions
- `refreshToolsListForServiceWithContent` does NOT acquire its own lock — callers are responsible for holding the lock. This avoids deadlocks since `refreshToolsList` (which holds the lock) calls it indirectly
- The `listenToService` callbacks acquire `Lock` before calling `refreshToolsListForServiceWithContent` and release it before calling `OnToolChanged` listeners (which call `ListToolsDescription` which needs `RLock`)
- `RegisterToolChangeEventListener` is protected with `Lock` for safety, though in practice it's only called once during initialization before any goroutines start

## Ⅵ. AI Coding Tool Usage Checklist

- [x] I used AI coding tools to help analyze the concurrent access patterns
- [x] I reviewed and verified all AI-generated code changes before submitting