### PR TITLE
fix: reuse plugin candidates before rebuilding

### DIFF
--- a/.github/workflows/prepare-plugin-release.yaml
+++ b/.github/workflows/prepare-plugin-release.yaml
@@ -244,20 +244,22 @@ jobs:
           }
           # END plugin-build-contract
           # BEGIN candidate-publish-contract
-          publish_or_reuse_candidate() {
-            local candidate=$1 wasm=$2 source_commit=$3 version=$4 input_hash=$5
-            local candidate_repo descriptor manifest resolved_digest push_result lookup_error wasm_digest
-            [[ "$source_commit" =~ ^[0-9a-f]{40}$ ]]
-            [[ "$version" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]
-            [[ "$input_hash" =~ ^sha256:[0-9a-f]{64}$ ]]
-            test -s "$wasm"
-            wasm_digest="sha256:$(sha256sum "$wasm" | awk '{print $1}')"
+          resolve_or_build_candidate() {
+            local candidate=$1 implementation=$2 source=$3 build_name=$4 source_commit=$5 version=$6 input_hash=$7
+            local candidate_repo descriptor manifest resolved_digest push_result lookup_error auth_error wasm
+            # Bash normally clears errexit inside command substitution. Restore
+            # it because the caller captures this function's digest that way.
+            set -e
+            if ! [[ "$source_commit" =~ ^[0-9a-f]{40}$ ]]; then echo "invalid candidate source commit" >&2; return 1; fi
+            if ! [[ "$version" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then echo "invalid stable candidate version" >&2; return 1; fi
+            if ! [[ "$input_hash" =~ ^sha256:[0-9a-f]{64}$ ]]; then echo "invalid candidate input hash" >&2; return 1; fi
             candidate_repo=${candidate%:*}
             lookup_error=$(mktemp)
             if descriptor=$(oras manifest fetch "$candidate" --descriptor 2>"$lookup_error"); then
               rm -f "$lookup_error"
-              if ! resolved_digest=$(jq -er '
-                select(.mediaType == "application/vnd.oci.image.manifest.v1+json")
+              if ! resolved_digest=$(jq -ser '
+                select(length == 1) | .[0]
+                | select(.mediaType == "application/vnd.oci.image.manifest.v1+json")
                 | .digest | strings | select(test("^sha256:[0-9a-f]{64}$"))
               ' <<<"$descriptor"); then
                 echo "existing candidate descriptor is malformed: $candidate" >&2
@@ -267,17 +269,19 @@ jobs:
                 echo "existing candidate manifest cannot be resolved by digest: $candidate_repo@$resolved_digest" >&2
                 return 1
               fi
-              if ! jq -e --arg commit "$source_commit" --arg version "$version" --arg input_hash "$input_hash" --arg wasm_digest "$wasm_digest" '
-                .schemaVersion == 2 and
-                .mediaType == "application/vnd.oci.image.manifest.v1+json" and
-                (.annotations["org.opencontainers.image.revision"] == $commit) and
-                (.annotations["org.opencontainers.image.version"] == $version) and
-                (.annotations["io.higress.plugin.input-hash"] == $input_hash) and
-                (.layers | length == 1) and
-                (.layers[0].mediaType == "application/vnd.module.wasm.content.layer.v1+wasm") and
-                (.layers[0].digest == $wasm_digest)
+              if ! jq -se --arg commit "$source_commit" --arg version "$version" --arg input_hash "$input_hash" '
+                length == 1 and (.[0] |
+                  .schemaVersion == 2 and
+                  .mediaType == "application/vnd.oci.image.manifest.v1+json" and
+                  (.annotations["org.opencontainers.image.revision"] == $commit) and
+                  (.annotations["org.opencontainers.image.version"] == $version) and
+                  (.annotations["io.higress.plugin.input-hash"] == $input_hash) and
+                  (.layers | type == "array" and length == 1) and
+                  (.layers[0].mediaType == "application/vnd.module.wasm.content.layer.v1+wasm") and
+                  (.layers[0].digest | strings | test("^sha256:[0-9a-f]{64}$"))
+                )
               ' >/dev/null <<<"$manifest"; then
-                echo "existing candidate does not match the locally rebuilt artifact: $candidate" >&2
+                echo "existing candidate manifest does not match its planned provenance: $candidate" >&2
                 return 1
               fi
               printf '%s\n' "$resolved_digest"
@@ -299,11 +303,19 @@ jobs:
               echo "candidate lookup failed without explicit absence evidence: $candidate" >&2
               return 1
             fi
+            # This function is consumed through command substitution below, so
+            # keep build output visible without mixing it into the digest value.
+            prepare_test_and_build_plugin "$implementation" "$source" "$build_name" >&2
+            wasm="$source/plugin.wasm"
+            if ! test -s "$wasm"; then
+              echo "candidate build did not produce plugin.wasm: $candidate" >&2
+              return 1
+            fi
             if ! push_result=$(oras push "$candidate" "$wasm:application/vnd.module.wasm.content.layer.v1+wasm" --annotation "org.opencontainers.image.revision=$source_commit" --annotation "org.opencontainers.image.version=$version" --annotation "io.higress.plugin.input-hash=$input_hash" --format json); then
               echo "candidate push failed: $candidate" >&2
               return 1
             fi
-            if ! resolved_digest=$(jq -er '.digest | strings | select(test("^sha256:[0-9a-f]{64}$"))' <<<"$push_result"); then
+            if ! resolved_digest=$(jq -ser 'select(length == 1) | .[0].digest | strings | select(test("^sha256:[0-9a-f]{64}$"))' <<<"$push_result"); then
               echo "candidate push returned a malformed descriptor: $candidate" >&2
               return 1
             fi
@@ -318,12 +330,10 @@ jobs:
             source=$(jq -r .sourceDir <<<"$entry"); version=$(jq -r .version <<<"$entry"); input_hash=$(jq -r .inputHash <<<"$entry")
             build_name=$(basename "$source")
             [[ "$source" = "plugins/wasm-$implementation/extensions/$build_name" ]]
-            prepare_test_and_build_plugin "$implementation" "$source" "$build_name"
-            wasm="$source/plugin.wasm"; test -s "$wasm"
             # Both hashes are fixed-width SHA-256 hex strings, so concatenation
             # retains their complete identities while meeting OCI's 128-byte tag limit.
             candidate="$CANDIDATE_REGISTRY/candidates/$id:${plan_id}${input_hash#sha256:}"
-            digest=$(publish_or_reuse_candidate "$candidate" "$wasm" "$source_commit" "$version" "$input_hash")
+            digest=$(resolve_or_build_candidate "$candidate" "$implementation" "$source" "$build_name" "$source_commit" "$version" "$input_hash")
             jq --arg id "$id" --arg ref "${candidate%@*}@$digest" --arg digest "$digest" --arg commit "$source_commit" --arg hash "$input_hash" '.plugins[$id]={candidateRef:$ref,digest:$digest,sourceCommit:$commit,inputHash:$hash}' /tmp/candidates.json >/tmp/candidates.next && mv /tmp/candidates.next /tmp/candidates.json
           done
           cp /tmp/candidates.json "plugins/release/evidence/$GATEWAY_VERSION.json"

--- a/tools/plugin-release/plugin_server_workflow_contract_test.go
+++ b/tools/plugin-release/plugin_server_workflow_contract_test.go
@@ -4,6 +4,7 @@
 package main
 
 import (
+	"bytes"
 	"crypto/sha256"
 	"errors"
 	"fmt"
@@ -358,9 +359,10 @@ printf 'build:%s\n' "$*" >> "$BUILD_LOG"
 }
 
 type candidateContractResult struct {
-	output string
-	log    string
-	err    error
+	output      string
+	diagnostics string
+	log         string
+	err         error
 }
 
 func runCandidatePublishContract(t *testing.T, mode string) candidateContractResult {
@@ -375,24 +377,43 @@ func runCandidatePublishContractWithCandidate(t *testing.T, mode, candidate stri
 	if err := os.MkdirAll(bin, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	log := filepath.Join(tmp, "oras.log")
+	log := filepath.Join(tmp, "operations.log")
+	source := filepath.Join(tmp, "plugin")
 	wasm := filepath.Join(tmp, "plugin.wasm")
 	wasmBytes := []byte("deterministic wasm fixture")
-	if err := os.WriteFile(wasm, wasmBytes, 0o600); err != nil {
+	if err := os.MkdirAll(source, 0o755); err != nil {
 		t.Fatal(err)
 	}
+	wasm = filepath.Join(source, "plugin.wasm")
 	wasmSum := sha256.Sum256(wasmBytes)
+	writeExecutableFixture(t, filepath.Join(source, "prepare.sh"), `#!/bin/sh
+set -eu
+printf 'prepare\n' >> "$OPERATIONS_LOG"
+if [ "$ORAS_MODE" = absent-build-error ]; then exit 23; fi
+`)
+	writeExecutableFixture(t, filepath.Join(bin, "go"), `#!/bin/sh
+set -eu
+printf 'test:%s\n' "$*" >> "$OPERATIONS_LOG"
+printf 'go test fixture output\n'
+`)
+	writeExecutableFixture(t, filepath.Join(bin, "make"), `#!/bin/sh
+set -eu
+printf 'build:%s\n' "$*" >> "$OPERATIONS_LOG"
+printf '%s' 'deterministic wasm fixture' > "$WASM_PATH"
+printf 'make fixture output\n'
+`)
 	writeExecutableFixture(t, filepath.Join(bin, "oras"), `#!/usr/bin/env bash
 set -euo pipefail
-printf '%s\n' "$*" >> "$ORAS_LOG"
+printf 'oras:%s\n' "$*" >> "$OPERATIONS_LOG"
 if [ "$1 $2" = "manifest fetch" ]; then
   ref=$3
   if [ "${4:-}" = "--descriptor" ]; then
     case "$ORAS_MODE" in
       absent-404) echo "response status code 404: Not Found" >&2; exit 1 ;;
-      absent-manifest) echo "MANIFEST UNKNOWN" >&2; exit 1 ;;
-      absent-name) echo "name unknown" >&2; exit 1 ;;
-      absent-acr) echo "Error response from registry: $ref: not found" >&2; exit 1 ;;
+	  absent-manifest) echo "MANIFEST UNKNOWN" >&2; exit 1 ;;
+	  absent-name) echo "name unknown" >&2; exit 1 ;;
+	  absent-acr) echo "Error response from registry: $ref: not found" >&2; exit 1 ;;
+	  absent-build-error|absent-push-error|absent-malformed-push) echo "response status code 404: Not Found" >&2; exit 1 ;;
       auth) echo "401 unauthorized" >&2; exit 1 ;;
       auth-401-status) echo "response status code 401" >&2; exit 1 ;;
       auth-403-http) echo "HTTP/1.1 403" >&2; exit 1 ;;
@@ -411,23 +432,32 @@ if [ "$1 $2" = "manifest fetch" ]; then
   case "$ORAS_MODE" in
     manifest-error) echo "registry unavailable" >&2; exit 1 ;;
     malformed-manifest) echo '{'; exit 0 ;;
+		wrong-manifest-media) manifest_media=application/example ;;
   esac
   revision=$SOURCE_COMMIT
   version=$STABLE_VERSION
   input_hash=$INPUT_HASH
   layer_digest=$WASM_DIGEST
-  layer_media=application/vnd.module.wasm.content.layer.v1+wasm
-  layers=''
-  case "$ORAS_MODE" in
-    annotation-mismatch) revision=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb ;;
-    layer-digest-mismatch) layer_digest=sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee ;;
+	layer_media=application/vnd.module.wasm.content.layer.v1+wasm
+	manifest_media=${manifest_media:-application/vnd.oci.image.manifest.v1+json}
+	layers=''
+	case "$ORAS_MODE" in
+	  annotation-mismatch) revision=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb ;;
+		version-mismatch) version=9.9.9 ;;
+		input-hash-mismatch) input_hash=sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee ;;
+		valid-different-layer) layer_digest=sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee ;;
+		invalid-layer-digest) layer_digest=sha256:not-a-digest ;;
     layer-media-mismatch) layer_media=application/octet-stream ;;
     layer-count-mismatch) layers=',{"mediaType":"application/vnd.module.wasm.content.layer.v1+wasm","digest":"sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"}' ;;
   esac
-  printf '{"schemaVersion":2,"mediaType":"application/vnd.oci.image.manifest.v1+json","annotations":{"org.opencontainers.image.revision":"%s","org.opencontainers.image.version":"%s","io.higress.plugin.input-hash":"%s"},"layers":[{"mediaType":"%s","digest":"%s"}%s]}\n' "$revision" "$version" "$input_hash" "$layer_media" "$layer_digest" "$layers"
+  printf '{"schemaVersion":2,"mediaType":"%s","annotations":{"org.opencontainers.image.revision":"%s","org.opencontainers.image.version":"%s","io.higress.plugin.input-hash":"%s"},"layers":[{"mediaType":"%s","digest":"%s"}%s]}\n' "$manifest_media" "$revision" "$version" "$input_hash" "$layer_media" "$layer_digest" "$layers"
   exit 0
 fi
 if [ "$1" = push ]; then
+	case "$ORAS_MODE" in
+	  absent-push-error) echo "registry rejected candidate push" >&2; exit 1 ;;
+	  absent-malformed-push) echo '{'; exit 0 ;;
+	esac
   printf '{"digest":"%s"}\n' "$ORAS_PUSH_DIGEST"
   exit 0
 fi
@@ -439,12 +469,14 @@ exit 2
 	const inputHash = "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
 	const manifestDigest = "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
 	const pushDigest = "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
-	contract := workflowShellContract(t, "prepare-plugin-release.yaml", "candidate-publish-contract")
-	script := "set -euo pipefail\n" + contract + fmt.Sprintf("\npublish_or_reuse_candidate %q %q %q 1.2.3 %q\n", candidate, wasm, sourceCommit, inputHash)
+	buildContract := workflowShellContract(t, "prepare-plugin-release.yaml", "plugin-build-contract")
+	publishContract := workflowShellContract(t, "prepare-plugin-release.yaml", "candidate-publish-contract")
+	script := "set -euo pipefail\n" + buildContract + publishContract + fmt.Sprintf("\ndigest=$(resolve_or_build_candidate %q go %q demo %q 1.2.3 %q)\nprintf '%%s\\n' \"$digest\"\n", candidate, source, sourceCommit, inputHash)
 	cmd := exec.Command("bash", "-c", script)
 	cmd.Env = append(os.Environ(),
 		"PATH="+bin+":"+os.Getenv("PATH"),
-		"ORAS_LOG="+log,
+		"OPERATIONS_LOG="+log,
+		"WASM_PATH="+wasm,
 		"ORAS_MODE="+mode,
 		"ORAS_MANIFEST_DIGEST="+manifestDigest,
 		"ORAS_PUSH_DIGEST="+pushDigest,
@@ -453,28 +485,37 @@ exit 2
 		"INPUT_HASH="+inputHash,
 		fmt.Sprintf("WASM_DIGEST=sha256:%x", wasmSum),
 	)
-	output, runErr := cmd.CombinedOutput()
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	runErr := cmd.Run()
 	logBytes, readErr := os.ReadFile(log)
 	if readErr != nil && !os.IsNotExist(readErr) {
 		t.Fatal(readErr)
 	}
-	return candidateContractResult{output: string(output), log: string(logBytes), err: runErr}
+	return candidateContractResult{output: stdout.String(), diagnostics: stderr.String(), log: string(logBytes), err: runErr}
 }
 
-func TestPreparationReusesOnlyIdenticalContentAddressedCandidate(t *testing.T) {
-	result := runCandidatePublishContract(t, "identical")
-	if result.err != nil {
-		t.Fatalf("identical candidate was not reused: %v\n%s", result.err, result.output)
-	}
-	want := "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc\n"
-	if result.output != want {
-		t.Fatalf("reused candidate digest = %q, want %q", result.output, want)
-	}
-	if strings.Contains(result.log, "push ") {
-		t.Fatalf("identical candidate was pushed again:\n%s", result.log)
-	}
-	if strings.Count(result.log, "manifest fetch ") != 2 || !strings.Contains(result.log, "@sha256:") {
-		t.Fatalf("reuse did not resolve descriptor then immutable manifest digest:\n%s", result.log)
+func TestPreparationReusesValidExistingCandidateWithoutRebuilding(t *testing.T) {
+	for _, mode := range []string{"identical", "valid-different-layer"} {
+		t.Run(mode, func(t *testing.T) {
+			result := runCandidatePublishContract(t, mode)
+			if result.err != nil {
+				t.Fatalf("valid candidate was not reused: %v\n%s", result.err, result.diagnostics)
+			}
+			want := "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc\n"
+			if result.output != want {
+				t.Fatalf("reused candidate digest = %q, want %q", result.output, want)
+			}
+			for _, forbidden := range []string{"prepare\n", "test:", "build:", "oras:push "} {
+				if strings.Contains(result.log, forbidden) {
+					t.Fatalf("valid candidate performed %q instead of read-only reuse:\n%s", forbidden, result.log)
+				}
+			}
+			if strings.Count(result.log, "oras:manifest fetch ") != 2 || !strings.Contains(result.log, "@sha256:") {
+				t.Fatalf("reuse did not resolve descriptor then immutable manifest digest:\n%s", result.log)
+			}
+		})
 	}
 }
 
@@ -489,8 +530,21 @@ func TestPreparationPushesOnceOnlyForStrictlyProvenCandidateAbsence(t *testing.T
 			if result.output != want {
 				t.Fatalf("new candidate digest = %q, want %q", result.output, want)
 			}
-			if strings.Count(result.log, "push ") != 1 {
+			for _, wantOperation := range []string{"prepare\n", "test:test ./...\n", "build:-C plugins/wasm-go PLUGIN_NAME=demo build\n"} {
+				if strings.Count(result.log, wantOperation) != 1 {
+					t.Fatalf("strict absence did not perform setup/test/build exactly once (%q):\n%s", wantOperation, result.log)
+				}
+			}
+			if strings.Count(result.log, "oras:push ") != 1 {
 				t.Fatalf("strict absence performed other than one push:\n%s", result.log)
+			}
+			previous := -1
+			for _, operation := range []string{"oras:manifest fetch ", "prepare\n", "test:test ./...\n", "build:-C plugins/wasm-go PLUGIN_NAME=demo build\n", "oras:push "} {
+				position := strings.Index(result.log, operation)
+				if position <= previous {
+					t.Fatalf("strict absence operations are not lookup -> setup -> test -> build -> push at %q:\n%s", operation, result.log)
+				}
+				previous = position
 			}
 		})
 	}
@@ -499,8 +553,8 @@ func TestPreparationPushesOnceOnlyForStrictlyProvenCandidateAbsence(t *testing.T
 func TestPreparationCandidateLookupAndManifestMismatchesFailWithoutMutation(t *testing.T) {
 	modes := []string{
 		"auth", "ambiguous", "repository-missing", "wrong-acr-ref", "transport", "malformed-descriptor", "wrong-descriptor-media",
-		"manifest-error", "malformed-manifest", "annotation-mismatch", "layer-count-mismatch",
-		"layer-media-mismatch", "layer-digest-mismatch",
+		"manifest-error", "malformed-manifest", "wrong-manifest-media", "annotation-mismatch", "version-mismatch", "input-hash-mismatch",
+		"layer-count-mismatch", "layer-media-mismatch", "invalid-layer-digest",
 	}
 	for _, mode := range modes {
 		t.Run(mode, func(t *testing.T) {
@@ -508,10 +562,42 @@ func TestPreparationCandidateLookupAndManifestMismatchesFailWithoutMutation(t *t
 			if result.err == nil {
 				t.Fatalf("unsafe candidate state %s was accepted: %s", mode, result.output)
 			}
-			if strings.Contains(result.log, "push ") {
-				t.Fatalf("unsafe candidate state %s caused mutation:\n%s", mode, result.log)
+			for _, forbidden := range []string{"prepare\n", "test:", "build:", "oras:push "} {
+				if strings.Contains(result.log, forbidden) {
+					t.Fatalf("unsafe candidate state %s performed %q:\n%s", mode, forbidden, result.log)
+				}
 			}
 		})
+	}
+}
+
+func TestPreparationCandidatePushFailuresDoNotReturnEvidence(t *testing.T) {
+	for _, mode := range []string{"absent-push-error", "absent-malformed-push"} {
+		t.Run(mode, func(t *testing.T) {
+			result := runCandidatePublishContract(t, mode)
+			if result.err == nil {
+				t.Fatalf("candidate push failure %s was accepted: %s", mode, result.output)
+			}
+			if result.output != "" {
+				t.Fatalf("candidate push failure %s returned evidence %q", mode, result.output)
+			}
+			if strings.Count(result.log, "oras:push ") != 1 {
+				t.Fatalf("candidate push failure %s performed other than one bounded push attempt:\n%s", mode, result.log)
+			}
+		})
+	}
+}
+
+func TestPreparationCandidateBuildFailureDoesNotPush(t *testing.T) {
+	result := runCandidatePublishContract(t, "absent-build-error")
+	if result.err == nil {
+		t.Fatalf("candidate build failure was accepted: %s", result.output)
+	}
+	if result.output != "" || strings.Contains(result.log, "oras:push ") {
+		t.Fatalf("candidate build failure returned evidence or pushed a candidate: output=%q\n%s", result.output, result.log)
+	}
+	if strings.Count(result.log, "prepare\n") != 1 || strings.Contains(result.log, "test:") || strings.Contains(result.log, "build:") {
+		t.Fatalf("candidate setup failure did not stop test/build immediately:\n%s", result.log)
 	}
 }
 
@@ -521,7 +607,7 @@ func TestPreparationDoesNotReadEmbedded404FromRealCandidateTagAsHTTPAbsence(t *t
 	if result.err == nil {
 		t.Fatalf("transport error containing the ai-proxy tag's embedded 404 was accepted: %s", result.output)
 	}
-	if strings.Contains(result.log, "push ") {
+	if strings.Contains(result.log, "oras:push ") {
 		t.Fatalf("transport error containing the ai-proxy tag's embedded 404 caused a push:\n%s", result.log)
 	}
 }
@@ -533,19 +619,19 @@ func TestPreparationClassifiesRealAIHashWithoutReadingEmbedded401AsAuthorization
 	if absent.err != nil {
 		t.Fatalf("exact ACR absence for real ai-cache candidate was not published: %v\n%s", absent.err, absent.output)
 	}
-	if strings.Count(absent.log, "push ") != 1 {
+	if strings.Count(absent.log, "oras:push ") != 1 {
 		t.Fatalf("exact ACR absence must perform one push:\n%s", absent.log)
 	}
 
 	transport := runCandidatePublishContractWithCandidate(t, "transport-with-ref", aiCacheCandidate)
-	if transport.err == nil || strings.Contains(transport.log, "push ") {
+	if transport.err == nil || strings.Contains(transport.log, "oras:push ") {
 		t.Fatalf("transport error echoing real ai-cache candidate must fail without push: err=%v\n%s", transport.err, transport.log)
 	}
 
 	for _, mode := range []string{"auth-401-status", "auth-403-http", "auth", "auth-phrase-denied", "auth-phrase-required"} {
 		t.Run(mode, func(t *testing.T) {
 			result := runCandidatePublishContractWithCandidate(t, mode, aiCacheCandidate)
-			if result.err == nil || strings.Contains(result.log, "push ") {
+			if result.err == nil || strings.Contains(result.log, "oras:push ") {
 				t.Fatalf("authorization evidence %s must fail without push: err=%v\n%s", mode, result.err, result.log)
 			}
 		})


### PR DESCRIPTION
## I. Summary

Make immutable plugin-candidate retries resolve and validate an existing exact candidate before running plugin setup, tests, or builds.

- A valid candidate is bound to its digest-resolved OCI manifest, exact Higress source commit, stable plugin version, artifact input hash, and one valid WASM layer, then reused without rebuilding or pushing.
- Only strict, hash-safe registry absence crosses the mutation boundary and runs setup -> test -> build -> one candidate push.
- Authorization, ambiguous transport failures, malformed/mismatched provenance, build failures, and push failures remain fail closed and do not produce candidate evidence.

This repairs formal Higress 2.2.4 preparation retries for Rust artifacts whose rebuilt WASM bytes may differ across runners. It does not change the release plan, candidate identity, public version/`latest` promotion, Console defaults, plugin-server, or Standalone behavior.

## II. Related issue

Related to #4022 and #4442. Implements [TASK-4442023](https://github.com/higress-group/higress/issues/4442#issuecomment-5282659666); exact-head verification is tracked by [TASK-4442024](https://github.com/higress-group/higress/issues/4442#issuecomment-5282660459). [TASK-4442005](https://github.com/higress-group/higress/issues/4442#issuecomment-5255965383) continues to own the protected post-merge 2.2.4 rehearsal.

## III. Change type

- [x] Bug fix
- [ ] Feature or enhancement
- [ ] Documentation or configuration only
- [x] Refactoring, tests, or maintenance

## IV. Agent participation and issue-spec gate

- [ ] **No agent participation:** This PR is human-only.
- [ ] **Trivial agent-use exception:** Agent use was limited to spelling, punctuation, whitespace, or formatting with no substantive choice or behavioral effect.
- [ ] **Verified maintainer/administrator exception:** Material agent participation occurred under the verified exception.
- [x] **Material agent participation:** An AI or coding agent materially participated in analysis, implementation, testing, review, and PR preparation.

- [x] **Before implementation began:** A Higress maintainer had approved the Proposal and Design Issues, and authorized implementation TASKs linked the work to the applicable SPECs.
- [x] **Before verification began:** The Design contained a concrete Verification Plan.
- [x] **Before requesting maintainer review or acceptance:** Applicable implementation and exact-head verification TASKs were completed with exact commands, results, evidence links, and hashes before this draft was moved to ready.

- [x] Complete: all three timed obligations above were satisfied.
- [ ] Noncompliant: one or more obligations were not satisfied.
- [ ] Verified exception: material agent participation used the verified-maintainer/administrator exception.
- [ ] N/A because the PR is human-only or qualifies for the trivial exception.

**Gate-status explanation (or N/A):** Approved Proposal #4022 and Design #4442 define restartable content-addressed candidates, identical retry, strict registry absence, and fail-closed mutation boundaries. TASK-4442023 is the bounded retry-order repair; TASK-4442024 records exact-head verification. Protected live-registry validation remains the post-merge responsibility of TASK-4442005.

**Trivial-exception explanation (or N/A):** N/A; material agent participation is declared.

**Verified maintainer/administrator exception evidence (or N/A):** N/A; this PR follows the approved Proposal/Design/TASK path.

**Approved Proposal Issue URL (or N/A with explanation):** https://github.com/higress-group/higress/issues/4022

**Approved Design Issue URL (or N/A with explanation):** https://github.com/higress-group/higress/issues/4442

**Maintainer approval link(s) (or N/A with explanation):** https://github.com/higress-group/higress/issues/4442#issuecomment-5260746437 and https://github.com/higress-group/higress/issues/4442#issuecomment-5260786221

**Authorized implementation TASK link(s) (or N/A with explanation):** https://github.com/higress-group/higress/issues/4442#issuecomment-5282659666

**Verification Plan and verification TASK/evidence link(s) (or N/A with explanation):** Design Verification Plan: https://github.com/higress-group/higress/issues/4442; exact-head verification: https://github.com/higress-group/higress/issues/4442#issuecomment-5282660459; protected post-merge rehearsal: https://github.com/higress-group/higress/issues/4442#issuecomment-5255965383.

## V. Testing and verification

**Test and deterministic rerun commands (or N/A with explanation):**

```text
cd tools/plugin-release && go test ./... -run 'TestPreparation(ReusesValidExistingCandidateWithoutRebuilding|PushesOnceOnlyForStrictlyProvenCandidateAbsence|CandidateLookupAndManifestMismatchesFailWithoutMutation|CandidatePushFailuresDoNotReturnEvidence|CandidateBuildFailureDoesNotPush|ClassifiesRealAIHashWithoutReadingEmbedded401AsAuthorization|DoesNotReadEmbedded404FromRealCandidateTagAsHTTPAbsence)$' -count=1 -v
cd tools/plugin-release && go test ./... -count=1
cd tools/plugin-release && go vet ./...
cd tools/plugin-release && go run . validate-catalog --root ../.. --catalog ../../plugins/release/catalog.json
go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 .github/workflows/prepare-plugin-release.yaml
git diff --check e48c7232e114aada57dee7f805168d2032b1eb8c..19fd9b162eec7043426525cba2d40b0a46dc65b7
```

All checks passed. Coordinator full tests passed in 6.775 seconds; the independent reviewer repeated the focused candidate contract suite ten times and reported P0=0, P1=0, P2=0.

**Environment and configuration (or N/A with explanation):** Linux x86_64; Go 1.26.0; jq 1.6; Docker 28.1.1; actionlint 1.7.7. Exact-head verification used credential-free fake-ORAS/build contracts and public read-only ORAS resolution. No registry or GitHub write credential was provided to the writer or reviewer.

**Exact tested revision, version, image tag/digest, manifests, and values (or N/A with explanation):** Base `e48c7232e114aada57dee7f805168d2032b1eb8c`; exact head `19fd9b162eec7043426525cba2d40b0a46dc65b7`; tree `124c2135912143caccb857cffd8debb3c2680ae6`; gateway `2.2.4`; plan `sha256:54a454267f3f667d5cbeeee0f043a968c41fb2f961f8ae831bb144a892c256b4`.

At the baseline failure, the existing `ai-data-masking` candidate resolved to manifest `sha256:3ba11da25cf7838fdad49bd954120c0aeeea1f8ca5ed984a83c6545047e8eb11`, source `e48c7232e114aada57dee7f805168d2032b1eb8c`, version `2.0.1`, input hash `sha256:c417987f489129fe71d560b65081f9c01576635185195b045a9d8b199bec0201`, and one WASM layer `sha256:e83cd7f683d6c01cf442166c378083df10765b52bd0b77a4a330cddbd631b0aa`.

**Baseline reproduction evidence for bug fixes (or N/A with explanation):** [Formal run 31711646145](https://github.com/higress-group/higress/actions/runs/31711646145): attempt 1 stopped on a transient `proxy.golang.org` HTTP/2 download error after publishing an immutable prefix of candidates. Attempt 2 rebuilt before lookup and rejected the valid existing Rust candidate with `existing candidate does not match the locally rebuilt artifact` because the fresh WASM bytes differed.

**Fixed-version verification evidence for bug fixes (or N/A with explanation):** Actual workflow-shell tests prove valid existing candidates (including a different valid layer digest) perform zero setup/test/build/push; explicit HTTP/OCI/ACR absence performs exactly lookup -> setup -> test -> build -> one push; malformed descriptor/manifest/provenance/layer, authorization, ambiguous transport, build failure, and push failure return no evidence and perform no unauthorized mutation. The independent exact-head reviewer additionally confirmed registry-port parsing, full 128-character candidate tags, digest-only manifest resolution, stdout isolation, temporary-file cleanup, and command-substitution `errexit` behavior.

**Wasm source revision and SHA-256 (or N/A with explanation):** No new public WASM artifact was created during PR verification. The protected post-merge rehearsal will verify every candidate. The live read-only baseline candidate above records source `e48c7232e114aada57dee7f805168d2032b1eb8c` and layer `sha256:e83cd7f683d6c01cf442166c378083df10765b52bd0b77a4a330cddbd631b0aa`.

## VI. Special notes for reviewers

### Implementation Rationale

- `.github/workflows/prepare-plugin-release.yaml:resolve_or_build_candidate`: a content-addressed candidate is validated from its immutable descriptor, digest-resolved manifest, and planned provenance before any local build, so retries can reuse reviewed Rust bytes even when rebuilding is not byte reproducible.
- The same function permits mutation only after explicit registry absence. Build output is sent to stderr so command substitution captures exactly the candidate manifest digest, and every ambiguous state fails closed.

The candidate tag still retains the complete fixed-width plan and input hashes. Candidate immutability is an external prerequisite; the workflow never accepts conflicting provenance under the same exact tag. Post-merge protected live-registry validation remains mandatory and is not replaced by these credential-free tests.

Exact hashes: diff SHA-256 `80d6552d2888bcad7ecd3dacf126065bf01c747ce0a129235ced46d3fa59d0b3`; git archive SHA-256 `78202b0a72fe38190844f1394988d8af58d0a00b4abf4e723a061b4238812331`; workflow file SHA-256 `d3d8ca47d1d2adbc48b87a16c7b138aad992b40eedbae28a6d2632e389ae1392`; contract-test file SHA-256 `b7484c291438e4b9cabc5c0f5e0af94073c4c14b12309ed7fced059e2b79c7a3`.

## VII. AI coding disclosure

**Tool(s) used (or N/A):** OpenAI Codex with one isolated implementation writer and one independent read-only reviewer.

### Prompts or instructions

After formal run 31711646145 exposed retry failure for an already-published Rust candidate, the writer was instructed to implement the approved Design's pre-build exact-candidate resolution, preserve strict hash-safe absence and fail-closed behavior, add actual-workflow executable contracts, remain within two owned paths, run the specified validation, and commit with DCO. The reviewer received the exact base/head and was instructed to report only actionable P0/P1/P2 findings, with no write paths or credentials. No credentials or secrets were included.

### AI-assisted work summary

Codex diagnosed both formal-run attempts, independently resolved the valid `ai-data-masking` candidate, created implementation/verification TASKs, delegated the bounded workflow repair, reran exact-head tests/static checks, and completed independent review at P0=0/P1=0/P2=0. No public version tag, `latest`, snapshot PR, Console default, plugin-server image, Higress release tag, or Standalone state was changed.
