### PR TITLE
docs: clarify trivial issue-spec exception

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,9 +27,10 @@ For every contribution to which that policy applies:
   maintainers to accept verification or review.
 
 Declare agent participation in the PR template. The policy excludes human-only
-work and allows only the declared trivial exception for spelling, punctuation,
-whitespace, or formatting changes with no substantive choice or behavioral
-effect.
+work. Small documentation-only corrections limited to spelling, punctuation,
+whitespace, or formatting (such as typo adjustments) may skip the issue-spec
+workflow when they involve no substantive choice or behavioral effect.
+Agent-assisted bug fixes and material feature work must still follow this gate.
 
 For work subject to this gate, the maintainer-approved issue-spec Design Issue
 is the authoritative design carrier. Do not create or require a plugin-local


### PR DESCRIPTION
## Summary

- Clarify that small documentation-only corrections—such as typos—may skip the issue-spec workflow when agent use is limited to spelling, punctuation, whitespace, or formatting with no substantive choice or behavioral effect.
- Keep agent-assisted bug fixes and material feature work explicitly subject to the issue-spec gate.

## Scope

Documentation-only policy clarification in `AGENTS.md`; no runtime behavior, configuration, API, or build changes.

## Agent participation and issue-spec gate

- [ ] No agent participation
- [x] Trivial agent-use exception
- [ ] Material agent participation

Agent use was limited to drafting and checking this small policy wording adjustment. The final change is documentation-only and confined to clarifying the existing trivial exception; it makes no runtime, configuration, or behavioral change.

- [ ] Complete
- [ ] Noncompliant
- [x] N/A because the PR qualifies for the trivial exception

**Approved Proposal Issue URL:** N/A — this PR qualifies for the declared trivial agent-use exception.

**Approved Design Issue URL:** N/A — this PR qualifies for the declared trivial agent-use exception.

**Maintainer approval link(s):** N/A — this PR qualifies for the declared trivial agent-use exception.

**Authorized implementation TASK link(s):** N/A — this PR qualifies for the declared trivial agent-use exception.

**Verification Plan and verification TASK/evidence link(s):** N/A — documentation-only wording clarification. Local checks are listed below.

## Testing and verification

```text
git diff --check
python3 policy wording assertions
Markdown hygiene checks (no CRLF or trailing whitespace)
documentation diff credential-pattern scan
independent read-only wording review: PASS
```

No runtime test applies: this PR changes only `AGENTS.md` guidance.

## AI coding disclosure

**Tool(s) used:** Hermes Agent

### Prompts or instructions

> Update `AGENTS.md` so small documentation changes such as typo adjustments do not need the issue-spec workflow, while bug fixes and material feature work remain subject to it.

### AI-assisted work summary

The agent inspected the current policy and PR template, changed only `AGENTS.md`, and verified that the new wording preserves the existing narrow exception (spelling, punctuation, whitespace, or formatting; no substantive choice or behavioral effect). It also explicitly retains the gate for agent-assisted bug fixes and material feature work.

No credentials or private artifacts are included.
