### PR TITLE
fix: keep plugin candidate tags within OCI limit

### DIFF
--- a/.github/workflows/prepare-plugin-release.yaml
+++ b/.github/workflows/prepare-plugin-release.yaml
@@ -233,7 +233,9 @@ jobs:
             [[ "$source" = "plugins/wasm-$implementation/extensions/$build_name" ]]
             if [ "$implementation" = go ]; then (cd "$source" && go test ./...); make -C plugins/wasm-go PLUGIN_NAME="$build_name" build; else make -C plugins/wasm-rust PLUGIN_NAME="$build_name" test build; fi
             wasm="$source/plugin.wasm"; test -s "$wasm"
-            candidate="$CANDIDATE_REGISTRY/candidates/$id:$plan_id-${input_hash#sha256:}"
+            # Both hashes are fixed-width SHA-256 hex strings, so concatenation
+            # retains their complete identities while meeting OCI's 128-byte tag limit.
+            candidate="$CANDIDATE_REGISTRY/candidates/$id:${plan_id}${input_hash#sha256:}"
             digest=$(oras push "$candidate" "$wasm:application/vnd.module.wasm.content.layer.v1+wasm" --annotation "org.opencontainers.image.revision=$(git rev-parse HEAD)" --annotation "org.opencontainers.image.version=$version" --annotation "io.higress.plugin.input-hash=$input_hash" --format json | jq -r .digest)
             jq --arg id "$id" --arg ref "${candidate%@*}@$digest" --arg digest "$digest" --arg commit "$(git rev-parse HEAD)" --arg hash "$input_hash" '.plugins[$id]={candidateRef:$ref,digest:$digest,sourceCommit:$commit,inputHash:$hash}' /tmp/candidates.json >/tmp/candidates.next && mv /tmp/candidates.next /tmp/candidates.json
           done

--- a/tools/plugin-release/plugin_server_workflow_contract_test.go
+++ b/tools/plugin-release/plugin_server_workflow_contract_test.go
@@ -6,6 +6,7 @@ package main
 import (
 	"os"
 	"os/exec"
+	"regexp"
 	"strings"
 	"testing"
 )
@@ -181,6 +182,55 @@ func TestPreparationBootstrapPlansFromExactHistoricalBase(t *testing.T) {
 		if strings.Contains(workflow, forbidden) {
 			t.Fatalf("preparation bootstrap retains unsafe/empty-plan contract %q", forbidden)
 		}
+	}
+}
+
+func TestPreparationCandidateTagRetainsFullHashesWithinOCILimit(t *testing.T) {
+	data, err := os.ReadFile("../../.github/workflows/prepare-plugin-release.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var candidateAssignment string
+	for _, line := range strings.Split(string(data), "\n") {
+		if strings.Contains(line, `candidate="$CANDIDATE_REGISTRY/candidates/$id:`) {
+			if candidateAssignment != "" {
+				t.Fatal("preparation workflow constructs the candidate reference more than once")
+			}
+			candidateAssignment = strings.TrimSpace(line)
+		}
+	}
+	if candidateAssignment == "" {
+		t.Fatal("preparation workflow lacks the candidate reference construction")
+	}
+
+	planHash := strings.Repeat("ab", 32)
+	inputHash := strings.Repeat("cd", 32)
+	script := candidateAssignment + `; printf '%s' "${candidate##*:}"`
+	bash, err := exec.LookPath("bash")
+	if err != nil {
+		t.Fatal("bash is required to execute the candidate tag construction")
+	}
+	cmd := exec.Command(bash, "-euo", "pipefail", "-c", script)
+	cmd.Env = []string{
+		"CANDIDATE_REGISTRY=registry.example.invalid:5000",
+		"id=example-plugin",
+		"plan_id=" + planHash,
+		"input_hash=sha256:" + inputHash,
+	}
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("candidate tag construction failed: %v\n%s", err, output)
+	}
+	tag := string(output)
+	if want := planHash + inputHash; tag != want {
+		t.Fatalf("candidate tag must retain the complete plan and input hashes: got %q, want %q", tag, want)
+	}
+	if len(tag) > 128 {
+		t.Fatalf("candidate tag is %d bytes, exceeding the OCI 128-byte limit", len(tag))
+	}
+	if !regexp.MustCompile(`^[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}$`).MatchString(tag) {
+		t.Fatalf("candidate tag %q does not match the OCI tag grammar", tag)
 	}
 }
 


