### PR TITLE
bugfix: fix nil pointer panic when redis is not configured in mcp-session

### DIFF
--- a/plugins/golang-filter/mcp-session/config.go
+++ b/plugins/golang-filter/mcp-session/config.go
@@ -77,11 +77,11 @@ func (p *Parser) Parse(any *anypb.Any, callbacks api.ConfigCallbackHandler) (int
 	enableUserLevelServer, ok := v.AsMap()["enable_user_level_server"].(bool)
 	if !ok {
 		enableUserLevelServer = false
-		if conf.redisClient == nil {
-			return nil, fmt.Errorf("redis configuration is not provided, enable_user_level_server is true")
-		}
 	}
 	conf.enableUserLevelServer = enableUserLevelServer
+	if enableUserLevelServer && conf.redisClient == nil {
+		return nil, fmt.Errorf("redis configuration is required when enable_user_level_server is true")
+	}
 
 	if rateLimit, ok := v.AsMap()["rate_limit"].(map[string]interface{}); ok {
 		rateLimitConfig := &handler.MCPRatelimitConfig{}

--- a/plugins/golang-filter/mcp-session/handler/rate_limit_handler.go
+++ b/plugins/golang-filter/mcp-session/handler/rate_limit_handler.go
@@ -70,6 +70,9 @@ type LimitContext struct {
 
 // TODO: needs to be refactored, rate limit should be registered as a request hook in MCP server
 func (h *MCPRatelimitHandler) HandleRatelimit(req *http.Request, body []byte) bool {
+	if h.redisClient == nil {
+		return true
+	}
 	parts := strings.Split(req.URL.Path, "/")
 	if len(parts) < 3 {
 		h.callbacks.DecoderFilterCallbacks().SendLocalReply(http.StatusForbidden, "", nil, 0, "")


### PR DESCRIPTION
## Ⅰ. Describe what this PR does

Fixes an inverted config validation logic in mcp-session that allows `enable_user_level_server: true` without a redis configuration, leading to nil pointer dereference panics that crash the Envoy worker.

The bug is in `config.go` `Parse`: the redis requirement check runs when `enable_user_level_server` key is **missing** (setting it to `false`), but does NOT check when it's explicitly set to `true`. This allows nil `redisClient` to flow into:
- `MCPConfigHandler.HandleConfigRequest` → `RedisConfigStore.GetConfig` → `s.redisClient.Get` → nil pointer dereference → Envoy worker crash
- `MCPRatelimitHandler.HandleRatelimit` → `h.redisClient.Eval` → nil pointer dereference → Envoy worker crash

### Changes:
1. **`config.go`**: Move the redis requirement check to after `enableUserLevelServer` is determined, so it correctly validates when `enable_user_level_server: true` and redisClient is nil
2. **`rate_limit_handler.go`**: Add nil redis guard in `HandleRatelimit` — return `true` (bypass rate limiting) when `redisClient` is nil instead of panicking. This is defense-in-depth for the case where `rate_limit` is configured but redis is not.

## Ⅱ. Does this fix any issue

fixes #4407

## Ⅲ. Why not add test cases

The golang-filter module runs inside Envoy and requires a full Redis + MCP server environment. The fix is a straightforward logic correction and nil guard.

## Ⅳ. How to verify

1. `go build ./...` passes in the `plugins/golang-filter/mcp-session/` directory
2. With the fix: configuring `enable_user_level_server: true` without redis now returns a clear config error instead of crashing Envoy at runtime
3. With the fix: `HandleRatelimit` with nil redis bypasses rate limiting instead of panicking

## Ⅴ. Special notes for reviewers

The original error message "redis configuration is not provided, enable_user_level_server is true" was misleading — it was triggered when the key was missing (meaning `enable_userLevelServer` would be `false`). The corrected message is "redis configuration is required when enable_user_level_server is true".

## Ⅵ. AI Coding Tool Usage Checklist

- [x] I used AI coding tools to help analyze the config validation logic
- [x] I reviewed and verified all AI-generated code changes before submitting