### PR TITLE
fix: publish plugin release marker with relative path

### DIFF
--- a/.github/workflows/promote-plugin-release.yaml
+++ b/.github/workflows/promote-plugin-release.yaml
@@ -327,7 +327,8 @@ jobs:
           else
             status=$?
             test "$status" = 1 || exit "$status"
-            marker_digest=$(oras push "$marker" "/tmp/plugin-release-latest-$SNAPSHOT_SHA256.json:application/vnd.higress.plugin-release-batch.v1+json" --format json | jq -r .digest)
+            marker_journal="plugin-release-latest-$SNAPSHOT_SHA256.json"
+            marker_digest=$(cd /tmp && oras push "$marker" "$marker_journal:application/vnd.higress.plugin-release-batch.v1+json" --format json | jq -r .digest)
           fi
           jq --arg ref "$marker" --arg digest "$marker_digest" '.completionMarker={ref:$ref,digest:$digest}' "/tmp/plugin-release-latest-$SNAPSHOT_SHA256.json" > /tmp/journal.next && mv /tmp/journal.next "/tmp/plugin-release-latest-$SNAPSHOT_SHA256.json"
       - name: Persist complete latest batch journal

--- a/tools/plugin-release/plugin_server_workflow_contract_test.go
+++ b/tools/plugin-release/plugin_server_workflow_contract_test.go
@@ -987,6 +987,25 @@ func TestLatestPromotionMarkerSupportsFreshPartialAndCompletedRetries(t *testing
 	}
 }
 