### PR DESCRIPTION
## I. Summary

Fix immutable plugin release candidate references so the complete plan SHA-256 and input SHA-256 fit the OCI/Docker 128-character tag limit. The two fixed-width 64-hex hashes are concatenated without a separator, preserving lossless and unambiguous identity. An executable workflow contract now guards the exact assignment, full-hash retention, length limit, and tag grammar.

Compatibility impact: candidate references generated by the failed, pre-release workflow were never valid or uploaded. Candidate references are opaque and no downstream parser depends on the removed separator.

## II. Related issue

Related to #4022 and #4442. This PR implements [TASK-4442017](https://github.com/higress-group/higress/issues/4442#issuecomment-5280117532); code-level verification is tracked by [TASK-4442018](https://github.com/higress-group/higress/issues/4442#issuecomment-5280132567), and the post-merge 2.2.4 formal rehearsal remains in TASK-4442005.

## III. Change type

- [x] Bug fix
- [ ] Feature or enhancement
- [ ] Documentation or configuration only
- [x] Refactoring, tests, or maintenance

## IV. Agent participation and issue-spec gate

- [ ] **No agent participation:** This PR is human-only.
- [ ] **Trivial agent-use exception:** Agent use was limited to spelling, punctuation, whitespace, or formatting with no substantive choice or behavioral effect.
- [ ] **Verified maintainer/administrator exception:** Material agent participation occurred under the verified exception.
- [x] **Material agent participation:** An AI or coding agent materially participated in analysis, implementation, testing, review, and PR preparation.

- [x] **Before implementation began:** A Higress maintainer had approved the Proposal and Design Issues, and authorized implementation TASKs linked the work to the applicable SPECs.
- [x] **Before verification began:** The Design contained a concrete Verification Plan.
- [x] **Before requesting maintainer review or acceptance:** Applicable implementation and verification TASKs were completed with exact commands, results, evidence links, and hashes before this draft is moved to ready.

- [x] Complete: all three timed obligations above were satisfied.
- [ ] Noncompliant: one or more obligations were not satisfied.
- [ ] Verified exception: material agent participation used the verified-maintainer/administrator exception.
- [ ] N/A because the PR is human-only or qualifies for the trivial exception.

**Gate-status explanation (or N/A):** Approved Proposal #4022 and Design #4442 authorize the immutable candidate workflow. TASK-4442017 is the bounded implementation repair and TASK-4442018 records exact-head code-level verification; TASK-4442005 owns the post-merge protected-registry rehearsal.

**Trivial-exception explanation (or N/A):** N/A; material agent participation is declared.

**Verified maintainer/administrator exception evidence (or N/A):** N/A; this PR follows the approved Proposal/Design/TASK path and does not use the exception.

**Approved Proposal Issue URL (or N/A with explanation):** https://github.com/higress-group/higress/issues/4022

**Approved Design Issue URL (or N/A with explanation):** https://github.com/higress-group/higress/issues/4442

**Maintainer approval link(s) (or N/A with explanation):** Maintainer approvals and subsequent Design resolution are recorded in #4022 and #4442; notably https://github.com/higress-group/higress/issues/4442#issuecomment-5276528470.

**Authorized implementation TASK link(s) (or N/A with explanation):** https://github.com/higress-group/higress/issues/4442#issuecomment-5280117532

**Verification Plan and verification TASK/evidence link(s) (or N/A with explanation):** Design Verification Plan: https://github.com/higress-group/higress/issues/4442; focused verification: https://github.com/higress-group/higress/issues/4442#issuecomment-5280132567; post-merge rehearsal: https://github.com/higress-group/higress/issues/4442#issuecomment-5255965383.

## V. Testing and verification

