### PR TITLE
bugfix: fix panic in hgctl when parsing Envoy config dump and version output

### DIFF
--- a/hgctl/pkg/utils.go
+++ b/hgctl/pkg/utils.go
@@ -38,38 +38,60 @@ func GetXDSResource(resourceType envoyConfigType, configDump []byte) (any, error
 	if resourceType == AllEnvoyConfigType {
 		return cd, nil
 	}
-	configs := cd["configs"]
-	globalConfigs := configs.([]any)
+	globalConfigs, ok := cd["configs"].([]any)
+	if !ok {
+		return nil, fmt.Errorf("invalid config dump: configs field is missing or not an array")
+	}
 
 	switch resourceType {
 	case BootstrapEnvoyConfigType:
 		for _, config := range globalConfigs {
-			if config.(map[string]interface{})["@type"] == "type.googleapis.com/envoy.admin.v3.BootstrapConfigDump" {
+			m, ok := config.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			if m["@type"] == "type.googleapis.com/envoy.admin.v3.BootstrapConfigDump" {
 				return config, nil
 			}
 		}
 	case EndpointEnvoyConfigType:
 		for _, config := range globalConfigs {
-			if config.(map[string]interface{})["@type"] == "type.googleapis.com/envoy.admin.v3.EndpointsConfigDump" {
+			m, ok := config.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			if m["@type"] == "type.googleapis.com/envoy.admin.v3.EndpointsConfigDump" {
 				return config, nil
 			}
 		}
 
 	case ClusterEnvoyConfigType:
 		for _, config := range globalConfigs {
-			if config.(map[string]interface{})["@type"] == "type.googleapis.com/envoy.admin.v3.ClustersConfigDump" {
+			m, ok := config.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			if m["@type"] == "type.googleapis.com/envoy.admin.v3.ClustersConfigDump" {
 				return config, nil
 			}
 		}
 	case ListenerEnvoyConfigType:
 		for _, config := range globalConfigs {
-			if config.(map[string]interface{})["@type"] == "type.googleapis.com/envoy.admin.v3.ListenersConfigDump" {
+			m, ok := config.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			if m["@type"] == "type.googleapis.com/envoy.admin.v3.ListenersConfigDump" {
 				return config, nil
 			}
 		}
 	case RouteEnvoyConfigType:
 		for _, config := range globalConfigs {
-			if config.(map[string]interface{})["@type"] == "type.googleapis.com/envoy.admin.v3.RoutesConfigDump" {
+			m, ok := config.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			if m["@type"] == "type.googleapis.com/envoy.admin.v3.RoutesConfigDump" {
 				return config, nil
 			}
 		}

--- a/hgctl/pkg/version.go
+++ b/hgctl/pkg/version.go
@@ -115,6 +115,9 @@ func retrieveVersion(w io.Writer, v *VersionInfo, containerName string, cmd stri
 		if err != nil {
 			return err
 		}
+		if info == nil {
+			continue
+		}
 
 		v.ServerVersions = append(v.ServerVersions, &ServerVersion{
 			NamespacedName: nn,


### PR DESCRIPTION
## Ⅰ. Describe what this PR does

Fixes two panic scenarios in the `hgctl` CLI tool:

### 1. `GetXDSResource` in `utils.go` — naked type assertions
The function uses naked type assertions to parse Envoy config dump JSON:
- `configs.([]any)` — panics if `configs` field is missing or not an array
- `config.(map[string]interface{})["@type"]` — panics if any config element is not a JSON object

Replaced all with comma-ok pattern. Returns descriptive error instead of panicking when the config dump is malformed.

### 2. `retrieveVersion` in `version.go` — nil pointer dereference
When `envoy --version` output doesn't contain a colon (`:`), the version parser returns `(nil, nil)`. The caller dereferences `*info`, causing a nil pointer panic that crashes `hgctl version`.

Added `if info == nil { continue }` guard to skip the pod instead of panicking.

## Ⅱ. Does this fix any issue

fixes #4411

## Ⅲ. Why not add test cases

The `hgctl` CLI commands require a running Kubernetes cluster with Higress installed to test end-to-end. The fixes are straightforward defensive checks using standard Go patterns.

## Ⅳ. How to verify

1. `gofmt` passes (no syntax errors)
2. With the fix: `hgctl gateway-config` against a malformed config dump returns an error instead of panicking
3. With the fix: `hgctl version` against a pod with unexpected `envoy --version` output skips the pod instead of crashing

## Ⅴ. Special notes for reviewers

- The pre-existing Istio submodule build errors (`ListenerSetSpec` undefined) are present on `main` as well and are unrelated to this PR
- The nil-check in `retrieveVersion` is consistent with the existing nil-check pattern in `sort.Slice` (which would also panic on nil entries)

## Ⅵ. AI Coding Tool Usage Checklist

- [x] I used AI coding tools to help analyze the panic scenarios
- [x] I reviewed and verified all AI-generated code changes before submitting