### PR TITLE
fix: make plugin preparation retries idempotent

### DIFF
--- a/.github/workflows/prepare-plugin-release.yaml
+++ b/.github/workflows/prepare-plugin-release.yaml
@@ -285,7 +285,7 @@ jobs:
               echo "candidate lookup authorization failure is never absence: $candidate" >&2
               return 1
             fi
-            if grep -Eiq '(^|[^[:digit:]])404([^[:digit:]]|$)|manifest unknown|name unknown' "$lookup_error" ||
+            if grep -Eiq 'HTTP(/[0-9.]+)?[[:space:]]+404([^[:digit:]]|$)|response status( code)?[[:space:]:=]+404([^[:digit:]]|$)|status code[[:space:]:=]+404([^[:digit:]]|$)|404[[:space:]]+Not[[:space:]]+Found|manifest unknown|name unknown' "$lookup_error" ||
                { grep -Fq 'Error response from registry:' "$lookup_error" && grep -Fq "$candidate: not found" "$lookup_error"; }; then
               rm -f "$lookup_error"
             else

--- a/.github/workflows/prepare-plugin-release.yaml
+++ b/.github/workflows/prepare-plugin-release.yaml
@@ -224,20 +224,101 @@ jobs:
           set -euo pipefail
           test -n "$CANDIDATE_REGISTRY"; test -n "$REGISTRY_USERNAME"; test -n "$REGISTRY_PASSWORD"
           echo "$REGISTRY_PASSWORD" | oras login "$CANDIDATE_REGISTRY" -u "$REGISTRY_USERNAME" --password-stdin