+func TestLatestPromotionMarkerPushUsesRelativeLayerPath(t *testing.T) {
+	data, err := os.ReadFile("../../.github/workflows/promote-plugin-release.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	workflow := string(data)
+	for _, required := range []string{
+		`marker_journal="plugin-release-latest-$SNAPSHOT_SHA256.json"`,
+		`marker_digest=$(cd /tmp && oras push "$marker" "$marker_journal:application/vnd.higress.plugin-release-batch.v1+json" --format json | jq -r .digest)`,
+	} {
+		if !strings.Contains(workflow, required) {
+			t.Fatalf("latest marker push lacks relative ORAS layer path contract %q", required)
+		}
+	}
+	if strings.Contains(workflow, `oras push "$marker" "/tmp/plugin-release-latest-`) {
+		t.Fatal("latest marker push passes an absolute layer path rejected by ORAS path validation")
+	}
+}
+
 func TestPromotionBackfillsVersionTagAndJoinsMonotonicLatest(t *testing.T) {
 	data, err := os.ReadFile("../../.github/workflows/promote-plugin-release.yaml")
 	if err != nil {


### PR DESCRIPTION
## I. Summary

Fix the 2.2.4 plugin promotion completion-marker upload after ORAS rejected the absolute journal path. The workflow now changes to `/tmp` and supplies the journal as a relative layer path; the marker media type and bytes are unchanged.

## II. Related issue

Related to #4022 and #4442 (TASK-4442005 runtime verification). Fixes the marker-stage failure in [run 31744641183](https://github.com/higress-group/higress/actions/runs/31744641183).

## III. Change type

- [x] Bug fix
- [ ] Feature or enhancement
- [ ] Documentation or configuration only
- [x] Refactoring, tests, or maintenance

## IV. Agent participation and issue-spec gate

- [ ] **No agent participation:** This PR is human-only.
- [ ] **Trivial agent-use exception:** Agent use was limited to spelling, punctuation, whitespace, or formatting with no substantive choice or behavioral effect.
- [x] **Verified maintainer/administrator exception:** Material agent participation occurred, and authenticated `gh` verification confirmed a `role_name` of `maintain` or `admin` on `higress-group/higress`, and the verified login matches this PR's GitHub author.
- [ ] **Material agent participation:** An AI or coding agent materially participated without the verified exception.

- [ ] Complete: all three timed obligations above were satisfied.
- [ ] Noncompliant: one or more obligations were not satisfied.
- [x] Verified exception: material agent participation used the verified-maintainer/administrator exception.
- [ ] N/A because the PR is human-only or qualifies for the trivial exception.

**Gate-status explanation (or N/A):** Verified administrator exception for a narrow runtime-blocking release workflow fix discovered while executing the approved #4442 verification plan.

**Trivial-exception explanation (or N/A):** N/A.

**Verified maintainer/administrator exception evidence (or N/A):**

- This PR number or URL: https://github.com/higress-group/higress/pull/4491
- Authenticated `gh` login: `johnlanni`
- Canonical-repository `role_name`: `admin`
- Actual PR author from gh pr view: johnlanni
- Login/author match: yes (johnlanni = johnlanni)
- Token override attestation (`GH_TOKEN` and `GITHUB_TOKEN` were unset for every verification command; required: `yes`): yes
- Bypass rationale: two-line operational repair for a real protected runtime failure, with a regression contract; no plugin bytes or version decisions change.
- Maintainer live validation: live checks after PR creation, with token override variables removed, returned login johnlanni, role_name admin, PR author johnlanni, and a login/author match.

**Approved Proposal Issue URL (or N/A with explanation):** https://github.com/higress-group/higress/issues/4022

**Approved Design Issue URL (or N/A with explanation):** https://github.com/higress-group/higress/issues/4442

**Maintainer approval link(s) (or N/A with explanation):** Approval is recorded in #4022/#4442 and the maintainer explicitly authorized autonomous runtime remediation and merging for this release operation.

**Authorized implementation TASK link(s) (or N/A with explanation):** TASK-4442005 in #4442 owns protected end-to-end verification and recording failures/remediations; this PR additionally relies on the verified administrator exception.

**Verification Plan and verification TASK/evidence link(s) (or N/A with explanation):** TASK-4442005 in #4442; exact runtime and local evidence is below.

## V. Testing and verification

**Test and deterministic rerun commands (or N/A with explanation):**

```text
env -u GH_TOKEN -u GITHUB_TOKEN go test ./... -run 'TestLatestPromotionMarkerPushUsesRelativeLayerPath|TestLatestPromotionMarkerSupportsFreshPartialAndCompletedRetries' -count=1
env -u GH_TOKEN -u GITHUB_TOKEN go test ./... -count=1
env -u GH_TOKEN -u GITHUB_TOKEN go vet ./...
env -u GH_TOKEN -u GITHUB_TOKEN go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 ../../.github/workflows/promote-plugin-release.yaml
env -u GH_TOKEN -u GITHUB_TOKEN git diff --check origin/main..HEAD
```

All passed at exact head `f3d9f00759e2842909d3871a755ab06e8cf1f3ec`.

**Environment and configuration (or N/A with explanation):** Linux amd64; repository Go toolchain; ORAS v1.3.0 in the protected run.

**Exact tested revision, version, image tag/digest, manifests, and values (or N/A with explanation):** base `478f4d84d9dfdad0861896771a0de481390cbb8e`, exact head `f3d9f00759e2842909d3871a755ab06e8cf1f3ec`; gateway `2.2.4`; snapshot SHA-256 `09bc798df37e50dae2e684947885c31eb756636c76a98761a9a980fc031e3a1a`.

**Baseline reproduction evidence for bug fixes (or N/A with explanation):** [run 31744641183](https://github.com/higress-group/higress/actions/runs/31744641183) successfully made all 43 version and `latest` tags resolve to the snapshot digest, then ORAS failed before marker creation with `absolute file path detected` for `/tmp/plugin-release-latest-....json`.

**Fixed-version verification evidence for bug fixes (or N/A with explanation):** local exact-head commands above. The protected idempotent retry after merge is the runtime acceptance check.

**Wasm source revision and SHA-256 (or N/A with explanation):** N/A; no WASM source or artifact changes.

## VI. Special notes for reviewers

The retry is safe: all 43 `latest` aliases already match the snapshot, so the workflow will classify them as identical, perform no alias writes, and only persist the missing immutable completion marker.

## VII. AI coding disclosure

**Tool(s) used (or N/A):** OpenAI Codex, including an independent exact-head review agent.

### Prompts or instructions

Codex was instructed to diagnose the protected runtime failure, make the smallest fail-closed correction, preserve marker bytes/media type and retry semantics, add a regression contract, verify with token overrides unset, and use a DCO commit.

### AI-assisted work summary

Codex identified the ORAS absolute-path validation failure, changed the marker layer argument to a relative path under `/tmp`, added an executable workflow contract regression, and ran exact-head validation. No registry credentials were exposed to a review agent.