### PR TITLE
test: accept stable plugin version bumps

### DIFF
--- a/tools/plugin-release/batch_build_contract_test.go
+++ b/tools/plugin-release/batch_build_contract_test.go
@@ -61,11 +61,15 @@ func TestGoBatchBuildUsesReleaseEligibleCatalogSelection(t *testing.T) {
 		}
 		t.Fatalf("release-eligible Go plugin %q was not selected", sourceDir)
 	}
-	assertSelected("plugins/wasm-go/extensions/cache-control")     // stable 2.0.0, not alpha
+	assertSelected("plugins/wasm-go/extensions/cache-control")     // stable SemVer, not a prerelease
 	assertSelected("plugins/wasm-go/extensions/replay-protection") // alpha version
 	assertSelected("plugins/wasm-go/extensions/mcp-server")
 	version, err := os.ReadFile(filepath.Join(root, "plugins/wasm-go/extensions/cache-control/VERSION"))
-	if err != nil || strings.TrimSpace(string(version)) != "2.0.0" {
+	if err != nil {
+		t.Fatalf("read stable cache-control VERSION fixture: %v", err)
+	}
+	stableVersion, err := parseSemver(string(version))
+	if err != nil || stableVersion.prerelease != "" {
 		t.Fatalf("fixture must exercise stable cache-control VERSION, got %q (%v)", version, err)
 	}
 	version, err = os.ReadFile(filepath.Join(root, "plugins/wasm-go/extensions/replay-protection/VERSION"))


### PR DESCRIPTION
## I. Summary

Make the release batch contract fixture assert the intended invariant: `cache-control` has a valid stable SemVer and is selected for release. The test no longer pins the fixture to the historical patch version `2.0.0`, so normal immutable release bumps such as `2.0.1` do not fail an otherwise valid plugin snapshot PR.

There is no production runtime behavior change. Invalid SemVer and every prerelease family (`alpha`, `beta`, `rc`, and others) remain fail-closed.

## II. Related issue

Related to #4442 and unblocks the generated plugin snapshot PR #4488.

## III. Change type

- [x] Bug fix
- [ ] Feature or enhancement
- [ ] Documentation or configuration only
- [x] Refactoring, tests, or maintenance

## IV. Agent participation and issue-spec gate

- [ ] **No agent participation:** This PR is human-only.
- [ ] **Trivial agent-use exception:** Agent use was limited to spelling, punctuation, whitespace, or formatting with no substantive choice or behavioral effect.
- [x] **Verified maintainer/administrator exception:** Material agent participation occurred, and authenticated `gh` verification confirmed a `role_name` of `maintain` or `admin` on `higress-group/higress`, and the verified login matches this PR's GitHub author.
- [ ] **Material agent participation:** An AI or coding agent materially participated without the verified exception.

- [ ] Complete: all three timed obligations above were satisfied.
- [ ] Noncompliant: one or more obligations were not satisfied.
- [x] Verified exception: material agent participation used the verified-maintainer/administrator exception.
- [ ] N/A because the PR is human-only or qualifies for the trivial exception.

**Gate-status explanation (or N/A):** Verified administrator exception; this narrowly fixes a release-validation test whose historical patch-version assertion blocks the already-prepared immutable snapshot.

**Trivial-exception explanation (or N/A):** N/A.

**Verified maintainer/administrator exception evidence (or N/A):**

- This PR's number or URL: https://github.com/higress-group/higress/pull/4489
- Authenticated `gh` login: `johnlanni`
- Canonical-repository `role_name`: `admin`
- Actual PR author from `gh pr view`: `johnlanni`
- Login/author match: yes (`johnlanni` = `johnlanni`)
- Token override attestation (`GH_TOKEN` and `GITHUB_TOKEN` were unset for every verification command; required: `yes`): yes
- Bypass rationale: Narrow bug fix to remove an accidental historical patch-version lock from a release-selection fixture; no production behavior changes. Runtime/test verification and an independent exact-head review were completed.
- Maintainer live validation (review URL or N/A until performed): current live verification was performed after PR creation with both token override variables unset: `login=johnlanni role_name=admin pr_author=johnlanni`.

**Approved Proposal Issue URL (or N/A with explanation):** N/A; verified administrator exception.

**Approved Design Issue URL (or N/A with explanation):** N/A; verified administrator exception.

**Maintainer approval link(s) (or N/A with explanation):** N/A; verified administrator exception and explicit maintainer authorization in the active release operation.

**Authorized implementation TASK link(s) (or N/A with explanation):** N/A; verified administrator exception.

**Verification Plan and verification TASK/evidence link(s) (or N/A with explanation):** N/A; verified administrator exception. Exact commands and evidence are below.

## V. Testing and verification

**Test and deterministic rerun commands (or N/A with explanation):**

```text
env -u GH_TOKEN -u GITHUB_TOKEN go test ./... -run '^TestGoBatchBuildUsesReleaseEligibleCatalogSelection$' -count=1
env -u GH_TOKEN -u GITHUB_TOKEN go test ./... -count=1
git diff 7774663e4353652f5c3cecd7e98a1a43b05ee15c..732967b945ce7e39af2f4229c3d656ce1279ed2b --check
```

All passed. The focused test completed in 0.029s; the full `tools/plugin-release` suite completed in 5.442s. An independent reviewer reran the focused and full suites with both token override variables unset; both passed and the exact-head review reported P0=0, P1=0, P2=0.

**Environment and configuration (or N/A with explanation):** Linux amd64 local checkout; no registry, cluster, or production credentials required.

**Exact tested revision, version, image tag/digest, manifests, and values (or N/A with explanation):** exact head `732967b945ce7e39af2f4229c3d656ce1279ed2b`, base `7774663e4353652f5c3cecd7e98a1a43b05ee15c`.

**Baseline reproduction evidence for bug fixes (or N/A with explanation):** [Validate Immutable Plugin Preparation PR failure](https://github.com/higress-group/higress/actions/runs/31739147839/job/94577947624) shows the fixture rejecting the valid `cache-control` version `2.0.1` because it expected `2.0.0` exactly.

**Fixed-version verification evidence for bug fixes (or N/A with explanation):** Commands and exact-head results above. The new assertion uses the package's unified SemVer parser and requires an empty prerelease.

**Wasm source revision and SHA-256 (or N/A with explanation):** N/A; this changes only a Go contract test and does not build or modify a WASM artifact.

## VI. Special notes for reviewers

Review focus: the invariant is “valid stable SemVer participates in exact catalog selection,” not “the fixture stays on a particular historical patch.” The exact catalog equality and separate alpha fixture assertions are unchanged.

## VII. AI coding disclosure

**Tool(s) used (or N/A):** OpenAI Codex, with an independent Codex review agent.

### Prompts or instructions

The agent was instructed to diagnose the dedicated release validation failure, make the smallest test-only correction, preserve fail-closed behavior for invalid/prerelease versions, run focused and package tests with GitHub token overrides unset, and obtain an independent exact-head P0/P1 review. No secrets were provided.

### AI-assisted work summary

The agent replaced the exact `2.0.0` string comparison with the existing strict SemVer parser plus an empty-prerelease requirement. Release catalog equality, selection assertions, and alpha replay-protection coverage remain unchanged. The change is intentionally test-only and low risk.
