### PR TITLE
fix: classify registry errors without reference hashes

### DIFF
--- a/.github/workflows/prepare-plugin-release.yaml
+++ b/.github/workflows/prepare-plugin-release.yaml
@@ -83,7 +83,10 @@ jobs:
             # neither presence nor absence: defer the definitive decision to
             # the protected authenticated bootstrap capture and keep checking
             # every deterministic reference.
-            if grep -Eiq '401|403|unauthorized|forbidden|denied|authentication required|authorization required' "$lookup_error"; then
+            auth_error=$(<"$lookup_error")
+            auth_error=${auth_error//"$public_ref"/}
+            if grep -Eiq 'unauthorized|forbidden|denied|authentication required|authorization required' <<<"$auth_error" ||
+               grep -Eiq 'HTTP(/[0-9.]+)?[[:space:]]+(401|403)([^[:digit:]]|$)|(^|[^[:alpha:]])status( code)?[[:space:]:=]+(401|403)([^[:digit:]]|$)' <<<"$auth_error"; then
               authenticated_capture=$((authenticated_capture + 1))
               rm -f "$lookup_error"
               echo "public registry preflight requires authenticated capture; authorization failure is never absence: $public_ref" >&2
@@ -280,7 +283,10 @@ jobs:
               printf '%s\n' "$resolved_digest"
               return 0
             fi
-            if grep -Eiq '401|403|unauthorized|forbidden|denied|authentication required|authorization required' "$lookup_error"; then
+            auth_error=$(<"$lookup_error")
+            auth_error=${auth_error//"$candidate"/}
+            if grep -Eiq 'unauthorized|forbidden|denied|authentication required|authorization required' <<<"$auth_error" ||
+               grep -Eiq 'HTTP(/[0-9.]+)?[[:space:]]+(401|403)([^[:digit:]]|$)|(^|[^[:alpha:]])status( code)?[[:space:]:=]+(401|403)([^[:digit:]]|$)' <<<"$auth_error"; then
               cat "$lookup_error" >&2; rm -f "$lookup_error"
               echo "candidate lookup authorization failure is never absence: $candidate" >&2
               return 1

--- a/.github/workflows/promote-plugin-release.yaml
+++ b/.github/workflows/promote-plugin-release.yaml
@@ -115,7 +115,7 @@ jobs:
                grep -Eiq 'HTTP(/[0-9.]+)?[[:space:]]+(401|403)([^[:digit:]]|$)|(^|[^[:alpha:]])status( code)?[[:space:]:=]+(401|403)([^[:digit:]]|$)' <<<"$auth_error"; then
               cat "$err" >&2; rm -f "$err"; return 2
             fi
-            if grep -Eiq '404|manifest unknown|name unknown|repository does not exist' "$err" ||
+            if grep -Eiq 'HTTP(/[0-9.]+)?[[:space:]]+404([^[:digit:]]|$)|response status( code)?[[:space:]:=]+404([^[:digit:]]|$)|status code[[:space:]:=]+404([^[:digit:]]|$)|404[[:space:]]+Not[[:space:]]+Found|manifest unknown|name unknown' <<<"$auth_error" ||
                { grep -Fq 'Error response from registry:' "$err" && grep -Fq "$ref: not found" "$err"; }; then rm -f "$err"; return 1; fi
             cat "$err" >&2; rm -f "$err"; return 2
           }
@@ -214,7 +214,7 @@ jobs:
                grep -Eiq 'HTTP(/[0-9.]+)?[[:space:]]+(401|403)([^[:digit:]]|$)|(^|[^[:alpha:]])status( code)?[[:space:]:=]+(401|403)([^[:digit:]]|$)' <<<"$auth_error"; then
               cat "$err" >&2; rm -f "$err"; return 2
             fi
-            if grep -Eiq '404|manifest unknown|name unknown|repository does not exist' "$err" ||
+            if grep -Eiq 'HTTP(/[0-9.]+)?[[:space:]]+404([^[:digit:]]|$)|response status( code)?[[:space:]:=]+404([^[:digit:]]|$)|status code[[:space:]:=]+404([^[:digit:]]|$)|404[[:space:]]+Not[[:space:]]+Found|manifest unknown|name unknown' <<<"$auth_error" ||
                { grep -Fq 'Error response from registry:' "$err" && grep -Fq "$ref: not found" "$err"; }; then rm -f "$err"; return 1; fi
             cat "$err" >&2; rm -f "$err"; return 2
           }

--- a/.github/workflows/promote-plugin-release.yaml
+++ b/.github/workflows/promote-plugin-release.yaml
@@ -98,8 +98,9 @@ jobs:
             args+=(--previous "../../plugins/release/snapshots/$(jq -r .previousRelease "$SNAPSHOT_PATH").json")
           fi
           (cd tools/plugin-release && go run . "${args[@]}")
