### PR TITLE
fix(plugins): normalize FROM AS casing in wasm-cpp Dockerfile

### DIFF
--- a/plugins/wasm-cpp/Dockerfile
+++ b/plugins/wasm-cpp/Dockerfile
@@ -1,5 +1,5 @@
 ARG BUILDER=higress-registry.cn-hangzhou.cr.aliyuncs.com/higress/build-tools-proxy:release-1.19-ef344298e65eeb2d9e2d07b87eb4e715c2def613
-FROM $BUILDER as builder
+FROM $BUILDER AS builder
 
 ARG PLUGIN_NAME
 
@@ -9,7 +9,7 @@ COPY . .
 
 RUN bazel build //extensions/$PLUGIN_NAME:$PLUGIN_NAME.wasm
 
-FROM scratch as output
+FROM scratch AS output
 
 ARG PLUGIN_NAME
 


### PR DESCRIPTION
## I. Summary

Fixes the two `FromAsCasing` warnings reported by Docker BuildKit on `plugins/wasm-cpp/Dockerfile` by normalizing the lowercase `as` to `AS` in both `FROM` instructions (`FROM $BUILDER AS builder`, `FROM scratch AS output`). Dockerfile instruction keywords are case-insensitive, so this is a pure formatting change with no behavioral or compatibility impact.

## II. Related issue

N/A.

## III. Change type

- [ ] Bug fix
- [ ] Feature or enhancement
- [x] Documentation or configuration only
- [ ] Refactoring, tests, or maintenance

## IV. Agent participation and issue-spec gate

- [x] **No agent participation:** This PR is human-only.
- [ ] **Trivial agent-use exception:** Agent use was limited to spelling,
      punctuation, whitespace, or formatting with no substantive choice or
      behavioral effect; the explanation is below.
- [ ] **Verified maintainer/administrator exception:** ...
- [ ] **Material agent participation:** ...

Gate status:

- [x] Complete
- [ ] Noncompliant
- [ ] Verified exception
- [x] N/A because the PR is human-only or qualifies for the trivial exception.

**Gate-status explanation (or N/A):** N/A

**Trivial-exception explanation (or N/A):** N/A
**Verified maintainer/administrator exception evidence (or N/A):** N/A.

- This PR's number or URL: N/A
- Authenticated `gh` login: N/A
- Canonical-repository `role_name`: N/A
- Actual PR author from `gh pr view`: N/A
- Login/author match: N/A
- Token override attestation: N/A
- Bypass rationale: N/A
- Maintainer live validation: N/A

**Approved Proposal Issue URL (or N/A with explanation):** N/A

**Approved Design Issue URL (or N/A with explanation):** N/A

**Maintainer approval link(s) (or N/A with explanation):** N/A

**Authorized implementation TASK link(s) (or N/A with explanation):** N/A

**Verification Plan and verification TASK/evidence link(s) (or N/A with explanation):** N/A

## V. Testing and verification

**Test and deterministic rerun commands (or N/A with explanation):**

```text
# Lint-level check that reproduces the pre-fix warning and confirms it is gone.
docker build --check -f plugins/wasm-cpp/Dockerfile .
# Full build (optional):
#   cd plugins/wasm-cpp && PLUGIN_NAME=request_block docker build --build-arg PLUGIN_NAME=request_block .
```

**Environment and configuration (or N/A with explanation):** N/A — no runtime environment involved; the change is a static Dockerfile text edit.

**Exact tested revision, version, image tag/digest, manifests, and values (or N/A with explanation):** N/A — no build artifacts produced by this change.

**Baseline reproduction evidence for bug fixes (or N/A with explanation):** N/A — not a behavioral bug fix; the pre-fix warning text is:

```text
2 warnings found (use docker --debug to expand):
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 2)
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 12)
```

**Fixed-version verification evidence for bug fixes (or N/A with explanation):** N/A until `docker build --check` is rerun by a maintainer or CI; expected result is zero warnings.

**Wasm source revision and SHA-256 (or N/A with explanation):** N/A — no Wasm artifacts changed.

## VI. Special notes for reviewers

- Scope is limited to `plugins/wasm-cpp/Dockerfile` (2 lines).
- No behavior change: Dockerfile `FROM`/`AS` keyword casing is not semantic.
- Only CI/lint benefit: removes two `FromAsCasing` BuildKit warnings.

## VII. AI coding disclosure

**Tool(s) used (or N/A):** N/A