### PR TITLE
fix(mcp-server): select the last instance during remote load balancing

### DIFF
--- a/plugins/golang-filter/mcp-server/registry/remote.go
+++ b/plugins/golang-filter/mcp-server/registry/remote.go
@@ -190,7 +190,7 @@ func selectOneInstance(ctx *RpcContext) (*Instance, error) {
 
 	instances := *ctx.Instances
 	if len(instances) > 1 {
-		instanceId = rand.Intn(len(instances) - 1)
+		instanceId = rand.Intn(len(instances))
 	}
 	select_instance := instances[instanceId]
 	return &select_instance, nil


### PR DESCRIPTION
## What is the purpose of the change

Fix #4477.

selectOneInstance used rand.Intn(len(instances) - 1) when there was more than one instance, so the last instance was never selected during remote load balancing.

## Brief changelog

- remote.go: use rand.Intn(len(instances)) to cover every instance

## How was this patch verified

- gofmt clean