+          # BEGIN plugin-build-contract
+          prepare_test_and_build_plugin() {
+            local implementation=$1 source=$2 build_name=$3
+            case "$implementation" in
+              go)
+                if [ -f "$source/prepare.sh" ]; then (cd "$source" && sh ./prepare.sh); fi
+                (cd "$source" && go test ./...)
+                make -C plugins/wasm-go PLUGIN_NAME="$build_name" build
+                ;;
+              rust)
+                make -C plugins/wasm-rust PLUGIN_NAME="$build_name" test build
+                ;;
+              *) echo "unsupported planned implementation: $implementation" >&2; return 1 ;;
+            esac
+          }
+          # END plugin-build-contract
+          # BEGIN candidate-publish-contract
+          publish_or_reuse_candidate() {
+            local candidate=$1 wasm=$2 source_commit=$3 version=$4 input_hash=$5
+            local candidate_repo descriptor manifest resolved_digest push_result lookup_error wasm_digest
+            [[ "$source_commit" =~ ^[0-9a-f]{40}$ ]]
+            [[ "$version" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]
+            [[ "$input_hash" =~ ^sha256:[0-9a-f]{64}$ ]]
+            test -s "$wasm"
+            wasm_digest="sha256:$(sha256sum "$wasm" | awk '{print $1}')"
+            candidate_repo=${candidate%:*}
+            lookup_error=$(mktemp)
+            if descriptor=$(oras manifest fetch "$candidate" --descriptor 2>"$lookup_error"); then
+              rm -f "$lookup_error"
+              if ! resolved_digest=$(jq -er '
+                select(.mediaType == "application/vnd.oci.image.manifest.v1+json")
+                | .digest | strings | select(test("^sha256:[0-9a-f]{64}$"))
+              ' <<<"$descriptor"); then
+                echo "existing candidate descriptor is malformed: $candidate" >&2
+                return 1
+              fi
+              if ! manifest=$(oras manifest fetch "$candidate_repo@$resolved_digest"); then
+                echo "existing candidate manifest cannot be resolved by digest: $candidate_repo@$resolved_digest" >&2
+                return 1
+              fi
+              if ! jq -e --arg commit "$source_commit" --arg version "$version" --arg input_hash "$input_hash" --arg wasm_digest "$wasm_digest" '
+                .schemaVersion == 2 and
+                .mediaType == "application/vnd.oci.image.manifest.v1+json" and
+                (.annotations["org.opencontainers.image.revision"] == $commit) and
+                (.annotations["org.opencontainers.image.version"] == $version) and
+                (.annotations["io.higress.plugin.input-hash"] == $input_hash) and
+                (.layers | length == 1) and
+                (.layers[0].mediaType == "application/vnd.module.wasm.content.layer.v1+wasm") and
+                (.layers[0].digest == $wasm_digest)
+              ' >/dev/null <<<"$manifest"; then
+                echo "existing candidate does not match the locally rebuilt artifact: $candidate" >&2
+                return 1
+              fi
+              printf '%s\n' "$resolved_digest"
+              return 0
+            fi
+            if grep -Eiq '401|403|unauthorized|forbidden|denied|authentication required|authorization required' "$lookup_error"; then
+              cat "$lookup_error" >&2; rm -f "$lookup_error"
+              echo "candidate lookup authorization failure is never absence: $candidate" >&2
+              return 1
+            fi
+            if grep -Eiq '(^|[^[:digit:]])404([^[:digit:]]|$)|manifest unknown|name unknown' "$lookup_error" ||
+               { grep -Fq 'Error response from registry:' "$lookup_error" && grep -Fq "$candidate: not found" "$lookup_error"; }; then
+              rm -f "$lookup_error"
+            else
+              cat "$lookup_error" >&2; rm -f "$lookup_error"
+              echo "candidate lookup failed without explicit absence evidence: $candidate" >&2
+              return 1
+            fi
+            if ! push_result=$(oras push "$candidate" "$wasm:application/vnd.module.wasm.content.layer.v1+wasm" --annotation "org.opencontainers.image.revision=$source_commit" --annotation "org.opencontainers.image.version=$version" --annotation "io.higress.plugin.input-hash=$input_hash" --format json); then
+              echo "candidate push failed: $candidate" >&2
+              return 1
+            fi
+            if ! resolved_digest=$(jq -er '.digest | strings | select(test("^sha256:[0-9a-f]{64}$"))' <<<"$push_result"); then
+              echo "candidate push returned a malformed descriptor: $candidate" >&2
+              return 1
+            fi
+            printf '%s\n' "$resolved_digest"
+          }
+          # END candidate-publish-contract
           jq -n '{plugins:{}}' >/tmp/candidates.json
           plan_id=$(jq -r '.planId | sub("sha256:"; "")' /tmp/plan.json)
+          source_commit=$(git rev-parse HEAD)
           jq -c '.plugins[]' /tmp/plan.json | while read -r entry; do
             id=$(jq -r .logicalId <<<"$entry"); implementation=$(jq -r .implementation <<<"$entry")
             source=$(jq -r .sourceDir <<<"$entry"); version=$(jq -r .version <<<"$entry"); input_hash=$(jq -r .inputHash <<<"$entry")
             build_name=$(basename "$source")
             [[ "$source" = "plugins/wasm-$implementation/extensions/$build_name" ]]
-            if [ "$implementation" = go ]; then (cd "$source" && go test ./...); make -C plugins/wasm-go PLUGIN_NAME="$build_name" build; else make -C plugins/wasm-rust PLUGIN_NAME="$build_name" test build; fi
+            prepare_test_and_build_plugin "$implementation" "$source" "$build_name"
             wasm="$source/plugin.wasm"; test -s "$wasm"
             # Both hashes are fixed-width SHA-256 hex strings, so concatenation
             # retains their complete identities while meeting OCI's 128-byte tag limit.
             candidate="$CANDIDATE_REGISTRY/candidates/$id:${plan_id}${input_hash#sha256:}"
-            digest=$(oras push "$candidate" "$wasm:application/vnd.module.wasm.content.layer.v1+wasm" --annotation "org.opencontainers.image.revision=$(git rev-parse HEAD)" --annotation "org.opencontainers.image.version=$version" --annotation "io.higress.plugin.input-hash=$input_hash" --format json | jq -r .digest)
-            jq --arg id "$id" --arg ref "${candidate%@*}@$digest" --arg digest "$digest" --arg commit "$(git rev-parse HEAD)" --arg hash "$input_hash" '.plugins[$id]={candidateRef:$ref,digest:$digest,sourceCommit:$commit,inputHash:$hash}' /tmp/candidates.json >/tmp/candidates.next && mv /tmp/candidates.next /tmp/candidates.json
+            digest=$(publish_or_reuse_candidate "$candidate" "$wasm" "$source_commit" "$version" "$input_hash")
+            jq --arg id "$id" --arg ref "${candidate%@*}@$digest" --arg digest "$digest" --arg commit "$source_commit" --arg hash "$input_hash" '.plugins[$id]={candidateRef:$ref,digest:$digest,sourceCommit:$commit,inputHash:$hash}' /tmp/candidates.json >/tmp/candidates.next && mv /tmp/candidates.next /tmp/candidates.json
           done
           cp /tmp/candidates.json "plugins/release/evidence/$GATEWAY_VERSION.json"
       - name: Render canonical snapshot

--- a/.github/workflows/validate-plugin-preparation-pr.yaml
+++ b/.github/workflows/validate-plugin-preparation-pr.yaml
@@ -86,20 +86,27 @@ jobs:
           set -euo pipefail
           test -s /tmp/changed-snapshots || exit 0
           test -f /tmp/planned-artifacts || exit 0
+          # BEGIN plugin-build-contract
+          prepare_test_and_build_plugin() {
+            local implementation=$1 source=$2 build_name=$3
+            case "$implementation" in
+              go)
+                if [ -f "$source/prepare.sh" ]; then (cd "$source" && sh ./prepare.sh); fi
+                (cd "$source" && go test ./...)
+                make -C plugins/wasm-go PLUGIN_NAME="$build_name" build
+                ;;
+              rust)
+                make -C plugins/wasm-rust PLUGIN_NAME="$build_name" test build
+                ;;
+              *) echo "unsupported planned implementation: $implementation" >&2; return 1 ;;
+            esac
+          }
+          # END plugin-build-contract
           sort -u /tmp/planned-artifacts | while read -r entry; do
             implementation=$(jq -r .implementation <<<"$entry")
             source=$(jq -r .sourceDir <<<"$entry")
             name=$(basename "$source")
             [[ "$source" = "plugins/wasm-$implementation/extensions/$name" ]]
