### PR TITLE
bugfix: fix nil server and naked type assertions in tool-search MCP server

### DIFF
--- a/plugins/golang-filter/mcp-server/servers/tool-search/milvus.go
+++ b/plugins/golang-filter/mcp-server/servers/tool-search/milvus.go
@@ -90,22 +90,36 @@ func (c *MilvusVectorStoreProvider) ListAllDocs(ctx context.Context, limit int) 
 		for _, col := range queryResult {
 			switch col.Name() {
 			case "id":
-				if v, err := col.(*entity.ColumnVarChar).Get(i); err == nil {
-					id = v.(string)
+				if varcharCol, ok := col.(*entity.ColumnVarChar); ok {
+					if v, err := varcharCol.Get(i); err == nil {
+						if s, ok := v.(string); ok {
+							id = s
+						}
+					}
 				}
 			case "content":
-				if v, err := col.(*entity.ColumnVarChar).Get(i); err == nil {
-					content = v.(string)
+				if varcharCol, ok := col.(*entity.ColumnVarChar); ok {
+					if v, err := varcharCol.Get(i); err == nil {
+						if s, ok := v.(string); ok {
+							content = s
+						}
+					}
 				}
 			case "metadata":
-				if v, err := col.(*entity.ColumnJSONBytes).Get(i); err == nil {
-					if bytes, ok := v.([]byte); ok {
-						_ = json.Unmarshal(bytes, &metadata)
+				if jsonCol, ok := col.(*entity.ColumnJSONBytes); ok {
+					if v, err := jsonCol.Get(i); err == nil {
+						if bytes, ok := v.([]byte); ok {
+							_ = json.Unmarshal(bytes, &metadata)
+						}
 					}
 				}
 			case "created_at":
-				if v, err := col.(*entity.ColumnInt64).Get(i); err == nil {
-					createdAt = v.(int64)
+				if int64Col, ok := col.(*entity.ColumnInt64); ok {
+					if v, err := int64Col.Get(i); err == nil {
+						if n, ok := v.(int64); ok {
+							createdAt = n
+						}
+					}
 				}
 			}
 		}

--- a/plugins/golang-filter/mcp-server/servers/tool-search/server.go
+++ b/plugins/golang-filter/mcp-server/servers/tool-search/server.go
@@ -178,7 +178,7 @@ func (c *ToolSearchConfig) NewServer(serverName string) (*common.MCPServer, erro
 	// Create embedding client
 	embeddingClient := NewEmbeddingClient(c.Embedding.APIKey, c.Embedding.BaseURL, c.Embedding.Model, c.Embedding.Dimensions)
 
-	// Create search service，使用写死的fixedMaxTools值
+	// Create search service
 	searchService := NewSearchService(
 		c.Vector.Host,
 		c.Vector.Port,
@@ -188,8 +188,11 @@ func (c *ToolSearchConfig) NewServer(serverName string) (*common.MCPServer, erro
 		c.Vector.TableName,
 		embeddingClient,
 		c.Embedding.Dimensions,
-		fixedMaxTools, // 使用写死的值
+		fixedMaxTools,
 	)
+	if searchService == nil {
+		return nil, errors.New("failed to create tool search service: Milvus connection failed")
+	}
 
 	// Add tool search tool
 	mcpServer.AddTool(


### PR DESCRIPTION
## Ⅰ. Describe what this PR does

Fixes two bugs in tool-search MCP server that crash the Envoy worker.

### 1. server.go — nil SearchService registered as tool handler
`NewSearchService` returns `nil` when Milvus connection fails. `NewServer` does not check the return value and registers a tool handler with nil `searchService`. When a tool call arrives, nil dereference panic crashes the Envoy worker.

Fix: Return error from `NewServer` when `searchService` is nil.

### 2. milvus.go — naked type assertions in ListAllDocs
`col.(*entity.ColumnVarChar)`, `col.(*entity.ColumnJSONBytes)`, `col.(*entity.ColumnInt64)` panic when the Milvus collection schema has different column types. Inner assertions `v.(string)` and `v.(int64)` also panic on unexpected types. `SearchDocs` in the same file correctly uses comma-ok — this is an inconsistency.

Fix: Replace all naked type assertions with comma-ok pattern.

## Ⅱ. Does this fix any issue

fixes #4461

## Ⅲ. Why not add test cases

golang-filter runs inside Envoy and requires a full Milvus + MCP server environment. The fixes are standard nil-guard and comma-ok patterns.

## Ⅳ. How to verify

1. `gofmt` passes (no syntax errors)
2. With Milvus unreachable: `NewServer` returns error instead of registering nil handler
3. With mismatched collection schema: `ListAllDocs` skips unknown columns instead of panicking

## Ⅴ. Special notes for reviewers

- The nil-guard in `NewServer` surfaces the error at config time rather than crashing at request time
- `SearchDocs` already uses comma-ok pattern correctly — this PR makes `ListAllDocs` consistent
- The `errors` package is already imported in server.go

## Ⅵ. AI Coding Tool Usage Checklist

- [x] I used AI coding tools to help analyze the panic scenarios
- [x] I reviewed and verified all AI-generated code changes before submitting