### PR TITLE
fix(mcp-server): avoid panic on non-string serviceMatcher values

### DIFF
--- a/plugins/golang-filter/mcp-server/registry/nacos/server.go
+++ b/plugins/golang-filter/mcp-server/registry/nacos/server.go
@@ -141,7 +141,11 @@ func (c *NacosConfig) ParseConfig(config map[string]any) error {
 
 	matchers := map[string]string{}
 	for key, value := range serviceMatcher {
-		matchers[key] = value.(string)
+		v, ok := value.(string)
+		if !ok {
+			return fmt.Errorf("serviceMatcher value for key %q must be a string", key)
+		}
+		matchers[key] = v
 	}
 
 	c.ServiceMatcher = &matchers


### PR DESCRIPTION
## What is the purpose of the change

Fix #4476.

The nacos registry ParseConfig did matchers[key] = value.(string) over user-supplied serviceMatcher values without a comma-ok check. A non-string value panicked the mcp-server filter during config parsing.

## Brief changelog

- nacos/server.go: use comma-ok assertion and return a clear error when a serviceMatcher value is not a string

## How was this patch verified

- gofmt clean