### PR TITLE
feat(ip-restriction): 支持自定义拒绝响应体 response_body / content_type || feat(ip-restriction): Support custom rejection response body response_body / content_type

### DIFF
--- a/plugins/wasm-go/extensions/ip-restriction/README.md
+++ b/plugins/wasm-go/extensions/ip-restriction/README.md
@@ -25,6 +25,8 @@ description: IP 访问限制插件配置参考
 | deny           | array  | 否  | []                          | 黑名单列表                                    |
 | status         | int    | 否  | 403                         | 拒绝访问时的 HTTP 状态码                          |
 | message        | string | 否  | Your IP address is blocked. | 拒绝访问时的返回信息                               |
+| response_body  | string | 否  |                             | 拒绝访问时返回的自定义响应体，设置后覆盖默认 JSON。常用于返回 HTML 拦截页            |
+| content_type   | string | 否  | text/html; charset=utf-8    | 自定义响应 Content-Type（仅在设置 `response_body` 时生效）                       |
 
 
 ```yaml
@@ -39,5 +41,16 @@ ip_source_type: header
 ip_header_name: x-real-iP
 deny:
   - 10.0.0.1
-  - 192.169.0.0/16   
+  - 192.168.0.0/16
+```
+
+```yaml
+# 拒绝时返回自定义 HTML 拦截页
+ip_source_type: header
+ip_header_name: x-forwarded-for
+allow:
+  - 10.0.0.0/8
+status: 403
+response_body: "<html><body><h1>访问受限</h1><p>请使用内网访问。</p></body></html>"
+content_type: "text/html; charset=utf-8"
 ```

--- a/plugins/wasm-go/extensions/ip-restriction/README_EN.md
+++ b/plugins/wasm-go/extensions/ip-restriction/README_EN.md
@@ -20,6 +20,8 @@ Plugin execution priority: `210`
 | deny                | array   | No       | []                              | Blacklist                                    |
 | status              | int     | No       | 403                             | HTTP status code when access is denied      |
 | message             | string  | No       | Your IP address is blocked.     | Return message when access is denied         |
+| response_body       | string  | No       |                                 | Custom response body when access is denied. Overrides the default JSON when set. Useful for returning an HTML block page. |
+| content_type        | string  | No       | text/html; charset=utf-8        | Custom response Content-Type. Only takes effect when `response_body` is set. |
 
 ```yaml
 ip_source_type: origin-source
@@ -33,5 +35,16 @@ ip_source_type: header
 ip_header_name: x-real-iP
 deny:
   - 10.0.0.1
-  - 192.169.0.0/16
+  - 192.168.0.0/16
+```
+
+```yaml
+# Return a custom HTML block page when access is denied
+ip_source_type: header
+ip_header_name: x-forwarded-for
+allow:
+  - 10.0.0.0/8
+status: 403
+response_body: "<html><body><h1>Access Restricted</h1><p>Please access via the intranet.</p></body></html>"
+content_type: "text/html; charset=utf-8"
 ```

--- a/plugins/wasm-go/extensions/ip-restriction/main.go
+++ b/plugins/wasm-go/extensions/ip-restriction/main.go
@@ -30,6 +30,8 @@ type RestrictionConfig struct {
 	Deny         *iptree.IPTree `json:"deny"`           //拒绝的IP
 	Status       uint32         `json:"status"`         //被拒绝时返回的状态码
 	Message      string         `json:"message"`        //被拒绝时返回的消息
+	ResponseBody string         `json:"response_body"`  //自定义拒绝响应体，设置后覆盖默认JSON
+	ContentType  string         `json:"content_type"`   //自定义Content-Type，默认 text/html
 }
 
 func main() {}
@@ -74,6 +76,8 @@ func parseConfig(json gjson.Result, config *RestrictionConfig, log log.Log) erro
 	} else {
 		config.Message = DefaultDenyMessage
 	}
