### PR TITLE
bugfix: fix data race and nil pointer panics in mcp-session Redis client and SSE handler

### DIFF
--- a/plugins/golang-filter/mcp-session/common/redis.go
+++ b/plugins/golang-filter/mcp-session/common/redis.go
@@ -3,6 +3,7 @@ package common
 import (
 	"context"
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/envoyproxy/envoy/contrib/golang/common/go/api"
@@ -53,8 +54,9 @@ func ParseRedisConfig(config map[string]interface{}) (*RedisConfig, error) {
 
 // RedisClient is a struct to handle Redis connections and operations
 type RedisClient struct {
-	client *redis.Client
-	ctx    context.Context
+	clientMu sync.RWMutex
+	client   *redis.Client
+	ctx      context.Context
 	cancel context.CancelFunc
 	config *RedisConfig
 	crypto *Crypto
@@ -124,12 +126,18 @@ func (r *RedisClient) keepAlive() {
 
 // checkConnection verifies if the Redis connection is still alive
 func (r *RedisClient) checkConnection() error {
-	_, err := r.client.Ping(r.ctx).Result()
+	r.clientMu.RLock()
+	client := r.client
+	r.clientMu.RUnlock()
+	_, err := client.Ping(r.ctx).Result()
 	return err
 }
 
 // reconnect attempts to establish a new connection to Redis
 func (r *RedisClient) reconnect() error {
+	r.clientMu.Lock()
+	defer r.clientMu.Unlock()
+
 	// Close the old client
 	if err := r.client.Close(); err != nil {
 		api.LogErrorf("Error closing old Redis connection: %v", err)
@@ -143,8 +151,9 @@ func (r *RedisClient) reconnect() error {
 		DB:       r.config.db,
 	})
 
-	// Test the new connection
-	if err := r.checkConnection(); err != nil {
+	// Test the new connection (inline to avoid recursive RLock)
+	_, err := r.client.Ping(r.ctx).Result()
+	if err != nil {
 		return fmt.Errorf("failed to reconnect to Redis: %w", err)
 	}
 
@@ -154,7 +163,10 @@ func (r *RedisClient) reconnect() error {
 
 // Publish publishes a message to a Redis channel
 func (r *RedisClient) Publish(channel string, message string) error {
-	err := r.client.Publish(r.ctx, channel, message).Err()
+	r.clientMu.RLock()
+	client := r.client
+	r.clientMu.RUnlock()
+	err := client.Publish(r.ctx, channel, message).Err()
 	if err != nil {
 		return fmt.Errorf("failed to publish message: %w", err)
 	}
@@ -163,7 +175,10 @@ func (r *RedisClient) Publish(channel string, message string) error {
 
 // Subscribe subscribes to a Redis channel and processes messages
 func (r *RedisClient) Subscribe(channel string, stopChan chan struct{}, callback func(message string)) error {
-	pubsub := r.client.Subscribe(r.ctx, channel)
+	r.clientMu.RLock()
+	client := r.client
+	r.clientMu.RUnlock()
+	pubsub := client.Subscribe(r.ctx, channel)
 	_, err := pubsub.Receive(r.ctx)
 	if err != nil {
 		return fmt.Errorf("failed to subscribe to channel: %w", err)
@@ -222,7 +237,10 @@ func (r *RedisClient) Set(key string, value string, expiration time.Duration) er
 		finalValue = value
 	}
 
-	err := r.client.Set(r.ctx, key, finalValue, expiration).Err()
+	r.clientMu.RLock()
+	client := r.client
+	r.clientMu.RUnlock()
+	err := client.Set(r.ctx, key, finalValue, expiration).Err()
 	if err != nil {
 		return fmt.Errorf("failed to set key: %w", err)
 	}
@@ -231,7 +249,10 @@ func (r *RedisClient) Set(key string, value string, expiration time.Duration) er
 
 // Get retrieves the value of a key from Redis
 func (r *RedisClient) Get(key string) (string, error) {
-	value, err := r.client.Get(r.ctx, key).Result()
+	r.clientMu.RLock()
+	client := r.client
+	r.clientMu.RUnlock()
+	value, err := client.Get(r.ctx, key).Result()
 	if err == redis.Nil {
 		return "", fmt.Errorf("key does not exist")
 	} else if err != nil {
@@ -252,7 +273,10 @@ func (r *RedisClient) Get(key string) (string, error) {
 
 // Expire sets the expiration time for a key
 func (r *RedisClient) Expire(key string, expiration time.Duration) error {
-	ok, err := r.client.Expire(r.ctx, key, expiration).Result()
+	r.clientMu.RLock()
+	client := r.client
+	r.clientMu.RUnlock()
+	ok, err := client.Expire(r.ctx, key, expiration).Result()
 	if err != nil {
 		return fmt.Errorf("failed to set expiration for key: %w", err)
 	}
@@ -265,12 +289,17 @@ func (r *RedisClient) Expire(key string, expiration time.Duration) error {
 // Close closes the Redis client and stops the keepalive goroutine
 func (r *RedisClient) Close() error {
 	r.cancel()
+	r.clientMu.Lock()
+	defer r.clientMu.Unlock()
 	return r.client.Close()
 }
 
 // Eval executes a Lua script
 func (r *RedisClient) Eval(script string, numKeys int, keys []string, args []interface{}) (interface{}, error) {
-	result, err := r.client.Eval(r.ctx, script, keys, args...).Result()
+	r.clientMu.RLock()
+	client := r.client
+	r.clientMu.RUnlock()
+	result, err := client.Eval(r.ctx, script, keys, args...).Result()
 	if err != nil {
 		return nil, fmt.Errorf("failed to execute Lua script: %w", err)
 	}

--- a/plugins/golang-filter/mcp-session/common/sse.go
+++ b/plugins/golang-filter/mcp-session/common/sse.go
@@ -98,6 +98,7 @@ func (s *SSEServer) HandleSSE(cb api.FilterCallbackHandler, stopChan chan struct
 	u, err := url.Parse(s.baseURL + s.messageEndpoint)
 	if err != nil {
 		api.LogErrorf("Failed to parse base URL: %v", err)
+		return
 	}
 
 	q := u.Query()
@@ -128,6 +129,11 @@ func (s *SSEServer) HandleSSE(cb api.FilterCallbackHandler, stopChan chan struct
 	// 		}
 	// 	}
 	// }()
+
+	if s.redisClient == nil {
+		api.LogErrorf("Redis client is not configured, SSE subscription skipped")
+		return
+	}
 
 	err = s.redisClient.Subscribe(channel, stopChan, func(message string) {
 		defer cb.EncoderFilterCallbacks().RecoverPanic()


### PR DESCRIPTION
## Ⅰ. Describe what this PR does

Fixes three bugs in mcp-session/common that crash the Envoy worker (no recover in golang-filter).

### 1. redis.go — Data Race on `r.client`
The `r.client` field was accessed concurrently without synchronization:
- **Writer**: `reconnect()` from `keepAlive()` goroutine swaps `r.client`
- **Readers**: `Publish/Subscribe/Set/Get/Expire/Eval/Close` from request goroutines

Fix: Add `sync.RWMutex` (clientMu). All read paths use `RLock` to get a stable client reference, `reconnect()` and `Close()` use `Lock` for exclusive access.

### 2. sse.go — Nil pointer after `url.Parse` error
`url.Parse` returns `(nil, err)` on malformed input. The error was only logged, then `u.Query()` immediately dereferenced nil → panic.

Fix: Return early on parse error.

### 3. sse.go — Nil `redisClient` dereference
`HandleSSE` called `s.redisClient.Subscribe` without nil check. When `SSEServer` is created without `WithRedisClient` option, `s.redisClient` is nil → panic.

Fix: Add nil guard before Subscribe.

## Ⅱ. Does this fix any issue

fixes #4459

## Ⅲ. Why not add test cases

golang-filter runs inside Envoy and requires a full Redis + MCP SSE environment. The fixes are standard synchronization and nil-guard patterns.

## Ⅳ. How to verify

1. `go build ./...` passes in `plugins/golang-filter/mcp-session/`
2. With race detector: no race on concurrent Redis operations during reconnect
3. With malformed baseURL: HandleSSE returns early instead of panicking
4. Without redis config: HandleSSE skips subscription instead of panicking

## Ⅴ. Special notes for reviewers

- `clientMu` is named descriptively per Go conventions (not `mu`/`lock`)
- `reconnect()` inlines the Ping check instead of calling `checkConnection()` to avoid recursive RLock while holding Lock
- `Close()` acquires Lock to prevent racing with reconnect
- The nil `redisClient` guard in sse.go is defense-in-depth; in practice the filter.go already checks `f.config.redisClient` before creating SSEServer, but a misconfiguration could still reach this path

## Ⅵ. AI Coding Tool Usage Checklist

- [x] I used AI coding tools to help analyze the concurrent access patterns
- [x] I reviewed and verified all AI-generated code changes before submitting