### PR TITLE
fix: make plugin release OCI resolver compatible with ORAS 1.2.3

### DIFF
--- a/.github/workflows/prepare-plugin-release.yaml
+++ b/.github/workflows/prepare-plugin-release.yaml
@@ -38,7 +38,41 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  preflight:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          ref: ${{ inputs.target_ref }}
+          fetch-depth: 1
+      - uses: oras-project/setup-oras@8d34698a59f5ffe24821f0b48ab62a3de8b64b20 # v1.2.3
+        with:
+          version: 1.2.3
+      - name: Preflight ORAS public manifest resolution
+        env:
+          TARGET_REF: ${{ inputs.target_ref }}
+        run: |
+          set -euo pipefail
+          [[ "$TARGET_REF" =~ ^[0-9a-f]{40}$ ]]
+          test "$(git rev-parse HEAD)" = "$TARGET_REF"
+          IFS=$'\t' read -r registry image source_dir < <(
+            jq -er '
+              . as $catalog
+              | ([.plugins[] | select(.releaseEligible)] | sort_by(.logicalId) | .[0]) as $plugin
+              | [$catalog.registry, $plugin.image, $plugin.sourceDir] | @tsv
+            ' plugins/release/catalog.json
+          )
+          [[ "$registry" =~ ^[a-z0-9][a-z0-9.-]*(\:[0-9]+)?$ ]]
+          [[ "$image" =~ ^plugins/[a-z0-9][a-z0-9._-]*$ ]]
+          [[ "$source_dir" =~ ^plugins/wasm-(go|rust)/extensions/[a-z0-9][a-z0-9._-]*$ ]]
+          version="$(tr -d '\r\n' < "$source_dir/VERSION")"
+          [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]
+          public_ref="$registry/$image:$version"
+          oras manifest fetch "$public_ref" --descriptor > /tmp/oras-public-descriptor.json
+          jq -er '.digest | strings and test("^sha256:[0-9a-f]{64}$")' /tmp/oras-public-descriptor.json >/dev/null
+          echo "Read-only ORAS descriptor preflight succeeded for deterministic catalog public artifact." >> "$GITHUB_STEP_SUMMARY"
   prepare:
+    needs: preflight
     runs-on: ubuntu-latest
     environment: plugin-release-candidate
     steps:

