### PR TITLE
fix: refresh app token before publishing plugin snapshot PR

### DIFF
--- a/.github/workflows/prepare-plugin-release.yaml
+++ b/.github/workflows/prepare-plugin-release.yaml
@@ -128,6 +128,7 @@ jobs:
           ref: ${{ inputs.target_ref }}
           fetch-depth: 0
           token: ${{ inputs.dry_run && github.token || steps.app-token.outputs.token }}
+          persist-credentials: false
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: "1.24.0"
@@ -349,22 +350,32 @@ jobs:
           if [ -n "$PREVIOUS" ]; then args+=(--previous "../../$PREVIOUS"); else args+=(--previous /tmp/bootstrap-snapshot.json --bootstrap-evidence /tmp/bootstrap-evidence.json); fi
           (cd tools/plugin-release && go run . "${args[@]}")
           sha256sum "plugins/release/snapshots/$GATEWAY_VERSION.json" | tee -a "$GITHUB_STEP_SUMMARY"
+      - name: Refresh GitHub App token for preparation PR
+        if: ${{ !inputs.dry_run }}
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
+        id: pr-app-token
+        with:
+          app-id: ${{ vars.RELEASE_PR_APP_ID }}
+          private-key: ${{ secrets.RELEASE_PR_APP_PRIVATE_KEY }}
+          owner: higress-group
+          repositories: higress
       - name: Create or update deterministic preparation PR
         if: ${{ !inputs.dry_run }}
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ steps.pr-app-token.outputs.token }}
           GATEWAY_VERSION: ${{ inputs.gateway_version }}
           TARGET_REF: ${{ inputs.target_ref }}
         run: |
           set -euo pipefail
           # The generated PR must fork the exact main/code-freeze commit. If
           # main moved while candidates built, reprepare from the new freeze.
+          gh auth setup-git
           git fetch --no-tags origin main
           test "$(git rev-parse refs/remotes/origin/main)" = "$TARGET_REF"
           branch="release/plugin-snapshot-$GATEWAY_VERSION"
           git config user.name "higress-release-bot"; git config user.email "release-bot@higress.io"
           git checkout -B "$branch"
           git add plugins/wasm-go/extensions plugins/wasm-rust/extensions plugins/release/snapshots plugins/release/plans plugins/release/evidence plugins/release/bootstrap-evidence
-          git commit -m "chore: prepare plugin snapshot $GATEWAY_VERSION" || true
+          git commit -s -m "chore: prepare plugin snapshot $GATEWAY_VERSION" || true
           git push --force-with-lease origin "$branch"
           gh pr create --base main --head "$branch" --title "chore: prepare plugin snapshot $GATEWAY_VERSION" --body "Immutable candidate snapshot; review VERSION edits and digest provenance." || gh pr edit "$branch" --title "chore: prepare plugin snapshot $GATEWAY_VERSION" --body "Immutable candidate snapshot; review VERSION edits and digest provenance."

--- a/tools/plugin-release/plugin_server_workflow_contract_test.go
+++ b/tools/plugin-release/plugin_server_workflow_contract_test.go
@@ -864,6 +864,63 @@ func TestPreparationPreflightsReadOnlyDeterministicCatalogPublicManifest(t *test
 	}
 }
 