+	config.ResponseBody = json.Get("response_body").String()
+	config.ContentType = json.Get("content_type").String()
 	allowNets, err := parseIPNets(json.Get("allow").Array())
 	if err != nil {
 		log.Error(err.Error())
@@ -150,9 +154,20 @@ func onHttpRequestHeaders(context wrapper.HttpContext, config RestrictionConfig,
 }
 
 func deniedUnauthorized(config RestrictionConfig, reason string) types.Action {
-	body, _ := json.Marshal(map[string]string{
-		"message": config.Message,
-	})
-	_ = proxywasm.SendHttpResponseWithDetail(config.Status, "key-auth."+reason, nil, body, -1)
+	var body []byte
+	var headers [][2]string
+	if config.ResponseBody != "" {
+		body = []byte(config.ResponseBody)
+		contentType := config.ContentType
+		if contentType == "" {
+			contentType = "text/html; charset=utf-8"
+		}
+		headers = [][2]string{{"content-type", contentType}}
+	} else {
+		body, _ = json.Marshal(map[string]string{
+			"message": config.Message,
+		})
+	}
+	_ = proxywasm.SendHttpResponseWithDetail(config.Status, "ip-restriction."+reason, headers, body, -1)
 	return types.ActionContinue
 }


### PR DESCRIPTION
## 背景 / Background

`ip-restriction` 拒绝访问时响应体写死为 JSON `{"message": ...}`，无法返回自定义内容（如 HTML 拦截页）。同类插件 `request-block`（`blocked_message`）、`gw-error-format` 已支持自定义响应体，`ip-restriction` 存在缺口。

The `ip-restriction` plugin hardcodes the denial body as JSON `{"message": ...}`, so it cannot return custom content such as an HTML block page. Peer plugins already support custom responses — this fills the gap.

## 为什么必须在请求阶段 / Why request phase

实测：`ip-restriction` 在请求阶段经 `proxy_send_local_response` 发出的 403 本地响应**不经过 WASM 编码器过滤链**，因此 `custom-response` / `gw-error-format` 等响应阶段插件无法改写它。自定义响应体必须由 `ip-restriction` 自身产出。

The 403 local reply sent via `proxy_send_local_response` at the request phase does **not** go through the WASM encoder filter chain, so response-phase plugins cannot rewrite it. The custom body must be produced by `ip-restriction` itself.

## 改动 / Changes

- 新增 `response_body`：拒绝时返回的自定义响应体，覆盖默认 JSON
- 新增 `content_type`：自定义 Content-Type，默认 `text/html; charset=utf-8`（仅 `response_body` 设置时生效）
- **向后兼容**：不设置 `response_body` 时行为完全不变
- 顺带修正 detail 前缀 `key-auth.` → `ip-restriction.`（历史复制粘贴遗留），及 README 示例 `192.169.0.0/16` → `192.168.0.0/16` 笔误

## 验证 / Verification

kind + Higress 实测：
- 外网 IP（`X-Forwarded-For: 8.8.8.8`）→ `403` + `content-type: text/html; charset=utf-8` + HTML body ✅
- 内网 IP（`10.0.0.0/8`）→ 正常放行 ✅
- access log：`response_code_details: via_wasm::ip-restriction::ip_denied`

---

> 取代 #4279：旧 PR 关闭后其 head 分支被 force-push，触发 GitHub 限制（closed + force-pushed 不可 reopen），故重开本 PR。Supersedes #4279.

<!--This is a translation content dividing line, the content below is generated by machine, please do not modify the content below-->
---
## Background / Background

When `ip-restriction` denies access, the response body is written as JSON `{"message": ...}`, and custom content (such as HTML interception page) cannot be returned. Similar plug-ins `request-block` (`blocked_message`) and `gw-error-format` already support custom response bodies, but there is a gap in `ip-restriction`.

The `ip-restriction` plugin hardcodes the denial body as JSON `{"message": ...}`, so it cannot return custom content such as an HTML block page. Peer plugins already support custom responses — this fills the gap.

## Why must be in the request phase / Why request phase

Actual measurement: The 403 local response sent by `ip-restriction` through `proxy_send_local_response` in the request phase does not go through the WASM encoder filter chain**, so response phase plug-ins such as `custom-response` / `gw-error-format` cannot rewrite it. Custom response bodies must be generated by `ip-restriction` itself.

The 403 local reply sent via `proxy_send_local_response` at the request phase does **not** go through the WASM encoder filter chain, so response-phase plugins cannot rewrite it. The custom body must be produced by `ip-restriction` itself.

## Changes

- Added `response_body`: custom response body returned when rejected, overriding the default JSON
- Added `content_type`: custom Content-Type, default `text/html; charset=utf-8` (only takes effect when `response_body` is set)
- **Backward Compatibility**: completely unchanged behavior when `response_body` is not set
- Incidentally correct the detail prefix `key-auth.` → `ip-restriction.` (leftover from historical copy and paste), and README example `192.169.0.0/16` → `192.168.0.0/16` typo

## Verification / Verification

kind + Higress actual measurement:
- External IP (`X-Forwarded-For: 8.8.8.8`) → `403` + `content-type: text/html; charset=utf-8` + HTML body ✅
- Intranet IP (`10.0.0.0/8`) → Normal release ✅
- access log: `response_code_details: via_wasm::ip-restriction::ip_denied`

---

> Replaced #4279: After the old PR is closed, its head branch is force-push, triggering GitHub restrictions (closed + force-pushed cannot be reopened), so this PR is reopened. Supersedes #4279.