+          # BEGIN promotion-descriptor-contract
           descriptor_or_absent() {
-            local ref=$1 out err
+            local ref=$1 out err auth_error
             err=$(mktemp)
             if out=$(oras manifest fetch "$ref" --descriptor 2>"$err"); then
               rm -f "$err"; printf '%s' "$out"; return 0
@@ -108,13 +109,17 @@ jobs:
             # explicit registry 404-class response proves the tag is absent. A
             # missing local executable/file or generic "not found" text fails
             # closed.
-            if grep -Eiq '401|403|unauthorized|forbidden|denied|authentication required|authorization required' "$err"; then
+            auth_error=$(<"$err")
+            auth_error=${auth_error//"$ref"/}
+            if grep -Eiq 'unauthorized|forbidden|denied|authentication required|authorization required' <<<"$auth_error" ||
+               grep -Eiq 'HTTP(/[0-9.]+)?[[:space:]]+(401|403)([^[:digit:]]|$)|(^|[^[:alpha:]])status( code)?[[:space:]:=]+(401|403)([^[:digit:]]|$)' <<<"$auth_error"; then
               cat "$err" >&2; rm -f "$err"; return 2
             fi
             if grep -Eiq '404|manifest unknown|name unknown|repository does not exist' "$err" ||
                { grep -Fq 'Error response from registry:' "$err" && grep -Fq "$ref: not found" "$err"; }; then rm -f "$err"; return 1; fi
             cat "$err" >&2; rm -f "$err"; return 2
           }
+          # END promotion-descriptor-contract
           marker="$REGISTRY/candidates/plugin-release-batches:$SNAPSHOT_SHA256"
           # A completion marker makes a retry read-only. Its layer is the
           # authoritative journal, and every mutable latest tag is rechecked
@@ -194,21 +199,26 @@ jobs:
           test "$(git rev-parse HEAD)" = "$SOURCE_COMMIT"
           test -n "$REGISTRY"; test -n "$REGISTRY_USERNAME"; test -n "$REGISTRY_PASSWORD"
           echo "$REGISTRY_PASSWORD" | oras login "$REGISTRY" -u "$REGISTRY_USERNAME" --password-stdin
+          # BEGIN promotion-descriptor-contract
           descriptor_or_absent() {
-            local ref=$1 out err
+            local ref=$1 out err auth_error
             err=$(mktemp)
             if out=$(oras manifest fetch "$ref" --descriptor 2>"$err"); then rm -f "$err"; printf '%s' "$out"; return 0; fi
             # Authorization evidence wins and is never absence; only an
             # explicit registry 404-class response proves the alias is absent.
             # A missing local executable/file or generic "not found" text
             # fails closed.
-            if grep -Eiq '401|403|unauthorized|forbidden|denied|authentication required|authorization required' "$err"; then
+            auth_error=$(<"$err")
+            auth_error=${auth_error//"$ref"/}
+            if grep -Eiq 'unauthorized|forbidden|denied|authentication required|authorization required' <<<"$auth_error" ||
+               grep -Eiq 'HTTP(/[0-9.]+)?[[:space:]]+(401|403)([^[:digit:]]|$)|(^|[^[:alpha:]])status( code)?[[:space:]:=]+(401|403)([^[:digit:]]|$)' <<<"$auth_error"; then
               cat "$err" >&2; rm -f "$err"; return 2
             fi
             if grep -Eiq '404|manifest unknown|name unknown|repository does not exist' "$err" ||
                { grep -Fq 'Error response from registry:' "$err" && grep -Fq "$ref: not found" "$err"; }; then rm -f "$err"; return 1; fi
             cat "$err" >&2; rm -f "$err"; return 2
           }
+          # END promotion-descriptor-contract
           marker="$REGISTRY/candidates/plugin-release-batches:$SNAPSHOT_SHA256"
           # A previously completed marker is an idempotent terminal state:
           # verify every latest tag again, retain its journal for upload, and

--- a/tools/plugin-release/bootstrap_backfill_test.go
+++ b/tools/plugin-release/bootstrap_backfill_test.go
@@ -23,6 +23,8 @@ import (
 )
 
 func TestClassifyOCIFailureDistinguishesUnauthorizedFromAbsent(t *testing.T) {
+	const aiCacheRef = "higress-registry.cn-hangzhou.cr.aliyuncs.com/candidates/ai-cache:5a150abf7a1a76129eef4e2d61927116a59c9141f87cdfb1d4a0b0f58e049a544bf98709658a92d40b7bda75b5f458387526143e09b321a401ff7a258fdea47f"
+	const authWordRef = "registry.example/plugins/unauthorized-401-forbidden-403:1.0.0"
 	cases := []struct {
 		msg         string
 		expectedRef string
@@ -33,12 +35,23 @@ func TestClassifyOCIFailureDistinguishesUnauthorizedFromAbsent(t *testing.T) {
 		{"denied: requested access to the resource is denied", "", ociFailureUnauthorized},
 		{"UNAUTHORIZED: authentication required", "", ociFailureUnauthorized},
 		{"authorization required", "", ociFailureUnauthorized},
+		{"response status code 401", "", ociFailureUnauthorized},
+		{"HTTP/1.1 403", "", ociFailureUnauthorized},
+		{"status: 403", "", ociFailureUnauthorized},
+		{"registry error 401", "", ociFailureOther},
+		{"backend code 403", "", ociFailureOther},
 		{"404 Not Found", "", ociFailureNotFound},
 		{"manifest unknown", "", ociFailureNotFound},
 		{"name unknown", "", ociFailureNotFound},
 		{"repository does not exist", "", ociFailureNotFound},
 		{`Error response from registry: failed to find "higress-registry.cn-hangzhou.cr.aliyuncs.com/plugins/missing:1.0.0": higress-registry.cn-hangzhou.cr.aliyuncs.com/plugins/missing:1.0.0: not found`, "higress-registry.cn-hangzhou.cr.aliyuncs.com/plugins/missing:1.0.0", ociFailureNotFound},
 		{`Error response from registry: higress-registry.cn-hangzhou.cr.aliyuncs.com/plugins/other:1.0.0: not found`, "higress-registry.cn-hangzhou.cr.aliyuncs.com/plugins/missing:1.0.0", ociFailureOther},
+		{"Error response from registry: " + aiCacheRef + ": not found", aiCacheRef, ociFailureNotFound},
+		{"transport error while resolving " + aiCacheRef + ": dial tcp: i/o timeout", aiCacheRef, ociFailureOther},
+		{"Error response from registry: " + authWordRef + ": not found", authWordRef, ociFailureNotFound},
+		{"transport error while resolving " + authWordRef, authWordRef, ociFailureOther},
+		{"response status code 403 while resolving " + aiCacheRef, aiCacheRef, ociFailureUnauthorized},
+		{"authentication required while resolving " + authWordRef, authWordRef, ociFailureUnauthorized},
 		{"connection refused", "", ociFailureOther},
 		{"i/o timeout", "", ociFailureOther},
 		// A local executable/file failure or generic "not found" text is never
@@ -49,10 +62,10 @@ func TestClassifyOCIFailureDistinguishesUnauthorizedFromAbsent(t *testing.T) {
 		{"not found", "", ociFailureOther},
 		{"Error response from registry: not found", "", ociFailureOther},
 		{"Error response from registry: /tmp/plugins/missing:1.0.0: not found", "/tmp/plugins/missing:1.0.0", ociFailureOther},
-		// Authorization always wins over absence: a 401/403 is never an
-		// absent artifact, even when the registry also says "unknown".
-		{"403: manifest unknown", "", ociFailureUnauthorized},
-		{"401: not found", "", ociFailureUnauthorized},
+		// Structured authorization always wins over absence, even when the
+		// registry also says "unknown".
+		{"HTTP 403: manifest unknown", "", ociFailureUnauthorized},
+		{"response status code 401: not found", "", ociFailureUnauthorized},
 		{`Error response from registry: 403 Forbidden: higress-registry.cn-hangzhou.cr.aliyuncs.com/plugins/missing:1.0.0: not found`, "higress-registry.cn-hangzhou.cr.aliyuncs.com/plugins/missing:1.0.0", ociFailureUnauthorized},
 	}
 	for _, tc := range cases {

--- a/tools/plugin-release/commands.go
+++ b/tools/plugin-release/commands.go
@@ -19,12 +19,15 @@ import (
 )
 
 var (
-	safeIDPattern             = regexp.MustCompile(`^[a-z0-9]+(?:[a-z0-9._-]*[a-z0-9])?$`)
-	digestPattern             = regexp.MustCompile(`^sha256:[0-9a-f]{64}$`)
-	commitPattern             = regexp.MustCompile(`^[0-9a-f]{40}$`)
-	credentialURLPattern      = regexp.MustCompile(`(?i)([a-z][a-z0-9+.-]*://)[^/\s@]+@`)
-	sensitiveValuePattern     = regexp.MustCompile(`(?i)(\b(?:password|token|secret|credential|access[_-]?key|api[_-]?key)\b(?:\s*[:=]\s*|\s+))([^\s,;]+)`)
-	authorizationValuePattern = regexp.MustCompile(`(?i)(\bauthorization\b\s*[:=]\s*)([^\s,;]+(?:\s+[^\s,;]+)?)`)
+	safeIDPattern              = regexp.MustCompile(`^[a-z0-9]+(?:[a-z0-9._-]*[a-z0-9])?$`)
+	digestPattern              = regexp.MustCompile(`^sha256:[0-9a-f]{64}$`)
+	commitPattern              = regexp.MustCompile(`^[0-9a-f]{40}$`)
+	credentialURLPattern       = regexp.MustCompile(`(?i)([a-z][a-z0-9+.-]*://)[^/\s@]+@`)
+	sensitiveValuePattern      = regexp.MustCompile(`(?i)(\b(?:password|token|secret|credential|access[_-]?key|api[_-]?key)\b(?:\s*[:=]\s*|\s+))([^\s,;]+)`)
+	authorizationValuePattern  = regexp.MustCompile(`(?i)(\bauthorization\b\s*[:=]\s*)([^\s,;]+(?:\s+[^\s,;]+)?)`)
+	authorizationPhrasePattern = regexp.MustCompile(`(?i)unauthorized|forbidden|denied|authentication required|authorization required`)
+	authorizationStatusPattern = regexp.MustCompile(`(?i)HTTP(?:/[0-9.]+)?\s+(?:401|403)(?:[^0-9]|$)|(?:^|[^a-z])status(?: code)?(?:\s*[:=]\s*|\s+)(?:401|403)(?:[^0-9]|$)`)
+	notFoundStatusPattern      = regexp.MustCompile(`(?i)HTTP(?:/[0-9.]+)?\s+404(?:[^0-9]|$)|response status(?: code)?(?:\s*[:=]\s*|\s+)404(?:[^0-9]|$)|status code(?:\s*[:=]\s*|\s+)404(?:[^0-9]|$)|404\s+not\s+found`)
 	// ACR reports an absent manifest as a provider-structured registry error
 	// ending in a fully qualified OCI reference followed by ": not found".
 	// The explicit registry prefix and qualified reference are both required;
@@ -42,24 +45,31 @@ const (
 
 // classifyOCIFailure reports whether a sanitized registry error means the
 // artifact is genuinely absent or the caller lacks authorization. The
-// authorization markers are checked first: a 401/403 is an
-// authorization/configuration error and is never an absent artifact. Absence
-// requires explicit registry evidence (404-class, manifest/name unknown), or
-// a provider-structured registry error naming the fully qualified reference;
-// a local executable/file failure or generic "not found" text fails closed.
+// authorization markers are checked first after removing the exact expected
+// OCI reference, so digits or words inside a content-addressed reference are
+// never treated as registry status. Numeric 401/403 markers require HTTP/status
+// context; explicit authorization phrases still fail closed. Absence requires
+// explicit registry evidence (404-class, manifest/name unknown), or a
+// provider-structured registry error naming the fully qualified reference; a
+// local executable/file failure or generic "not found" text fails closed.
 func classifyOCIFailure(err error, expectedRef string) ociFailureClass {
 	msg := strings.ToLower(err.Error())
-	for _, marker := range []string{"401", "403", "unauthorized", "forbidden", "denied", "authentication required", "authorization required"} {
-		if strings.Contains(msg, marker) {
-			return ociFailureUnauthorized
-		}
+	expectedRef = strings.ToLower(expectedRef)
+	classificationMsg := msg
+	if expectedRef != "" {
+		classificationMsg = strings.ReplaceAll(classificationMsg, expectedRef, "")
 	}
-	for _, marker := range []string{"404", "manifest unknown", "name unknown", "repository does not exist"} {
-		if strings.Contains(msg, marker) {
+	if authorizationPhrasePattern.MatchString(classificationMsg) || authorizationStatusPattern.MatchString(classificationMsg) {
+		return ociFailureUnauthorized
+	}
+	if notFoundStatusPattern.MatchString(classificationMsg) {
+		return ociFailureNotFound
+	}
+	for _, marker := range []string{"manifest unknown", "name unknown", "repository does not exist"} {
+		if strings.Contains(classificationMsg, marker) {
 			return ociFailureNotFound
 		}
 	}
-	expectedRef = strings.ToLower(expectedRef)
 	if strings.Contains(msg, "error response from registry:") &&
 		registryQualifiedReferencePattern.MatchString(expectedRef) &&
 		strings.Contains(msg, expectedRef+": not found") {

--- a/tools/plugin-release/plugin_server_workflow_contract_test.go
+++ b/tools/plugin-release/plugin_server_workflow_contract_test.go
@@ -624,6 +624,30 @@ func TestPromotionDescriptorClassifiersIgnoreAuthDigitsInsideExpectedReference(t
 	}
 }
 
+func TestPromotionDescriptorClassifiersIgnore404InsideExpectedReferences(t *testing.T) {
+	contracts := workflowShellContracts(t, "promote-plugin-release.yaml", "promotion-descriptor-contract")
+	if len(contracts) != 2 {
+		t.Fatalf("promotion version/latest jobs have %d descriptor contracts, want 2", len(contracts))
+	}
+	refs := map[string]string{
+		"completion-marker":     "registry.example.invalid/candidates/plugin-release-batches:abc404def",
+		"plugin-version-latest": "registry.example.invalid/plugins/plugin-404:hash404value",
+	}
+	for i, contract := range contracts {
+		for name, ref := range refs {
+			t.Run(fmt.Sprintf("classifier-%d/%s", i+1, name), func(t *testing.T) {
+				status, log := runPromotionDescriptorContract(t, contract, "transport-with-ref", ref)
+				if status != 2 {
+					t.Fatalf("transport error echoing 404-containing ref returned %d, want fail-closed status 2\n%s", status, log)
+				}
+				if strings.Contains(log, "push ") || strings.Contains(log, "cp ") {
+					t.Fatalf("transport error echoing 404-containing ref caused registry mutation:\n%s", log)
+				}
+			})
+		}
+	}
+}
+
 func TestPreparationVersionOverridesPreserveCanonicalObjectAndRejectMalformedInputs(t *testing.T) {
 	data, err := os.ReadFile("../../.github/workflows/prepare-plugin-release.yaml")
 	if err != nil {

--- a/tools/plugin-release/plugin_server_workflow_contract_test.go
+++ b/tools/plugin-release/plugin_server_workflow_contract_test.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"crypto/sha256"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -254,6 +255,35 @@ func workflowShellContract(t *testing.T, workflowName, contractName string) stri
 	return string(data)[start:finish]
 }
 
+func workflowShellContracts(t *testing.T, workflowName, contractName string) []string {
+	t.Helper()
+	data, err := os.ReadFile("../../.github/workflows/" + workflowName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	begin := "# BEGIN " + contractName
+	end := "# END " + contractName
+	remainder := string(data)
+	var contracts []string
+	for {
+		start := strings.Index(remainder, begin)
+		if start < 0 {
+			break
+		}
+		start += len(begin)
+		finish := strings.Index(remainder[start:], end)
+		if finish < 0 {
+			t.Fatalf("%s has an unterminated executable shell contract %s", workflowName, contractName)
+		}
+		contracts = append(contracts, remainder[start:start+finish])
+		remainder = remainder[start+finish+len(end):]
+	}
+	if len(contracts) == 0 {
+		t.Fatalf("%s lacks executable shell contract %s", workflowName, contractName)
+	}
+	return contracts
+}
+
 func writeExecutableFixture(t *testing.T, path, contents string) {
 	t.Helper()
 	if err := os.WriteFile(path, []byte(contents), 0o700); err != nil {
@@ -364,6 +394,10 @@ if [ "$1 $2" = "manifest fetch" ]; then
       absent-name) echo "name unknown" >&2; exit 1 ;;
       absent-acr) echo "Error response from registry: $ref: not found" >&2; exit 1 ;;
       auth) echo "401 unauthorized" >&2; exit 1 ;;
+      auth-401-status) echo "response status code 401" >&2; exit 1 ;;
+      auth-403-http) echo "HTTP/1.1 403" >&2; exit 1 ;;
+      auth-phrase-denied) echo "requested access is denied" >&2; exit 1 ;;
+      auth-phrase-required) echo "authentication required" >&2; exit 1 ;;
       ambiguous) echo "not found" >&2; exit 1 ;;
       repository-missing) echo "repository does not exist" >&2; exit 1 ;;
       wrong-acr-ref) echo "Error response from registry: registry.example.invalid/candidates/other: not found" >&2; exit 1 ;;
@@ -492,6 +526,104 @@ func TestPreparationDoesNotReadEmbedded404FromRealCandidateTagAsHTTPAbsence(t *t
 	}
 }
 
+func TestPreparationClassifiesRealAIHashWithoutReadingEmbedded401AsAuthorization(t *testing.T) {
+	const aiCacheCandidate = "higress-registry.cn-hangzhou.cr.aliyuncs.com/candidates/ai-cache:5a150abf7a1a76129eef4e2d61927116a59c9141f87cdfb1d4a0b0f58e049a544bf98709658a92d40b7bda75b5f458387526143e09b321a401ff7a258fdea47f"
+
+	absent := runCandidatePublishContractWithCandidate(t, "absent-acr", aiCacheCandidate)
+	if absent.err != nil {
+		t.Fatalf("exact ACR absence for real ai-cache candidate was not published: %v\n%s", absent.err, absent.output)
+	}
+	if strings.Count(absent.log, "push ") != 1 {
+		t.Fatalf("exact ACR absence must perform one push:\n%s", absent.log)
+	}
+
+	transport := runCandidatePublishContractWithCandidate(t, "transport-with-ref", aiCacheCandidate)
+	if transport.err == nil || strings.Contains(transport.log, "push ") {
+		t.Fatalf("transport error echoing real ai-cache candidate must fail without push: err=%v\n%s", transport.err, transport.log)
+	}
+
+	for _, mode := range []string{"auth-401-status", "auth-403-http", "auth", "auth-phrase-denied", "auth-phrase-required"} {
+		t.Run(mode, func(t *testing.T) {
+			result := runCandidatePublishContractWithCandidate(t, mode, aiCacheCandidate)
+			if result.err == nil || strings.Contains(result.log, "push ") {
+				t.Fatalf("authorization evidence %s must fail without push: err=%v\n%s", mode, result.err, result.log)
+			}
+		})
+	}
+}
+
+func runPromotionDescriptorContract(t *testing.T, contract, mode, ref string) (int, string) {
+	t.Helper()
+	tmp := t.TempDir()
+	bin := filepath.Join(tmp, "bin")
+	if err := os.MkdirAll(bin, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	log := filepath.Join(tmp, "oras.log")
+	writeExecutableFixture(t, filepath.Join(bin, "oras"), `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "$ORAS_LOG"
+ref=$3
+case "$ORAS_MODE" in
+  absent-acr) echo "Error response from registry: $ref: not found" >&2; exit 1 ;;
+  transport-with-ref) echo "transport error while resolving $ref: dial tcp: i/o timeout" >&2; exit 1 ;;
+  auth-401-status) echo "response status code 401" >&2; exit 1 ;;
+  auth-403-http) echo "HTTP/1.1 403" >&2; exit 1 ;;
+  auth-phrase) echo "authorization required" >&2; exit 1 ;;
+  *) echo "unsupported fixture mode" >&2; exit 3 ;;
+esac
+`)
+	script := "set -euo pipefail\n" + contract + fmt.Sprintf("\ndescriptor_or_absent %q\n", ref)
+	cmd := exec.Command("bash", "-c", script)
+	cmd.Env = append(os.Environ(), "PATH="+bin+":"+os.Getenv("PATH"), "ORAS_LOG="+log, "ORAS_MODE="+mode)
+	output, err := cmd.CombinedOutput()
+	status := 0
+	if err != nil {
+		var exitErr *exec.ExitError
+		if !errors.As(err, &exitErr) {
+			t.Fatalf("promotion descriptor fixture failed to execute: %v\n%s", err, output)
+		}
+		status = exitErr.ExitCode()
+	}
+	logBytes, readErr := os.ReadFile(log)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	return status, string(logBytes)
+}
+
+func TestPromotionDescriptorClassifiersIgnoreAuthDigitsInsideExpectedReference(t *testing.T) {
+	contracts := workflowShellContracts(t, "promote-plugin-release.yaml", "promotion-descriptor-contract")
+	if len(contracts) != 2 {
+		t.Fatalf("promotion version/latest jobs have %d descriptor contracts, want 2", len(contracts))
+	}
+	const ref = "registry.example.invalid/plugins/plugin-401-and-403:hash401value403"
+	for i, contract := range contracts {
+		t.Run(fmt.Sprintf("classifier-%d", i+1), func(t *testing.T) {
+			for _, tc := range []struct {
+				mode string
+				want int
+			}{
+				{mode: "absent-acr", want: 1},
+				{mode: "transport-with-ref", want: 2},
+				{mode: "auth-401-status", want: 2},
+				{mode: "auth-403-http", want: 2},
+				{mode: "auth-phrase", want: 2},
+			} {
+				t.Run(tc.mode, func(t *testing.T) {
+					status, log := runPromotionDescriptorContract(t, contract, tc.mode, ref)
+					if status != tc.want {
+						t.Fatalf("descriptor status for %s = %d, want %d\n%s", tc.mode, status, tc.want, log)
+					}
+					if strings.Contains(log, "push ") || strings.Contains(log, "cp ") {
+						t.Fatalf("descriptor classification mutated the registry:\n%s", log)
+					}
+				})
+			}
+		})
+	}
+}
+
 func TestPreparationVersionOverridesPreserveCanonicalObjectAndRejectMalformedInputs(t *testing.T) {
 	data, err := os.ReadFile("../../.github/workflows/prepare-plugin-release.yaml")
 	if err != nil {
@@ -593,6 +725,8 @@ func TestPreparationPreflightsReadOnlyDeterministicCatalogPublicManifest(t *test
 		`descriptor=$(oras manifest fetch "$public_ref" --descriptor`, `jq -er '.digest | strings and test("^sha256:[0-9a-f]{64}$")'`,
 		`present=$((present + 1))`, `absent=$((absent + 1))`, `authenticated_capture=0`,
 		`authenticated_capture=$((authenticated_capture + 1))`,
+		`auth_error=${auth_error//"$public_ref"/}`,
+		`unauthorized|forbidden|denied|authentication required|authorization required`,
 		`grep -Fq 'Error response from registry:'`, `grep -Fq "$public_ref: not found"`,
 		"public registry preflight requires authenticated capture; authorization failure is never absence",
 		"public registry preflight failed without explicit absence evidence",
@@ -609,7 +743,7 @@ func TestPreparationPreflightsReadOnlyDeterministicCatalogPublicManifest(t *test
 	if strings.Contains(preflight, "--descriptor --format") {
 		t.Fatal("ORAS 1.2.3 descriptor preflight must not combine --descriptor and --format")
 	}
-	authStart := strings.Index(preflight, "if grep -Eiq '401|403|")
+	authStart := strings.Index(preflight, `auth_error=$(<"$lookup_error")`)
 	absenceStart := strings.Index(preflight, "if grep -Eiq '404|manifest unknown|")
 	if authStart < 0 || absenceStart < 0 || authStart > absenceStart {
 		t.Fatal("uncredentialed preflight must classify authorization before explicit absence")


### PR DESCRIPTION
## I. Summary

Make registry failure classification independent of content-addressed OCI reference text.

- Remove the exact expected OCI reference before scanning for authorization or structured status evidence.
- Require HTTP/status context for numeric `401`/`403`; keep explicit authorization phrases fail-closed.
- Use reference-stripped text for structured promotion absence classification, while reserving raw stderr for ACR's conjunctive exact-reference `not found` proof.
- Apply the invariant to preparation preflight/candidate handling, both promotion version/latest classifiers, and the Go bootstrap classifier.
- Execute the actual marked workflow shell functions in regression tests with real failure-shaped references containing embedded `401`, `403`, and `404`.

Compatibility impact: no plan, plugin version, candidate identity, public tag, `latest`, or downstream default semantics change.

## II. Related issue

Related to #4022 and #4442. This PR implements [TASK-4442021](https://github.com/higress-group/higress/issues/4442#issuecomment-5281229492); exact-head verification is tracked by [TASK-4442022](https://github.com/higress-group/higress/issues/4442#issuecomment-5281229912). [TASK-4442005](https://github.com/higress-group/higress/issues/4442#issuecomment-5255965383) continues to own the protected 2.2.4 release rehearsal.

## III. Change type

- [x] Bug fix
- [ ] Feature or enhancement
- [ ] Documentation or configuration only
- [x] Refactoring, tests, or maintenance

## IV. Agent participation and issue-spec gate

- [ ] **No agent participation:** This PR is human-only.
- [ ] **Trivial agent-use exception:** Agent use was limited to spelling, punctuation, whitespace, or formatting with no substantive choice or behavioral effect.
- [ ] **Verified maintainer/administrator exception:** Material agent participation occurred under the verified exception.
- [x] **Material agent participation:** An AI or coding agent materially participated in analysis, implementation, testing, review, and PR preparation.

- [x] **Before implementation began:** A Higress maintainer had approved the Proposal and Design Issues, and authorized implementation TASKs linked the work to the applicable SPECs.
- [x] **Before verification began:** The Design contained a concrete Verification Plan.
- [x] **Before requesting maintainer review or acceptance:** Applicable implementation and verification TASKs were completed with exact commands, results, evidence links, and hashes before this draft was moved to ready.

- [x] Complete: all three timed obligations above were satisfied.
- [ ] Noncompliant: one or more obligations were not satisfied.
- [ ] Verified exception: material agent participation used the verified-maintainer/administrator exception.
- [ ] N/A because the PR is human-only or qualifies for the trivial exception.

**Gate-status explanation (or N/A):** Approved Proposal #4022 and Design #4442 define strict authorization/absence classification and idempotent candidate/promotion behavior. TASK-4442021 is the bounded classifier repair; TASK-4442022 records exact-head verification; TASK-4442005 owns live protected-registry validation after merge.

**Trivial-exception explanation (or N/A):** N/A; material agent participation is declared.

**Verified maintainer/administrator exception evidence (or N/A):** N/A; this PR follows the approved Proposal/Design/TASK path.

**Approved Proposal Issue URL (or N/A with explanation):** https://github.com/higress-group/higress/issues/4022

**Approved Design Issue URL (or N/A with explanation):** https://github.com/higress-group/higress/issues/4442

**Maintainer approval link(s) (or N/A with explanation):** https://github.com/higress-group/higress/issues/4442#issuecomment-5260746437 and https://github.com/higress-group/higress/issues/4442#issuecomment-5260786221

**Authorized implementation TASK link(s) (or N/A with explanation):** https://github.com/higress-group/higress/issues/4442#issuecomment-5281229492

**Verification Plan and verification TASK/evidence link(s) (or N/A with explanation):** Design Verification Plan: https://github.com/higress-group/higress/issues/4442; focused verification: https://github.com/higress-group/higress/issues/4442#issuecomment-5281229912; protected post-merge rehearsal: https://github.com/higress-group/higress/issues/4442#issuecomment-5255965383.

## V. Testing and verification

**Test and deterministic rerun commands (or N/A with explanation):**

```text
cd tools/plugin-release && go test ./... -run 'Test(PreparationClassifiesRealAIHashWithoutReadingEmbedded401AsAuthorization|PromotionDescriptorClassifiersIgnoreAuthDigitsInsideExpectedReference|PromotionDescriptorClassifiersIgnore404InsideExpectedReferences|ClassifyOCIFailure)' -count=1 -v
cd tools/plugin-release && go test ./... -count=1
cd tools/plugin-release && go vet ./...
cd tools/plugin-release && go run . validate-catalog --root ../.. --catalog ../../plugins/release/catalog.json
go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 .github/workflows/prepare-plugin-release.yaml .github/workflows/promote-plugin-release.yaml
git diff --check 4784897bff09562e0406eef6a4ba7d07da2f52d3..312d5f3a13021a5dccfa105780a5a2a419f98ac7
```

All checks passed. Full plugin-release tests passed in 6.500 seconds. Both promotion classifiers are extracted from their `# BEGIN/# END promotion-descriptor-contract` markers and executed directly.

**Environment and configuration (or N/A with explanation):** Linux x86_64; Go 1.26.0; jq 1.6; actionlint 1.7.7. A checksum-verified ORAS 1.2.3 binary from the official release was used for live read-only candidate resolution. No registry write credential was used for repair-head verification.

**Exact tested revision, version, image tag/digest, manifests, and values (or N/A with explanation):** Base `4784897bff09562e0406eef6a4ba7d07da2f52d3`; exact head `312d5f3a13021a5dccfa105780a5a2a419f98ac7`; gateway `2.2.4`; plan ID `sha256:5a150abf7a1a76129eef4e2d61927116a59c9141f87cdfb1d4a0b0f58e049a54`; plan SHA-256 `51ed778debf5eb9e0c66debdf82d49e8714375d512ef8c42df35e45fdbdc15a8`; bootstrap evidence SHA-256 `eedf9bc97fe940877cc0976bb1899e31b24eb0434ccef6bdb0c8fed7baece0c1`.

Partial-run `ai-agent` candidate resolved read-only with ORAS 1.2.3 to manifest `sha256:e7503d0fa25b6793be721df1cc3ce8ae642cb742a8c79ef4c4c2420353485054`, single WASM layer `sha256:d0335faf4b9875abab1ac64b6bfd3bd5122d50c58fcbe4840d80e39f24373eb7`, source `4784897bff09562e0406eef6a4ba7d07da2f52d3`, version `2.0.1`, and the exact planned input hash.

The exact `ai-cache` candidate remains absent. ORAS 1.2.3 reproduced ACR's provider-structured exact-reference `not found` error containing the input-hash substring `401`; executable workflow contracts prove that response authorizes exactly one push, while transport errors echoing the same reference and genuine structured authorization responses perform zero pushes.

**Baseline reproduction evidence for bug fixes (or N/A with explanation):** Successful exact-main dry-run: https://github.com/higress-group/higress/actions/runs/31703639823. Failed formal run: https://github.com/higress-group/higress/actions/runs/31704623392, job https://github.com/higress-group/higress/actions/runs/31704623392/job/94462732739. ACR returned exact-reference absence for `ai-cache`, but its input hash contained `401`, so the former bare numeric authorization regex aborted before the valid absence branch.

**Fixed-version verification evidence for bug fixes (or N/A with explanation):** Actual-shell tests cover the full real `ai-cache` reference, structured 401/403 and authorization phrases, transport echoes, both promotion completion-marker/version/latest reference shapes containing `404`, strict absence, and no-mutation negative states. Independent exact-head review found one P1 in promotion's remaining raw `404` scan; the original writer repaired it at `312d5f3a...`, and re-review concluded P0=0, P1=0, P2=2.

**Wasm source revision and SHA-256 (or N/A with explanation):** The retained `ai-agent` candidate records source `4784897bff09562e0406eef6a4ba7d07da2f52d3` and WASM layer `sha256:d0335faf4b9875abab1ac64b6bfd3bd5122d50c58fcbe4840d80e39f24373eb7`. No public artifact was published by this PR verification.

## VI. Special notes for reviewers

The classifier intentionally separates two views of an error: reference-stripped text is used for general status/authorization decisions so content hashes cannot synthesize evidence; raw stderr is used only for ACR's conjunctive provider prefix plus exact fully qualified reference `not found` proof.

Two non-blocking P2 hardening notes remain and are published inline: the read-only preparation preflight retains a loose `404` scan, and ORAS-derived `/v2/.../manifests/...` URLs can retain authorization-like plugin-name words after literal OCI-ref removal. Both paths fail closed before protected mutation; neither permits an erroneous write in the current 2.2.4 plan.

### Implementation Rationale

- Strip only the exact expected reference before authorization scanning, while retaining raw provider output for strict ACR absence proof.
- Require structured HTTP/status context for numeric authorization and absence codes so random digest digits cannot control release state.
- Keep the two promotion descriptor classifiers byte-identical and executable-testable because both version and `latest` phases inspect content-addressed references.
- Test the production failure reference through the workflow shell itself so future regex changes cannot silently reintroduce hash-dependent behavior.

## VII. AI coding disclosure

**Tool(s) used (or N/A):** OpenAI Codex with one isolated implementation worker and one independent read-only reviewer.

### Prompts or instructions

After formal run 31704623392 exposed the embedded-`401` false authorization result, the worker was instructed to establish a hash-safe classifier across the approved preparation/promotion/bootstrap entry points, add executable actual-shell contracts, stay within five owned paths, run the specified validation, and commit with DCO signoff. The independent reviewer was instructed to inspect exact base/head and report only P0/P1/P2 findings. Its promotion embedded-`404` P1 was returned unchanged to the same writer, repaired, and re-reviewed to zero P0/P1. No credentials or secrets were included.

### AI-assisted work summary

Codex diagnosed the protected formal-run failure, captured the real ACR stderr, independently resolved the partial `ai-agent` candidate and confirmed `ai-cache` absence with ORAS 1.2.3, created implementation/verification TASKs, delegated the bounded classifier repair, reran exact-head tests/static checks, and completed the independent review/repair loop. No public version tag, `latest`, snapshot PR, Console, plugin-server, or Standalone state was changed.