-            case "$implementation" in
-              go)
-                (cd "$source" && go test ./...)
-                make -C plugins/wasm-go PLUGIN_NAME="$name" build
-                ;;
-              rust)
-                make -C plugins/wasm-rust PLUGIN_NAME="$name" test build
-                ;;
-              *) echo "unsupported planned implementation: $implementation" >&2; exit 1 ;;
-            esac
+            prepare_test_and_build_plugin "$implementation" "$source" "$name"
             test -s "$source/plugin.wasm"
           done

--- a/tools/plugin-release/plugin_server_workflow_contract_test.go
+++ b/tools/plugin-release/plugin_server_workflow_contract_test.go
@@ -335,6 +335,11 @@ type candidateContractResult struct {
 
 func runCandidatePublishContract(t *testing.T, mode string) candidateContractResult {
 	t.Helper()
+	return runCandidatePublishContractWithCandidate(t, mode, "registry.example.invalid:5000/candidates/demo:plan-and-input-hash")
+}
+
+func runCandidatePublishContractWithCandidate(t *testing.T, mode, candidate string) candidateContractResult {
+	t.Helper()
 	tmp := t.TempDir()
 	bin := filepath.Join(tmp, "bin")
 	if err := os.MkdirAll(bin, 0o755); err != nil {
@@ -354,7 +359,7 @@ if [ "$1 $2" = "manifest fetch" ]; then
   ref=$3
   if [ "${4:-}" = "--descriptor" ]; then
     case "$ORAS_MODE" in
-      absent-404) echo "404 manifest lookup failed" >&2; exit 1 ;;
+      absent-404) echo "response status code 404: Not Found" >&2; exit 1 ;;
       absent-manifest) echo "MANIFEST UNKNOWN" >&2; exit 1 ;;
       absent-name) echo "name unknown" >&2; exit 1 ;;
       absent-acr) echo "Error response from registry: $ref: not found" >&2; exit 1 ;;
@@ -363,6 +368,7 @@ if [ "$1 $2" = "manifest fetch" ]; then
       repository-missing) echo "repository does not exist" >&2; exit 1 ;;
       wrong-acr-ref) echo "Error response from registry: registry.example.invalid/candidates/other: not found" >&2; exit 1 ;;
       transport) echo "dial tcp: i/o timeout" >&2; exit 1 ;;
+      transport-with-ref) echo "transport error while resolving $ref: dial tcp: i/o timeout" >&2; exit 1 ;;
       malformed-descriptor) echo '{'; exit 0 ;;
       wrong-descriptor-media) printf '{"mediaType":"application/example","digest":"%s"}\n' "$ORAS_MANIFEST_DIGEST"; exit 0 ;;
       *) printf '{"mediaType":"application/vnd.oci.image.manifest.v1+json","digest":"%s"}\n' "$ORAS_MANIFEST_DIGEST"; exit 0 ;;
@@ -399,7 +405,6 @@ exit 2
 	const inputHash = "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
 	const manifestDigest = "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
 	const pushDigest = "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
-	const candidate = "registry.example.invalid:5000/candidates/demo:plan-and-input-hash"
 	contract := workflowShellContract(t, "prepare-plugin-release.yaml", "candidate-publish-contract")
 	script := "set -euo pipefail\n" + contract + fmt.Sprintf("\npublish_or_reuse_candidate %q %q %q 1.2.3 %q\n", candidate, wasm, sourceCommit, inputHash)
 	cmd := exec.Command("bash", "-c", script)
@@ -473,6 +478,17 @@ func TestPreparationCandidateLookupAndManifestMismatchesFailWithoutMutation(t *t
 				t.Fatalf("unsafe candidate state %s caused mutation:\n%s", mode, result.log)
 			}
 		})