--- a/tools/plugin-release/commands.go
+++ b/tools/plugin-release/commands.go
@@ -4,6 +4,7 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"flag"
@@ -18,9 +19,12 @@ import (
 )
 
 var (
-	safeIDPattern = regexp.MustCompile(`^[a-z0-9]+(?:[a-z0-9._-]*[a-z0-9])?$`)
-	digestPattern = regexp.MustCompile(`^sha256:[0-9a-f]{64}$`)
-	commitPattern = regexp.MustCompile(`^[0-9a-f]{40}$`)
+	safeIDPattern             = regexp.MustCompile(`^[a-z0-9]+(?:[a-z0-9._-]*[a-z0-9])?$`)
+	digestPattern             = regexp.MustCompile(`^sha256:[0-9a-f]{64}$`)
+	commitPattern             = regexp.MustCompile(`^[0-9a-f]{40}$`)
+	credentialURLPattern      = regexp.MustCompile(`(?i)([a-z][a-z0-9+.-]*://)[^/\s@]+@`)
+	sensitiveValuePattern     = regexp.MustCompile(`(?i)(\b(?:password|token|secret|credential|access[_-]?key|api[_-]?key)\b(?:\s*[:=]\s*|\s+))([^\s,;]+)`)
+	authorizationValuePattern = regexp.MustCompile(`(?i)(\bauthorization\b\s*[:=]\s*)([^\s,;]+(?:\s+[^\s,;]+)?)`)
 )
 
 type ociManifest struct {
@@ -32,6 +36,10 @@ type ociManifest struct {
 // resolves the supplied reference itself, rather than trusting a digest copied
 // from workflow input.
 var ociManifestResolver = resolveOCIManifest
+
+// orasRunner keeps the command boundary testable without requiring a registry
+// or an ORAS binary in unit tests.
+var orasRunner = runORAS
 
 func loadCatalog(path string) (Catalog, []byte, error) {
 	var c Catalog
@@ -591,8 +599,7 @@ func verifyOCI(entry SnapshotEntry, provenanceMode, snapshotMode, ociSource stri
 }
 
 func resolveOCIManifest(ref string) (ociManifest, error) {
-	descriptorCmd := exec.Command("oras", "manifest", "fetch", ref, "--descriptor", "--format", "json")
-	descriptorOut, err := descriptorCmd.Output()
+	descriptorOut, err := runORASManifestFetch("oras manifest fetch --descriptor", "manifest", "fetch", ref, "--descriptor")
 	if err != nil {
 		return ociManifest{}, err
 	}
@@ -602,8 +609,7 @@ func resolveOCIManifest(ref string) (ociManifest, error) {
 	if err := json.Unmarshal(descriptorOut, &descriptor); err != nil {
 		return ociManifest{}, err
 	}
-	manifestCmd := exec.Command("oras", "manifest", "fetch", ref)
-	manifestOut, err := manifestCmd.Output()
+	manifestOut, err := runORASManifestFetch("oras manifest fetch", "manifest", "fetch", ref)
 	if err != nil {
 		return ociManifest{}, err
 	}
@@ -614,6 +620,33 @@ func resolveOCIManifest(ref string) (ociManifest, error) {
 		return ociManifest{}, err
 	}
 	return ociManifest{Digest: descriptor.Digest, Annotations: manifest.Annotations}, nil
+}
+
+func runORAS(args ...string) ([]byte, string, error) {
+	cmd := exec.Command("oras", args...)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	output, err := cmd.Output()
+	return output, stderr.String(), err
+}
+
+func runORASManifestFetch(operation string, args ...string) ([]byte, error) {
+	output, stderr, err := orasRunner(args...)
+	if err == nil {
+		return output, nil
+	}
+	if detail := sanitizeCommandStderr(stderr); detail != "" {
+		return nil, fmt.Errorf("%s failed: %w: %s", operation, err, detail)
+	}
+	return nil, fmt.Errorf("%s failed: %w", operation, err)
+}
+
+func sanitizeCommandStderr(stderr string) string {
+	detail := strings.TrimSpace(stderr)
+	detail = credentialURLPattern.ReplaceAllString(detail, "$1[REDACTED]@")
+	detail = sensitiveValuePattern.ReplaceAllString(detail, "$1[REDACTED]")
+	detail = authorizationValuePattern.ReplaceAllString(detail, "$1[REDACTED]")
+	return detail
 }
 
 func digestReference(ociRef, digest string) (string, error) {

--- a/tools/plugin-release/oci_test.go
+++ b/tools/plugin-release/oci_test.go
@@ -1,10 +1,77 @@
 package main
 
-import "testing"
+import (
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+)
 
 func TestDigestReferencePreservesRegistryPort(t *testing.T) {
 	got, err := digestReference("oci://registry.example:5000/plugins/demo:1.2.3", "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
 	if err != nil || got != "registry.example:5000/plugins/demo@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" {
 		t.Fatalf("digestReference=%q, %v", got, err)
 	}
+}
+
+func TestResolveOCIManifestUsesORAS123CompatibleDescriptorInvocation(t *testing.T) {
+	ref := "registry.example/plugins/demo:1.2.3"
+	digest := "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	var calls [][]string
+	withORASRunner(t, func(args ...string) ([]byte, string, error) {
+		calls = append(calls, append([]string(nil), args...))
+		switch len(calls) {
+		case 1:
+			return []byte(`{"digest":"` + digest + `"}`), "", nil
+		case 2:
+			return []byte(`{"annotations":{"org.opencontainers.image.version":"1.2.3"}}`), "", nil
+		default:
+			t.Fatalf("unexpected ORAS invocation %v", args)
+			return nil, "", nil
+		}
+	})
+
+	manifest, err := resolveOCIManifest(ref)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if manifest.Digest != digest || manifest.Annotations["org.opencontainers.image.version"] != "1.2.3" {
+		t.Fatalf("unexpected manifest %#v", manifest)
+	}
+	want := [][]string{
+		{"manifest", "fetch", ref, "--descriptor"},
+		{"manifest", "fetch", ref},
+	}
+	if !reflect.DeepEqual(calls, want) {
+		t.Fatalf("ORAS calls = %#v, want %#v", calls, want)
+	}
+}
+
+func TestResolveOCIManifestReportsSanitizedORASStderr(t *testing.T) {
+	withORASRunner(t, func(args ...string) ([]byte, string, error) {
+		return nil, "denied: token=fixture-token authorization: Bearer fixture-auth authorization: Basic Zml4dHVyZS11c2VyOmZpeHR1cmUtcGFzc3dvcmQ= https://user:fixture-password@registry.example", errors.New("exit status 1")
+	})
+
+	_, err := resolveOCIManifest("registry.example/plugins/demo:1.2.3")
+	if err == nil {
+		t.Fatal("expected descriptor resolution failure")
+	}
+	message := err.Error()
+	for _, required := range []string{"oras manifest fetch --descriptor failed", "denied:", "token=[REDACTED]", "authorization: [REDACTED]", "https://[REDACTED]@registry.example"} {
+		if !strings.Contains(message, required) {
+			t.Fatalf("error %q lacks %q", message, required)
+		}
+	}
+	for _, secret := range []string{"fixture-token", "fixture-auth", "Zml4dHVyZS11c2VyOmZpeHR1cmUtcGFzc3dvcmQ=", "fixture-password"} {
+		if strings.Contains(message, secret) {
+			t.Fatalf("error leaked test credential %q: %q", secret, message)
+		}
+	}
+}
+
+func withORASRunner(t *testing.T, runner func(args ...string) ([]byte, string, error)) {
+	t.Helper()
+	previous := orasRunner
+	orasRunner = runner
+	t.Cleanup(func() { orasRunner = previous })
 }

--- a/tools/plugin-release/plugin_server_workflow_contract_test.go
+++ b/tools/plugin-release/plugin_server_workflow_contract_test.go
@@ -41,7 +41,7 @@ func TestReleaseWorkflowsPairORASSetupMetadataWithPinnedCLI(t *testing.T) {
 	const supersededSetup = "oras-project/setup-oras@ca28077386065e263c03428f4ae0c09024817c93"
 
 	expectedCallers := map[string]int{
-		"prepare-plugin-release.yaml":            1,
+		"prepare-plugin-release.yaml":            2,
 		"promote-plugin-release.yaml":            2,
 		"build-plugin-server-from-snapshot.yaml": 1,
 		"authorize-higress-release-tag.yaml":     1,
@@ -174,6 +174,39 @@ func TestPreparationBootstrapPlansFromExactHistoricalBase(t *testing.T) {
 		if strings.Contains(workflow, forbidden) {
 			t.Fatalf("preparation bootstrap retains unsafe/empty-plan contract %q", forbidden)
 		}
+	}
+}
+
+func TestPreparationPreflightsReadOnlyDeterministicCatalogPublicManifest(t *testing.T) {
+	data, err := os.ReadFile("../../.github/workflows/prepare-plugin-release.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	workflow := string(data)
+	preflightStart := strings.Index(workflow, "  preflight:\n")
+	prepareStart := strings.Index(workflow, "  prepare:\n")
+	bootstrap := strings.Index(workflow, "capture-bootstrap-evidence")
+	if preflightStart < 0 || prepareStart < 0 || bootstrap < 0 || preflightStart > prepareStart || prepareStart > bootstrap {
+		t.Fatal("read-only ORAS preflight job must run before the protected full bootstrap job")
+	}
+	preflight := workflow[preflightStart:prepareStart]
+	if !strings.Contains(workflow[prepareStart:], "needs: preflight") {
+		t.Fatal("protected preparation job must wait for the read-only preflight")
+	}
+	if strings.Contains(preflight, "environment:") || strings.Contains(preflight, "create-github-app-token") || strings.Contains(preflight, "oras login") {
+		t.Fatal("ORAS preflight must remain read-only and outside the protected credential environment")
+	}
+	for _, required := range []string{
+		"sort_by(.logicalId) | .[0]", "select(.releaseEligible)", "[$catalog.registry, $plugin.image, $plugin.sourceDir] | @tsv",
+		`oras manifest fetch "$public_ref" --descriptor > /tmp/oras-public-descriptor.json`, `jq -er '.digest | strings and test("^sha256:[0-9a-f]{64}$")'`,
+		"Read-only ORAS descriptor preflight succeeded for deterministic catalog public artifact.",
+	} {
+		if !strings.Contains(preflight, required) {
+			t.Fatalf("preflight lacks required read-only contract %q", required)
+		}
+	}
+	if strings.Contains(preflight, "--descriptor --format") {
+		t.Fatal("ORAS 1.2.3 descriptor preflight must not combine --descriptor and --format")
 	}
 }
 


### PR DESCRIPTION
## I. Summary

Fix the first-release bootstrap OCI resolver for ORAS CLI 1.2.3. The previous resolver combined `--descriptor` and `--format`, which ORAS rejects as mutually exclusive, causing the no-production-mutation rehearsal to fail while resolving public plugin manifests.

The resolver now uses descriptor-only mode, preserves the existing separate annotation fetch, reports sanitized ORAS stderr on failures, and adds an unprotected deterministic public-manifest preflight before the protected preparation job.

## II. Related issue

Related to #4442, [TASK-4442014](https://github.com/higress-group/higress/issues/4442#issuecomment-5268317892).

## III. Change type

- [x] Bug fix
- [ ] Feature or enhancement
- [ ] Documentation or configuration only
- [x] Refactoring, tests, or maintenance

## IV. Agent participation and issue-spec gate

- [ ] **No agent participation:** This PR is human-only.
- [ ] **Trivial agent-use exception:** Agent use was limited to spelling, punctuation, whitespace, or formatting with no substantive choice or behavioral effect; the explanation is below.
- [x] **Verified maintainer/administrator exception:** Material agent participation occurred, and authenticated `gh` verification confirmed a `role_name` of `maintain` or `admin` on `higress-group/higress`, and the verified login matches this PR's GitHub author; record the required evidence and rationale below.
- [ ] **Material agent participation:** An AI or coding agent materially participated in analysis, design, implementation, testing, or PR preparation.

- [ ] Complete: all three timed obligations above were satisfied.
- [ ] Noncompliant: one or more obligations were not satisfied; explain below.
- [x] Verified exception: material agent participation used the verified-maintainer/administrator exception; provide the required evidence and rationale below.
- [ ] N/A because the PR is human-only or qualifies for the trivial exception.

**Gate-status explanation (or N/A):** The verified maintainer/administrator exception is used for planning/traceability. It does not waive the required red/green workflow rehearsal for this bug fix; the fixed-version dry-run is pending merge because production workflow execution intentionally checks out canonical `main`. TASK-4442005 remains in progress and no review/acceptance is requested yet.

**Trivial-exception explanation (or N/A):** N/A.

**Verified maintainer/administrator exception evidence (or N/A):**

- This PR's number or URL: https://github.com/higress-group/higress/pull/4464
- Authenticated `gh` login: `johnlanni`
- Canonical-repository `role_name`: `admin`
- Actual PR author from `gh pr view`: `johnlanni`
- Login/author match: yes
- Token override attestation (`GH_TOKEN` and `GITHUB_TOKEN` were unset for every verification command; required: `yes`): yes
- Bypass rationale: Maintainer-authorized repair of a release rehearsal blocker; no production mutation.
- Maintainer live validation (review URL or N/A until performed): N/A until performed.

**Approved Proposal Issue URL (or N/A with explanation):** https://github.com/higress-group/higress/issues/4022

**Approved Design Issue URL (or N/A with explanation):** https://github.com/higress-group/higress/issues/4442

**Maintainer approval link(s) (or N/A with explanation):** https://github.com/higress-group/higress/issues/4442#issuecomment-5260746437 and https://github.com/higress-group/higress/issues/4442#issuecomment-5260786221

**Authorized implementation TASK link(s) (or N/A with explanation):** https://github.com/higress-group/higress/issues/4442#issuecomment-5268317892

**Verification Plan and verification TASK/evidence link(s) (or N/A with explanation):** Design Verification Plan and TASK-4442005. The failing dry-run is https://github.com/higress-group/higress/actions/runs/31606700140/job/94147375916.

## V. Testing and verification

**Test and deterministic rerun commands (or N/A with explanation):**

```text
cd tools/plugin-release && env -u GH_TOKEN -u GITHUB_TOKEN go test ./...
env -u GH_TOKEN -u GITHUB_TOKEN go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 .github/workflows/prepare-plugin-release.yaml
git diff --check ded7405c391005a4c35f39bb9e3c8156caddc6cb..f137ac1714b1520e5a84d8f90cd0c883be285bf3
oras_1.2.3_linux_amd64 manifest fetch higress-registry.cn-hangzhou.cr.aliyuncs.com/plugins/ai-agent:2.0.0 --descriptor
```

All commands passed. The last command is a read-only public descriptor lookup; it returned a valid SHA-256 digest. No registry authentication, candidate/public artifact write, tag, release, or downstream mutation was performed.

**Environment and configuration (or N/A with explanation):** Linux amd64; Go module tests; actionlint v1.7.7; official ORAS CLI v1.2.3.

**Exact tested revision, version, image tag/digest, manifests, and values (or N/A with explanation):** `f137ac1714b1520e5a84d8f90cd0c883be285bf3`; public read-only control `higress-registry.cn-hangzhou.cr.aliyuncs.com/plugins/ai-agent:2.0.0`.

**Baseline reproduction evidence for bug fixes (or N/A with explanation):** https://github.com/higress-group/higress/actions/runs/31606700140/job/94147375916 failed after ORAS setup passed, at bootstrap manifest resolution.

**Fixed-version verification evidence for bug fixes (or N/A with explanation):** Unit tests cover exact ORAS descriptor-only arguments and sanitized Bearer/Basic stderr. A workflow dry-run on the merged canonical main head is still required before acceptance and will be recorded in TASK-4442005.

**Wasm source revision and SHA-256 (or N/A with explanation):** N/A; no plugin source or artifact changed.

## VI. Special notes for reviewers

- Scope is limited to the OCI resolver, its regression/contract tests, and an unauthenticated read-only preflight.
- The preflight is deterministic from the checked-out catalog and runs before the protected environment; it cannot push an artifact or create a PR.
- The independent reviewer concluded P0=0/P1=0 after the Basic-Authorization redaction repair.
- One P2 is published inline: preflight validates the exact checked-out SHA but relies on the protected `prepare` job to enforce `TARGET_REF == origin/main`. It has no credentials or write path.

## VII. AI coding disclosure

**Tool(s) used (or N/A):** Codex coding agents, issue-spec, GitHub CLI, Go test, actionlint, and official ORAS CLI.

### Prompts or instructions

Implement TASK-4442014 from approved Design #4442: fix ORAS 1.2.3 descriptor resolution and diagnostics without changing plugin versions, registry credentials, tags, artifacts, or downstream repositories; run tests and independent review.

### AI-assisted work summary

A single non-Coordinator writer made the implementation in an isolated worktree. An independent reviewer found a Basic Authorization stderr-redaction leak; the same writer repaired it and the reviewer rechecked the amended exact head with P0=0/P1=0. One P2 about preflight main-ref validation is recorded as non-blocking.