### PR TITLE
fix(mcp-server): guard config Merge type assertions

### DIFF
--- a/plugins/golang-filter/mcp-server/config.go
+++ b/plugins/golang-filter/mcp-server/config.go
@@ -159,8 +159,14 @@ func (p *Parser) Parse(any *anypb.Any, callbacks api.ConfigCallbackHandler) (int
 }
 
 func (p *Parser) Merge(parent interface{}, child interface{}) interface{} {
-	parentConfig := parent.(*config)
-	childConfig := child.(*config)
+	parentConfig, ok := parent.(*config)
+	if !ok || parentConfig == nil {
+		return child
+	}
+	childConfig, ok := child.(*config)
+	if !ok || childConfig == nil {
+		return parentConfig
+	}
 
 	newConfig := *parentConfig
 	if childConfig.servers != nil {


### PR DESCRIPTION
## What is the purpose of the change

Fix #4479.

Parser.Merge did parent.(*config) and child.(*config) without a comma-ok check. A nil or unexpected parent/child type panicked during filter chain config merging.

## Brief changelog

- mcp-server/config.go: use comma-ok assertions with a safe fallback

## How was this patch verified

- gofmt clean