+	}
+}
+
+func TestPreparationDoesNotReadEmbedded404FromRealCandidateTagAsHTTPAbsence(t *testing.T) {
+	const aiProxyCandidate = "higress-registry.cn-hangzhou.cr.aliyuncs.com/candidates/ai-proxy:b0776c63af093544e840df5c88187a658767e51f7b0b424aca802bbcb531b351fc42f8a92ee198eacb59689be844cbeb00dab79b359b583cb404f4106fef5cee"
+	result := runCandidatePublishContractWithCandidate(t, "transport-with-ref", aiProxyCandidate)
+	if result.err == nil {
+		t.Fatalf("transport error containing the ai-proxy tag's embedded 404 was accepted: %s", result.output)
+	}
+	if strings.Contains(result.log, "push ") {
+		t.Fatalf("transport error containing the ai-proxy tag's embedded 404 caused a push:\n%s", result.log)
 	}
 }
 

--- a/tools/plugin-release/plugin_server_workflow_contract_test.go
+++ b/tools/plugin-release/plugin_server_workflow_contract_test.go
@@ -4,8 +4,11 @@
 package main
 
 import (
+	"crypto/sha256"
+	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"testing"
@@ -231,6 +234,245 @@ func TestPreparationCandidateTagRetainsFullHashesWithinOCILimit(t *testing.T) {
 	}
 	if !regexp.MustCompile(`^[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}$`).MatchString(tag) {
 		t.Fatalf("candidate tag %q does not match the OCI tag grammar", tag)
+	}
+}
+
+func workflowShellContract(t *testing.T, workflowName, contractName string) string {
+	t.Helper()
+	data, err := os.ReadFile("../../.github/workflows/" + workflowName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	begin := "# BEGIN " + contractName
+	end := "# END " + contractName
+	start := strings.Index(string(data), begin)
+	finish := strings.Index(string(data), end)
+	if start < 0 || finish < 0 || start >= finish {
+		t.Fatalf("%s lacks executable shell contract %s", workflowName, contractName)
+	}
+	start += len(begin)
+	return string(data)[start:finish]
+}
+
+func writeExecutableFixture(t *testing.T, path, contents string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(contents), 0o700); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestPreparationRunsOptionalGoSetupBeforeTestsAndBuild(t *testing.T) {
+	workflows := []string{"prepare-plugin-release.yaml", "validate-plugin-preparation-pr.yaml"}
+	var canonical string
+	for _, workflow := range workflows {
+		t.Run(workflow, func(t *testing.T) {
+			contract := workflowShellContract(t, workflow, "plugin-build-contract")
+			if canonical == "" {
+				canonical = contract
+			} else if contract != canonical {
+				t.Fatal("formal preparation and credential-free PR rebuild must execute the same plugin build contract")
+			}
+
+			tmp := t.TempDir()
+			source := filepath.Join(tmp, "plugin")
+			bin := filepath.Join(tmp, "bin")
+			if err := os.MkdirAll(source, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.MkdirAll(bin, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			log := filepath.Join(tmp, "build.log")
+			writeExecutableFixture(t, filepath.Join(source, "prepare.sh"), `#!/bin/sh
+set -eu
+printf 'prepare\n' >> "$BUILD_LOG"
+`)
+			writeExecutableFixture(t, filepath.Join(bin, "go"), `#!/bin/sh
+set -eu
+printf 'test:%s\n' "$*" >> "$BUILD_LOG"
+`)
+			writeExecutableFixture(t, filepath.Join(bin, "make"), `#!/bin/sh
+set -eu
+printf 'build:%s\n' "$*" >> "$BUILD_LOG"
+`)
+			script := "set -euo pipefail\n" + contract + fmt.Sprintf("\nprepare_test_and_build_plugin go %q demo\n", source)
+			cmd := exec.Command("bash", "-c", script)
+			cmd.Env = append(os.Environ(), "PATH="+bin+":"+os.Getenv("PATH"), "BUILD_LOG="+log)
+			if output, err := cmd.CombinedOutput(); err != nil {
+				t.Fatalf("extracted workflow build contract failed: %v\n%s", err, output)
+			}
+			got, err := os.ReadFile(log)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(got) != "prepare\ntest:test ./...\nbuild:-C plugins/wasm-go PLUGIN_NAME=demo build\n" {
+				t.Fatalf("optional setup/test/build order = %q", got)
+			}
+
+			if err := os.WriteFile(filepath.Join(source, "prepare.sh"), []byte("#!/bin/sh\nexit 23\n"), 0o700); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(log, nil, 0o600); err != nil {
+				t.Fatal(err)
+			}
+			cmd = exec.Command("bash", "-c", script)
+			cmd.Env = append(os.Environ(), "PATH="+bin+":"+os.Getenv("PATH"), "BUILD_LOG="+log)
+			if output, err := cmd.CombinedOutput(); err == nil {
+				t.Fatalf("failed optional setup did not stop the workflow contract: %s", output)
+			}
+			if got, err := os.ReadFile(log); err != nil || len(got) != 0 {
+				t.Fatalf("test/build ran after failed optional setup: %q, %v", got, err)
+			}
+		})
+	}
+}
+
+type candidateContractResult struct {
+	output string
+	log    string
+	err    error
+}
+
+func runCandidatePublishContract(t *testing.T, mode string) candidateContractResult {
+	t.Helper()
+	tmp := t.TempDir()
+	bin := filepath.Join(tmp, "bin")
+	if err := os.MkdirAll(bin, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	log := filepath.Join(tmp, "oras.log")
+	wasm := filepath.Join(tmp, "plugin.wasm")
+	wasmBytes := []byte("deterministic wasm fixture")
+	if err := os.WriteFile(wasm, wasmBytes, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	wasmSum := sha256.Sum256(wasmBytes)
+	writeExecutableFixture(t, filepath.Join(bin, "oras"), `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "$ORAS_LOG"
+if [ "$1 $2" = "manifest fetch" ]; then
+  ref=$3
+  if [ "${4:-}" = "--descriptor" ]; then
+    case "$ORAS_MODE" in
+      absent-404) echo "404 manifest lookup failed" >&2; exit 1 ;;
+      absent-manifest) echo "MANIFEST UNKNOWN" >&2; exit 1 ;;
+      absent-name) echo "name unknown" >&2; exit 1 ;;
+      absent-acr) echo "Error response from registry: $ref: not found" >&2; exit 1 ;;
+      auth) echo "401 unauthorized" >&2; exit 1 ;;
+      ambiguous) echo "not found" >&2; exit 1 ;;
+      repository-missing) echo "repository does not exist" >&2; exit 1 ;;
+      wrong-acr-ref) echo "Error response from registry: registry.example.invalid/candidates/other: not found" >&2; exit 1 ;;
+      transport) echo "dial tcp: i/o timeout" >&2; exit 1 ;;
+      malformed-descriptor) echo '{'; exit 0 ;;
+      wrong-descriptor-media) printf '{"mediaType":"application/example","digest":"%s"}\n' "$ORAS_MANIFEST_DIGEST"; exit 0 ;;
+      *) printf '{"mediaType":"application/vnd.oci.image.manifest.v1+json","digest":"%s"}\n' "$ORAS_MANIFEST_DIGEST"; exit 0 ;;
+    esac
+  fi
+  case "$ORAS_MODE" in
+    manifest-error) echo "registry unavailable" >&2; exit 1 ;;
+    malformed-manifest) echo '{'; exit 0 ;;
+  esac
+  revision=$SOURCE_COMMIT
+  version=$STABLE_VERSION
+  input_hash=$INPUT_HASH
+  layer_digest=$WASM_DIGEST
+  layer_media=application/vnd.module.wasm.content.layer.v1+wasm
+  layers=''
+  case "$ORAS_MODE" in
+    annotation-mismatch) revision=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb ;;
+    layer-digest-mismatch) layer_digest=sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee ;;
+    layer-media-mismatch) layer_media=application/octet-stream ;;
+    layer-count-mismatch) layers=',{"mediaType":"application/vnd.module.wasm.content.layer.v1+wasm","digest":"sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"}' ;;
+  esac
+  printf '{"schemaVersion":2,"mediaType":"application/vnd.oci.image.manifest.v1+json","annotations":{"org.opencontainers.image.revision":"%s","org.opencontainers.image.version":"%s","io.higress.plugin.input-hash":"%s"},"layers":[{"mediaType":"%s","digest":"%s"}%s]}\n' "$revision" "$version" "$input_hash" "$layer_media" "$layer_digest" "$layers"
+  exit 0
+fi
+if [ "$1" = push ]; then
+  printf '{"digest":"%s"}\n' "$ORAS_PUSH_DIGEST"
+  exit 0
+fi
+echo "unexpected fake oras invocation: $*" >&2
+exit 2
+`)
+
+	const sourceCommit = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	const inputHash = "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	const manifestDigest = "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+	const pushDigest = "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+	const candidate = "registry.example.invalid:5000/candidates/demo:plan-and-input-hash"
+	contract := workflowShellContract(t, "prepare-plugin-release.yaml", "candidate-publish-contract")
+	script := "set -euo pipefail\n" + contract + fmt.Sprintf("\npublish_or_reuse_candidate %q %q %q 1.2.3 %q\n", candidate, wasm, sourceCommit, inputHash)
+	cmd := exec.Command("bash", "-c", script)
+	cmd.Env = append(os.Environ(),
+		"PATH="+bin+":"+os.Getenv("PATH"),
+		"ORAS_LOG="+log,
+		"ORAS_MODE="+mode,
+		"ORAS_MANIFEST_DIGEST="+manifestDigest,
+		"ORAS_PUSH_DIGEST="+pushDigest,
+		"SOURCE_COMMIT="+sourceCommit,
+		"STABLE_VERSION=1.2.3",
+		"INPUT_HASH="+inputHash,
+		fmt.Sprintf("WASM_DIGEST=sha256:%x", wasmSum),
+	)
+	output, runErr := cmd.CombinedOutput()
+	logBytes, readErr := os.ReadFile(log)
+	if readErr != nil && !os.IsNotExist(readErr) {
+		t.Fatal(readErr)
+	}
+	return candidateContractResult{output: string(output), log: string(logBytes), err: runErr}
+}
+
+func TestPreparationReusesOnlyIdenticalContentAddressedCandidate(t *testing.T) {
+	result := runCandidatePublishContract(t, "identical")
+	if result.err != nil {
+		t.Fatalf("identical candidate was not reused: %v\n%s", result.err, result.output)
+	}
+	want := "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc\n"
+	if result.output != want {
+		t.Fatalf("reused candidate digest = %q, want %q", result.output, want)
+	}
+	if strings.Contains(result.log, "push ") {
+		t.Fatalf("identical candidate was pushed again:\n%s", result.log)
+	}
+	if strings.Count(result.log, "manifest fetch ") != 2 || !strings.Contains(result.log, "@sha256:") {
+		t.Fatalf("reuse did not resolve descriptor then immutable manifest digest:\n%s", result.log)
+	}
+}
+
+func TestPreparationPushesOnceOnlyForStrictlyProvenCandidateAbsence(t *testing.T) {
+	for _, mode := range []string{"absent-404", "absent-manifest", "absent-name", "absent-acr"} {
+		t.Run(mode, func(t *testing.T) {
+			result := runCandidatePublishContract(t, mode)
+			if result.err != nil {
+				t.Fatalf("strict absence was not published: %v\n%s", result.err, result.output)
+			}
+			want := "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd\n"
+			if result.output != want {
+				t.Fatalf("new candidate digest = %q, want %q", result.output, want)
+			}
+			if strings.Count(result.log, "push ") != 1 {
+				t.Fatalf("strict absence performed other than one push:\n%s", result.log)
+			}
+		})
+	}
+}
+
+func TestPreparationCandidateLookupAndManifestMismatchesFailWithoutMutation(t *testing.T) {
+	modes := []string{
+		"auth", "ambiguous", "repository-missing", "wrong-acr-ref", "transport", "malformed-descriptor", "wrong-descriptor-media",
+		"manifest-error", "malformed-manifest", "annotation-mismatch", "layer-count-mismatch",
+		"layer-media-mismatch", "layer-digest-mismatch",
+	}
+	for _, mode := range modes {
+		t.Run(mode, func(t *testing.T) {
+			result := runCandidatePublishContract(t, mode)
+			if result.err == nil {
+				t.Fatalf("unsafe candidate state %s was accepted: %s", mode, result.output)
+			}
+			if strings.Contains(result.log, "push ") {
+				t.Fatalf("unsafe candidate state %s caused mutation:\n%s", mode, result.log)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## I. Summary

Make immutable plugin preparation restartable after a partial candidate batch and align Go plugin setup across formal preparation and snapshot-PR validation.

- Run an official Go plugin's optional `prepare.sh` before `go test ./...` and build. This fixes the clean-runner failure where `ai-context-limit` could not embed its generated BPE vocabulary.
- Rebuild every selected plugin before registry lookup, then reuse an existing immutable candidate only after its descriptor, digest-resolved manifest, provenance annotations, unique WASM layer, and locally rebuilt WASM digest match exactly.
- Push only after strict absence evidence. Authorization, transport, generic errors, malformed metadata, provenance mismatch, or byte mismatch fail without mutation.
- Add executable contracts that extract and run the workflow's actual shell functions for setup ordering, identical reuse, strict absence, and fail-closed negative cases.

Compatibility impact: no public plugin tag or downstream default changes. Candidate references remain content-addressed and opaque.

## II. Related issue

Related to #4022 and #4442. This PR implements [TASK-4442019](https://github.com/higress-group/higress/issues/4442#issuecomment-5280544511); exact-head verification is tracked by [TASK-4442020](https://github.com/higress-group/higress/issues/4442#issuecomment-5280544950). TASK-4442005 continues to own the protected post-merge 2.2.4 release rehearsal.

## III. Change type

- [x] Bug fix
- [ ] Feature or enhancement
- [ ] Documentation or configuration only
- [x] Refactoring, tests, or maintenance

## IV. Agent participation and issue-spec gate

- [ ] **No agent participation:** This PR is human-only.
- [ ] **Trivial agent-use exception:** Agent use was limited to spelling, punctuation, whitespace, or formatting with no substantive choice or behavioral effect.
- [ ] **Verified maintainer/administrator exception:** Material agent participation occurred under the verified exception.
- [x] **Material agent participation:** An AI or coding agent materially participated in analysis, implementation, testing, review, and PR preparation.

- [x] **Before implementation began:** A Higress maintainer had approved the Proposal and Design Issues, and authorized implementation TASKs linked the work to the applicable SPECs.
- [x] **Before verification began:** The Design contained a concrete Verification Plan.
- [x] **Before requesting maintainer review or acceptance:** Applicable implementation and verification TASKs were completed with exact commands, results, evidence links, and hashes before this draft was moved to ready.

- [x] Complete: all three timed obligations above were satisfied.
- [ ] Noncompliant: one or more obligations were not satisfied.
- [ ] Verified exception: material agent participation used the verified-maintainer/administrator exception.
- [ ] N/A because the PR is human-only or qualifies for the trivial exception.

**Gate-status explanation (or N/A):** Approved Proposal #4022 and Design #4442 authorize restartable content-addressed candidate preparation and strict registry-state verification. TASK-4442019 is the bounded implementation repair; TASK-4442020 records exact-head verification; TASK-4442005 owns live protected-registry validation after merge.

**Trivial-exception explanation (or N/A):** N/A; material agent participation is declared.

**Verified maintainer/administrator exception evidence (or N/A):** N/A; this PR follows the approved Proposal/Design/TASK path and does not use the exception.

**Approved Proposal Issue URL (or N/A with explanation):** https://github.com/higress-group/higress/issues/4022

**Approved Design Issue URL (or N/A with explanation):** https://github.com/higress-group/higress/issues/4442

**Maintainer approval link(s) (or N/A with explanation):** Maintainer approval and the refined strict-absence/backfill resolution are recorded in #4022 and #4442, including https://github.com/higress-group/higress/issues/4442#issuecomment-5276528470.

**Authorized implementation TASK link(s) (or N/A with explanation):** https://github.com/higress-group/higress/issues/4442#issuecomment-5280544511

**Verification Plan and verification TASK/evidence link(s) (or N/A with explanation):** Design Verification Plan: https://github.com/higress-group/higress/issues/4442; focused verification: https://github.com/higress-group/higress/issues/4442#issuecomment-5280544950; post-merge rehearsal: https://github.com/higress-group/higress/issues/4442#issuecomment-5255965383.

## V. Testing and verification

**Test and deterministic rerun commands (or N/A with explanation):**

```text
cd tools/plugin-release && go test ./... -run 'TestPreparation(RunsOptionalGoSetupBeforeTestsAndBuild|ReusesOnlyIdenticalContentAddressedCandidate|PushesOnceOnlyForStrictlyProvenCandidateAbsence|CandidateLookupAndManifestMismatchesFailWithoutMutation|DoesNotReadEmbedded404FromRealCandidateTagAsHTTPAbsence)$' -count=1 -v
cd tools/plugin-release && go test ./... -count=1
cd tools/plugin-release && go vet ./...
cd tools/plugin-release && go run . validate-catalog --root ../.. --catalog ../../plugins/release/catalog.json
go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 .github/workflows/prepare-plugin-release.yaml .github/workflows/validate-plugin-preparation-pr.yaml
git diff --check bf9510ad4ecef3dbac0aa030bdaaf2509c4f6492..f367504c408afc40ba5eb384c2159735610f9a2a
cd plugins/wasm-go/extensions/ai-context-limit && sh ./prepare.sh && go test ./...
make -C plugins/wasm-go PLUGIN_NAME=ai-context-limit build
```

All listed checks passed. A separate clean-worktree sweep ran optional setup plus `go test ./...` for all 42 planned Go plugins: 42/42 passed. The Rust `ai-data-masking` local container test could not fetch its GitHub dependency due network timeout; the post-merge formal runner remains responsible for its unchanged `make test build` path.

**Environment and configuration (or N/A with explanation):** Linux x86_64; Go 1.26.0; jq 1.6; actionlint 1.7.7; real ORAS command built from v1.2.3. Docker build used the repository-pinned Go WASM builder. PR-head and independent-review tests used no registry write credential.

**Exact tested revision, version, image tag/digest, manifests, and values (or N/A with explanation):** Base `bf9510ad4ecef3dbac0aa030bdaaf2509c4f6492`; head `f367504c408afc40ba5eb384c2159735610f9a2a`; gateway 2.2.4 plan ID `sha256:b0776c63af093544e840df5c88187a658767e51f7b0b424aca802bbcb531b351`.

Partial-run candidates independently resolved and pulled:

- `ai-agent`: manifest `sha256:e97650455aa1dd12df500162372ecf3923e80c21d292f0f0e0856988255f15f0`; WASM layer/local rebuild `sha256:d0335faf4b9875abab1ac64b6bfd3bd5122d50c58fcbe4840d80e39f24373eb7`.
- `ai-cache`: manifest `sha256:75254e1e73bb6cd56f52296123e8b62f572cdaf290bc17dcbfb99dac32b4b7b8`; WASM layer `sha256:26dc085bd0a6b2aacfb18d1ff63e3cd66083abd6d9e6c5f2163945577f088080`.

Both tags are exactly 128 characters and carry exact source `bf9510ad...`, planned version, and input-hash annotations.

**Baseline reproduction evidence for bug fixes (or N/A with explanation):** https://github.com/higress-group/higress/actions/runs/31699985099 and job https://github.com/higress-group/higress/actions/runs/31699985099/job/94446978709. The run published `ai-agent` and `ai-cache`, then failed before `ai-context-limit` tests with `tokenizer.go:29:12: pattern bpe/o200k_base.tiktoken: no matching files found` because optional setup had not run.

**Fixed-version verification evidence for bug fixes (or N/A with explanation):** `ai-context-limit` setup/test/Docker WASM build passed and generated files were not committed. The exact workflow reuse function was also executed read-only against the live `ai-agent` candidate using ORAS 1.2.3: the local rebuilt WASM digest matched and the function returned the existing manifest digest without push. Fake-ORAS tests prove one push only for strict absence and zero push for all mismatch/error states. Independent exact-head review reported P0=0, P1=0, P2=0 after repairing an embedded-`404` classifier finding.

**Wasm source revision and SHA-256 (or N/A with explanation):** Read-only verification rebuilt `ai-agent` from source `bf9510ad4ecef3dbac0aa030bdaaf2509c4f6492` as `sha256:d0335faf4b9875abab1ac64b6bfd3bd5122d50c58fcbe4840d80e39f24373eb7`, identical to the existing candidate layer. No new public artifact was published.

## VI. Special notes for reviewers

The workflow deliberately rebuilds before checking whether a candidate exists. This costs retry time but proves the immutable candidate still represents the exact reviewed bytes instead of accepting provenance annotations alone. The existing candidate manifest is resolved by digest after tag lookup to bind all subsequent checks to one immutable object.

The strict absence classifier accepts only structured HTTP/status 404 forms, OCI `manifest unknown`/`name unknown`, or ACR's conjunctive registry-error form naming the exact candidate. A review finding demonstrated that a loose numeric `404` regex could match the real `ai-proxy` tag's hash; the repaired executable regression covers the full tag plus a transport timeout and proves no push.

### Implementation Rationale

- Keep the formal preparation and credential-free PR rebuild setup/test/build functions byte-identical so review validation exercises the same prerequisite ordering.
- Rebuild before lookup and compare the local SHA-256 to the single declared WASM layer before reusing a candidate. This is slower but makes partial retries safe under immutable tags.
- Extract marked workflow shell into tests and execute it with controlled fake commands. The intentional marker coupling prevents workflow behavior from changing without exercising the positive and negative state matrix.

## VII. AI coding disclosure

**Tool(s) used (or N/A):** OpenAI Codex with one isolated implementation worker and one independent read-only reviewer.

### Prompts or instructions

After formal run 31699985099 exposed the missing setup ordering and partial immutable batch, the worker was instructed to align optional Go setup across both workflows, rebuild before candidate lookup, strictly validate and reuse identical candidates, push only on Design-approved absence evidence, add executable actual-shell contracts, stay within three owned paths, run the specified validations, and commit with DCO signoff. The independent reviewer was instructed to check exact base/head read-only and report only P0/P1/P2 findings. The review's embedded-`404` P1 was returned unchanged to the writer, repaired, and re-reviewed to zero findings. No credentials or secrets were included.

### AI-assisted work summary

Codex diagnosed the live workflow failure, inspected and independently resolved the two partial candidates, created implementation and verification TASKs, delegated the bounded code change, performed a clean 42-plugin Go test sweep, reran exact-head contracts and static checks, executed the real workflow reuse function read-only against ACR with ORAS 1.2.3, and completed the independent review/repair loop. No public plugin tag, `latest`, snapshot PR, Console, plugin-server, or Standalone state was changed.