+func TestPreparationPRUsesAppTokenForGitAndSignsGeneratedCommit(t *testing.T) {
+	data, err := os.ReadFile("../../.github/workflows/prepare-plugin-release.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	workflow := string(data)
+	renderStart := strings.Index(workflow, "      - name: Render canonical snapshot\n")
+	refreshStart := strings.Index(workflow, "      - name: Refresh GitHub App token for preparation PR\n")
+	stepStart := strings.Index(workflow, "      - name: Create or update deterministic preparation PR\n")
+	if renderStart < 0 || refreshStart < 0 || stepStart < 0 || renderStart >= refreshStart || refreshStart >= stepStart {
+		t.Fatal("preparation workflow must refresh its App token after snapshot rendering and immediately before PR publication")
+	}
+	checkout := workflow[strings.Index(workflow, "  prepare:\n"):renderStart]
+	if !strings.Contains(checkout, "persist-credentials: false") {
+		t.Fatal("preparation checkout must not persist the job-start App token across the long candidate build")
+	}
+	refresh := workflow[refreshStart:stepStart]
+	for _, required := range []string{
+		"if: ${{ !inputs.dry_run }}",
+		"actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1",
+		"id: pr-app-token",
+		"app-id: ${{ vars.RELEASE_PR_APP_ID }}",
+		"private-key: ${{ secrets.RELEASE_PR_APP_PRIVATE_KEY }}",
+		"owner: higress-group",
+		"repositories: higress",
+	} {
+		if !strings.Contains(refresh, required) {
+			t.Fatalf("preparation workflow lacks fresh post-build App-token contract %q", required)
+		}
+	}
+	step := workflow[stepStart:]
+	for _, required := range []string{
+		`GH_TOKEN: ${{ steps.pr-app-token.outputs.token }}`,
+		"gh auth setup-git",
+		"git fetch --no-tags origin main",
+		`test "$(git rev-parse refs/remotes/origin/main)" = "$TARGET_REF"`,
+		`git commit -s -m "chore: prepare plugin snapshot $GATEWAY_VERSION"`,
+		`git push --force-with-lease origin "$branch"`,
+	} {
+		if !strings.Contains(step, required) {
+			t.Fatalf("preparation PR publication lacks App-authenticated/DCO contract %q", required)
+		}
+	}
+	auth := strings.Index(step, "gh auth setup-git")
+	fetch := strings.Index(step, "git fetch --no-tags origin main")
+	push := strings.Index(step, `git push --force-with-lease origin "$branch"`)
+	if auth < 0 || fetch < 0 || push < 0 || auth > fetch || fetch > push {
+		t.Fatal("App-token Git authentication must precede exact-main fetch and deterministic branch push")
+	}
+	if strings.Contains(step, "x-access-token:${GH_TOKEN}") || strings.Contains(step, "x-access-token:$GH_TOKEN") {
+		t.Fatal("preparation PR publication must not embed the App token in a remote URL")
+	}
+	if strings.Contains(step, `GH_TOKEN: ${{ steps.app-token.outputs.token }}`) {
+		t.Fatal("preparation PR publication must not reuse the job-start App token after a long candidate build")
+	}
+}
+
 func TestPreparationPRValidatorPinsAllActions(t *testing.T) {
 	data, err := os.ReadFile("../../.github/workflows/validate-plugin-preparation-pr.yaml")
 	if err != nil {


### PR DESCRIPTION
## I. Summary

Repair the final snapshot-PR publication step of `prepare-plugin-release` after the 43 candidate builds and snapshot rendering have completed.

- Do not persist the job-start GitHub App credential through the long build.
- Generate a fresh installation token immediately after snapshot rendering and use it for both Git and `gh` operations.
- Configure Git authentication with `gh auth setup-git` before the exact-main fetch and branch push.
- Sign the generated snapshot commit off so the bot-created PR passes DCO.

No candidate identity, version plan, snapshot contents, public tag, `latest`, Console, plugin-server, or Standalone behavior changes.

## II. Related issue

Related to #4022 and #4442. Fixes the final-step failure in [formal run 31722711345](https://github.com/higress-group/higress/actions/runs/31722711345).

## III. Change type

- [x] Bug fix
- [ ] Feature or enhancement
- [ ] Documentation or configuration only
- [x] Refactoring, tests, or maintenance

## IV. Agent participation and issue-spec gate

- [ ] **No agent participation:** This PR is human-only.
- [ ] **Trivial agent-use exception:** Agent use was limited to spelling, punctuation, whitespace, or formatting with no substantive choice or behavioral effect.
- [x] **Verified maintainer/administrator exception:** Material agent participation occurred, and authenticated `gh` verification confirmed a canonical-repository `role_name` of `admin`; the evidence is completed below after PR creation.
- [ ] **Material agent participation:** Material participation used the approved Proposal/Design/TASK gate path.

- [ ] **Before implementation began:** N/A under verified exception.
- [ ] **Before verification began:** N/A under verified exception.
- [ ] **Before requesting maintainer review or acceptance:** N/A under verified exception.

- [ ] Complete: all three timed obligations above were satisfied.
- [ ] Noncompliant: one or more obligations were not satisfied.
- [x] Verified exception: material agent participation used the verified-maintainer/administrator exception.
- [ ] N/A because the PR is human-only or qualifies for the trivial exception.

**Gate-status explanation (or N/A):** A canonical Higress administrator explicitly authorized autonomous repair/PR/merge for blockers in this 2.2.4 release chain. The exception does not waive runtime verification: the protected workflow will be rerun after merge.

**Trivial-exception explanation (or N/A):** N/A; material agent participation is declared.

**Verified maintainer/administrator exception evidence (or N/A):**

- This PR number or URL: https://github.com/higress-group/higress/pull/4487
- Authenticated `gh` login: `johnlanni`
- Canonical-repository `role_name`: `admin`
- Actual PR author from `gh pr view`: `johnlanni`
- Login/author match: yes
- Token override attestation (`GH_TOKEN` and `GITHUB_TOKEN` were unset for every verification command; required: `yes`): yes
- Bypass rationale: urgent bounded repair of the exact final-step failure in the already-approved and protected Higress 2.2.4 plugin release rehearsal; no release-plan or artifact semantics change.
- Maintainer live validation: performed by the same authenticated administrator before merge, with token overrides unset.

**Approved Proposal Issue URL (or N/A with explanation):** N/A for exception; surrounding release design is https://github.com/higress-group/higress/issues/4022.

**Approved Design Issue URL (or N/A with explanation):** N/A for exception; surrounding approved design is https://github.com/higress-group/higress/issues/4442.

**Maintainer approval link(s) (or N/A with explanation):** N/A under verified administrator exception; current task contains explicit maintainer authorization for autonomous blocker repair and merge.

**Authorized implementation TASK link(s) (or N/A with explanation):** N/A under verified administrator exception.

**Verification Plan and verification TASK/evidence link(s) (or N/A with explanation):** Exact-head tests/review below; protected post-merge runtime verification remains TASK-4442005: https://github.com/higress-group/higress/issues/4442#issuecomment-5255965383.

## V. Testing and verification

**Test and deterministic rerun commands (or N/A with explanation):**

```text
cd tools/plugin-release && go test ./... -run '^TestPreparationPRUsesAppTokenForGitAndSignsGeneratedCommit$' -count=1 -v
cd tools/plugin-release && go test ./... -count=1
cd tools/plugin-release && go vet ./...
cd tools/plugin-release && go run . validate-catalog --root ../.. --catalog ../../plugins/release/catalog.json
go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 .github/workflows/prepare-plugin-release.yaml
git diff --check fac270497440d12c3183e6809ee0641085d26c35..0a92563671c9bb6991520cc2d4922130b79599c4
```

All passed. Full tests passed in 6.773 seconds at the final head.

**Environment and configuration (or N/A with explanation):** Linux x86_64; Go 1.26.0; jq 1.6; actionlint 1.7.7. The fix reuses the already configured `RELEASE_PR_APP_ID` and `RELEASE_PR_APP_PRIVATE_KEY`; no new secret or variable is required.

**Exact tested revision, version, image tag/digest, manifests, and values (or N/A with explanation):** Base `fac270497440d12c3183e6809ee0641085d26c35`; exact head `0a92563671c9bb6991520cc2d4922130b79599c4`; gateway `2.2.4`; plan `sha256:c4cccd0b621fa7185c94d2ad18c0ff72f8e6749cabba96a338c47d2b85d5241d`. This PR does not alter that plan or its already-built candidates.

**Baseline reproduction evidence for bug fixes (or N/A with explanation):** Formal run 31722711345 completed `Build and publish content-addressed candidates` and `Render canonical snapshot`, then failed at 2026-08-13T18:24:47Z on `git fetch --no-tags origin main` with `fatal: could not read Username for 'https://github.com'`. The job-start App token had been created at 17:17:16Z, over 67 minutes earlier, so it was also beyond the one-hour installation-token lifetime.

**Fixed-version verification evidence for bug fixes (or N/A with explanation):** Static executable contract requires checkout `persist-credentials: false`, a fresh pinned App-token action after rendering and before PR publication using the established `RELEASE_PR_*` configuration, PR-step `GH_TOKEN` bound only to that fresh output, `gh auth setup-git` before exact-main fetch/push, and `git commit -s`. Independent review initially found and drove repair of stale-token reuse and incorrect configuration names; final exact-head review reported P0=0, P1=0, P2=0.

**Wasm source revision and SHA-256 (or N/A with explanation):** N/A; this fix does not rebuild or alter WASM. Protected rerun will reuse the exact immutable candidate manifests already produced by run 31722711345.

## VI. Special notes for reviewers

The refresh step is deliberately after snapshot rendering because candidate batches can exceed the one-hour App installation-token lifetime. The checkout credential is not persisted, and the fresh token is installed through GitHub CLI's credential helper rather than embedded in the remote URL. The post-merge protected run is the required runtime proof.

## VII. AI coding disclosure

**Tool(s) used (or N/A):** OpenAI Codex plus one independent read-only reviewer.

### Prompts or instructions

Codex was instructed to autonomously repair, review, test, create, and merge blockers scoped to the Higress 2.2.4 plugin release chain. The reviewer received exact base/head, no write paths or credentials, and was instructed to report P0/P1/P2 only. Its two P1 findings (expired token reuse; wrong variable/secret names) were repaired and re-reviewed to zero findings.

### AI-assisted work summary

Codex diagnosed the final Git authentication failure, added post-build App-token refresh and DCO signoff, created a regression contract, ran all focused/full/static checks, and completed an independent review/repair loop. No release artifact semantics or public tag was changed.
