### PR TITLE
fix: align ORAS setup action with CLI pin

### DIFF
--- a/.github/workflows/authorize-higress-release-tag.yaml
+++ b/.github/workflows/authorize-higress-release-tag.yaml
@@ -74,7 +74,7 @@ jobs:
           go-version: "1.24.0"
       - uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
       - uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
-      - uses: oras-project/setup-oras@ca28077386065e263c03428f4ae0c09024817c93 # v1.2.0
+      - uses: oras-project/setup-oras@8d34698a59f5ffe24821f0b48ab62a3de8b64b20 # v1.2.3
         with:
           version: 1.2.3
       - uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1

--- a/.github/workflows/build-plugin-server-from-snapshot.yaml
+++ b/.github/workflows/build-plugin-server-from-snapshot.yaml
@@ -85,7 +85,7 @@ jobs:
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
       - name: Set up pinned ORAS
         if: ${{ !inputs.dry_run }}
-        uses: oras-project/setup-oras@ca28077386065e263c03428f4ae0c09024817c93 # v1.2.0
+        uses: oras-project/setup-oras@8d34698a59f5ffe24821f0b48ab62a3de8b64b20 # v1.2.3
         with:
           version: 1.2.3
       - name: Build, verify, and promote immutable plugin-server image

--- a/.github/workflows/dispatch-standalone-release.yaml
+++ b/.github/workflows/dispatch-standalone-release.yaml
@@ -14,7 +14,7 @@ jobs:
         with:
           ref: ${{ github.event.release.tag_name }}
           fetch-depth: 0
-      - uses: oras-project/setup-oras@ca28077386065e263c03428f4ae0c09024817c93 # v1.2.0
+      - uses: oras-project/setup-oras@8d34698a59f5ffe24821f0b48ab62a3de8b64b20 # v1.2.3
         with:
           version: 1.2.3
       - uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1

--- a/.github/workflows/prepare-plugin-release.yaml
+++ b/.github/workflows/prepare-plugin-release.yaml
@@ -56,7 +56,7 @@ jobs:
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: "1.24.0"
-      - uses: oras-project/setup-oras@ca28077386065e263c03428f4ae0c09024817c93 # v1.2.0
+      - uses: oras-project/setup-oras@8d34698a59f5ffe24821f0b48ab62a3de8b64b20 # v1.2.3
         with:
           version: 1.2.3
       - name: Validate immutable inputs

--- a/.github/workflows/promote-plugin-release.yaml
+++ b/.github/workflows/promote-plugin-release.yaml
@@ -40,7 +40,7 @@ jobs:
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: "1.24.0"
-      - uses: oras-project/setup-oras@ca28077386065e263c03428f4ae0c09024817c93 # v1.2.0
+      - uses: oras-project/setup-oras@8d34698a59f5ffe24821f0b48ab62a3de8b64b20 # v1.2.3
         with:
           version: 1.2.3
       - name: Verify exact snapshot provenance
@@ -153,7 +153,7 @@ jobs:
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: '1.24.0'
-      - uses: oras-project/setup-oras@ca28077386065e263c03428f4ae0c09024817c93 # v1.2.0
+      - uses: oras-project/setup-oras@8d34698a59f5ffe24821f0b48ab62a3de8b64b20 # v1.2.3
         with:
           version: 1.2.3
       - name: Promote latest only after complete verified batch

--- a/tools/plugin-release/plugin_server_workflow_contract_test.go
+++ b/tools/plugin-release/plugin_server_workflow_contract_test.go
@@ -21,7 +21,7 @@ func TestPluginServerWorkflowFailsClosedBeforeCandidateMutation(t *testing.T) {
 		t.Fatal("public lookup must fail closed before the candidate build/push")
 	}
 	for _, required := range []string{
-		"docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392", "docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435", "oras-project/setup-oras@ca28077386065e263c03428f4ae0c09024817c93",
+		"docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392", "docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435", "oras-project/setup-oras@8d34698a59f5ffe24821f0b48ab62a3de8b64b20",
 		"length == 2", "linux/amd64", "linux/arm64", "org.opencontainers.image.revision",
 		"snapshot-inventory.json", "jsonrpc-converter", "unmanaged-plugins.lock.json",
 	} {
@@ -32,6 +32,36 @@ func TestPluginServerWorkflowFailsClosedBeforeCandidateMutation(t *testing.T) {
 	buildData, err := os.ReadFile("../../.github/workflows/build-plugin-server-from-snapshot.yaml")
 	if err != nil || !strings.Contains(string(buildData), "plugin-release-batches:$SNAPSHOT_SHA256") {
 		t.Fatal("plugin-server build must require the immutable latest-completion marker")
+	}
+}
+
+func TestReleaseWorkflowsPairORASSetupMetadataWithPinnedCLI(t *testing.T) {
+	const orasSetup = "oras-project/setup-oras@8d34698a59f5ffe24821f0b48ab62a3de8b64b20 # v1.2.3"
+	const orasSetupWithCLI = orasSetup + "\n        with:\n          version: 1.2.3"
+	const supersededSetup = "oras-project/setup-oras@ca28077386065e263c03428f4ae0c09024817c93"
+
+	expectedCallers := map[string]int{
+		"prepare-plugin-release.yaml":            1,
+		"promote-plugin-release.yaml":            2,
+		"build-plugin-server-from-snapshot.yaml": 1,
+		"authorize-higress-release-tag.yaml":     1,
+		"dispatch-standalone-release.yaml":       1,
+	}
+	for name, expected := range expectedCallers {
+		data, err := os.ReadFile("../../.github/workflows/" + name)
+		if err != nil {
+			t.Fatal(err)
+		}
+		workflow := string(data)
+		if strings.Contains(workflow, supersededSetup) {
+			t.Fatalf("%s retains the setup-oras v1.2.0 metadata action", name)
+		}
+		if got := strings.Count(workflow, "version: 1.2.3"); got != expected {
+			t.Fatalf("%s has %d ORAS CLI 1.2.3 declarations, want %d", name, got, expected)
+		}
+		if got := strings.Count(workflow, orasSetupWithCLI); got != expected {
+			t.Fatalf("%s has %d setup-oras v1.2.3 action/CLI pairs, want %d", name, got, expected)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

- Fix the failed dry-run preparation run: `setup-oras@v1.2.0` did not include metadata for requested ORAS CLI 1.2.3.
- Pin all Higress release-path callers to the exact upstream `setup-oras` v1.2.3 commit while retaining the requested CLI version.
- Add a release-workflow contract test that enumerates all six callers, including the Standalone dispatcher.

## Validation

- `go test ./...` in `tools/plugin-release`
- actionlint v1.7.7 for five modified workflows
- YAML/static assertions and `git diff --check`

## Traceability

- Design: https://github.com/higress-group/higress/issues/4442
- TASK-4442013: https://github.com/higress-group/higress/issues/4442#issuecomment-5267888225
- Failing rehearsal: https://github.com/higress-group/higress/actions/runs/31601014448/job/94128145517

## Agent-assisted contribution

Implemented with Codex assistance and independently reviewed. No registry, tag, release, or credential behavior changed.