**Test and deterministic rerun commands (or N/A with explanation):**

```text
cd tools/plugin-release && go test ./... -run '^TestPreparationCandidateTagRetainsFullHashesWithinOCILimit$' -count=1
cd tools/plugin-release && go test ./... -count=1
cd tools/plugin-release && go vet ./...
cd tools/plugin-release && go run . validate-catalog --root ../.. --catalog ../../plugins/release/catalog.json
go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 .github/workflows/prepare-plugin-release.yaml
git diff --check 84111de54e0f03ea88a8ba499512f6a57486e049..a1473bed166042042c20b64d579263a128240bc2
go run oras.land/oras/cmd/oras@v1.2.3 manifest fetch <recorded-invalid-reference> --descriptor
```

All positive commands passed. The final baseline command failed locally before network access with the same `invalid tag` error as run 31697151078, as expected.

**Environment and configuration (or N/A with explanation):** Linux x86_64; Go 1.26.0; jq 1.6; actionlint 1.7.7; ORAS command built from v1.2.3. No registry credential was used for PR-head verification.

**Exact tested revision, version, image tag/digest, manifests, and values (or N/A with explanation):** Base `84111de54e0f03ea88a8ba499512f6a57486e049`; head `a1473bed166042042c20b64d579263a128240bc2`; gateway plan remains 2.2.4 plan ID `sha256:188f3400bc1f8fb73454c6b3361df9483fe02d47bc331f50b86b6b7cbe4508ac`. No candidate was uploaded by the failed run.

**Baseline reproduction evidence for bug fixes (or N/A with explanation):** Formal run https://github.com/higress-group/higress/actions/runs/31697151078 failed on the first `ai-agent` candidate: 64-hex plan ID + hyphen + 64-hex input hash produced a 129-character invalid tag. The plugin test and WASM build had succeeded immediately before ORAS rejected the reference.

**Fixed-version verification evidence for bug fixes (or N/A with explanation):** The new contract executes the exact workflow assignment and proves the result equals both complete 64-hex hashes concatenated, is exactly 128 characters, and matches the OCI tag grammar. Full tests, vet, catalog validation, actionlint, diff check, and independent review passed. A protected live registry push is intentionally deferred until this PR merges and is tracked by TASK-4442005.

**Wasm source revision and SHA-256 (or N/A with explanation):** N/A; this PR changes release orchestration only and creates no WASM artifact.

## VI. Special notes for reviewers

Review focus: the missing separator is intentional. Because each component is a fixed-width 64-hex SHA-256, the boundary remains unambiguous while retaining all 256 bits of each identity. Candidate references are stored and consumed opaquely by digest. Independent exact-head review reported P0=0, P1=0, P2=0.

### Implementation Rationale

The candidate assignment in `.github/workflows/prepare-plugin-release.yaml` omits the former separator because OCI permits at most 128 tag characters. Two complete SHA-256 values consume all 128 characters; their fixed 64-character widths preserve deterministic, lossless plan/input identity without parsing ambiguity. The post-merge formal workflow is the remaining live-registry check and is deliberately outside this PR-head verification.

## VII. AI coding disclosure

**Tool(s) used (or N/A):** OpenAI Codex with an isolated implementation worker and an independent read-only reviewer.

### Prompts or instructions

The maintainer asked Codex to execute the approved 2.2.4 formal preparation. After run 31697151078 exposed the 129-character tag defect, the implementation worker was instructed to preserve the complete plan and input hashes within the OCI 128-character limit, add an executable regression contract for the actual workflow expression, limit changes to the workflow and existing contract-test file, run the specified checks, and commit with DCO sign-off. The independent reviewer was instructed to review the exact base/head read-only and report only P0/P1/P2 findings. No credentials or secrets were included.

### AI-assisted work summary

Codex diagnosed the live workflow failure, created issue-spec implementation and verification TASKs, delegated the bounded code change to one writer, independently reproduced the ORAS boundary failure, reran all checks, and obtained an independent exact-head review with zero findings. The repair removes one separator, retains both full hashes, and adds a contract test that prevents length, syntax, or identity regressions.
