### PR TITLE
fix: use ORAS blob reference syntax in releases

### DIFF
--- a/.github/workflows/authorize-higress-release-tag.yaml
+++ b/.github/workflows/authorize-higress-release-tag.yaml
@@ -162,7 +162,7 @@ jobs:
           jq -e '.layers | length == 1 and .[0].mediaType == "application/vnd.cncf.helm.chart.content.v1.tar+gzip"' /tmp/console-chart-oci-manifest.json >/dev/null
           console_chart_layer=$(jq -er '.layers[0].digest' /tmp/console-chart-oci-manifest.json)
           [[ "$console_chart_layer" =~ ^sha256:[0-9a-f]{64}$ ]]
-          oras blob fetch "$console_chart_repo@$CONSOLE_CHART_DIGEST" "$console_chart_layer" -o /tmp/console-chart-oci.tgz
+          oras blob fetch "$console_chart_repo@$console_chart_layer" -o /tmp/console-chart-oci.tgz
           CONSOLE_CHART_PACKAGE_SHA256=$(sha256sum "$CONSOLE_HTTP_CHART" | awk '{print $1}')
           test "sha256:$CONSOLE_CHART_PACKAGE_SHA256" = "$console_chart_layer"
           test "$(sha256sum /tmp/console-chart-oci.tgz | awk '{print $1}')" = "$CONSOLE_CHART_PACKAGE_SHA256"
@@ -182,7 +182,7 @@ jobs:
           PLUGIN_SERVER_HIGRESS_COMMIT=""
           while IFS=$'\t' read -r platform child; do
             manifest=$(oras manifest fetch "$plugin_server_repo@$child"); config=$(jq -er .config.digest <<<"$manifest")
-            labels=$(oras blob fetch "$plugin_server_repo@$child" "$config" -o - | jq -c '.config.Labels // {}')
+            labels=$(oras blob fetch "$plugin_server_repo@$config" -o - | jq -c '.config.Labels // {}')
             child_higress_commit=$(jq -er '."io.higress.higress-source-commit"' <<<"$labels")
             [[ "$child_higress_commit" =~ ^[0-9a-f]{40}$ ]]
             if [ -z "$PLUGIN_SERVER_HIGRESS_COMMIT" ]; then PLUGIN_SERVER_HIGRESS_COMMIT=$child_higress_commit; else test "$child_higress_commit" = "$PLUGIN_SERVER_HIGRESS_COMMIT"; fi

--- a/.github/workflows/build-plugin-server-from-snapshot.yaml
+++ b/.github/workflows/build-plugin-server-from-snapshot.yaml
@@ -125,7 +125,8 @@ jobs:
           marker_manifest=$(oras manifest fetch "$marker")
           marker_layer=$(jq -r '.layers[] | select(.mediaType == "application/vnd.higress.plugin-release-batch.v1+json").digest' <<<"$marker_manifest")
           [[ "$marker_layer" =~ ^sha256:[0-9a-f]{64}$ ]]
-          oras blob fetch "$marker" "$marker_layer" -o /tmp/latest-batch-marker.json
+          marker_repo=${marker%:*}
+          oras blob fetch "$marker_repo@$marker_layer" -o /tmp/latest-batch-marker.json
           jq -e --arg sha "$SNAPSHOT_SHA256" '.snapshotSha256 == $sha and .phase == "latest-complete" and (.entries | length > 0)' /tmp/latest-batch-marker.json >/dev/null
           cp "$SNAPSHOT_PATH" plugin-server/snapshot.json
           test "$(sha256sum plugin-server/snapshot.json | awk '{print $1}')" = "$SNAPSHOT_SHA256"
@@ -173,7 +174,8 @@ jobs:
           managed_path=$(jq -r '.consumers.pluginServer.httpPath' <<<"$managed"); managed_version=$(jq -r .version <<<"$managed")
           fetch_wasm "$managed_path" "$managed_version" /tmp/managed.wasm
           managed_ref=$(jq -r '.ociRef | sub(":[^/:]+$"; "")' <<<"$managed"); managed_digest=$(jq -r .digest <<<"$managed")
-          oras blob fetch "$managed_ref@$managed_digest" "$(oras manifest fetch "$managed_ref@$managed_digest" | jq -r '.layers[] | select(.mediaType == "application/vnd.module.wasm.content.layer.v1+wasm").digest')" -o /tmp/managed-oci.wasm
+          managed_layer=$(oras manifest fetch "$managed_ref@$managed_digest" | jq -r '.layers[] | select(.mediaType == "application/vnd.module.wasm.content.layer.v1+wasm").digest')
+          oras blob fetch "$managed_ref@$managed_layer" -o /tmp/managed-oci.wasm
           cmp /tmp/managed.wasm /tmp/managed-oci.wasm
           json_version=$(jq -r '.plugins[] | select(.consumers.pluginServer.inventoryKey == "json-converter") | .version' "$SNAPSHOT_PATH")
           fetch_wasm jsonrpc-converter "$json_version" /tmp/jsonrpc.wasm

--- a/.github/workflows/dispatch-standalone-release.yaml
+++ b/.github/workflows/dispatch-standalone-release.yaml
@@ -92,7 +92,7 @@ jobs:
             while IFS=$'\t' read -r platform child; do
               manifest=$(oras manifest fetch "$repo@$child")
               config=$(jq -er .config.digest <<<"$manifest")
-              label=$(oras blob fetch "$repo@$child" "$config" -o - | jq -c '.config.Labels // {}')
+              label=$(oras blob fetch "$repo@$config" -o - | jq -c '.config.Labels // {}')
               jq -e --arg plugin "$PLUGIN_SERVER_COMMIT" --arg source "$SNAPSHOT_SOURCE_COMMIT" --arg snapshot "$sha" --arg version "${TAG#v}" '."org.opencontainers.image.revision" == $plugin and ."io.higress.higress-source-commit" == $source and ."io.higress.plugin-snapshot-sha256" == $snapshot and ."io.higress.gateway-version" == $version' <<<"$label" >/dev/null
               labels=$(jq --arg platform "$platform" --argjson label "$label" '.[$platform]=$label' <<<"$labels")
             done < <(jq -r '.manifests[] | [(.platform.os + "/" + .platform.architecture), .digest] | @tsv' /tmp/index.json)

--- a/.github/workflows/promote-plugin-release.yaml
+++ b/.github/workflows/promote-plugin-release.yaml
@@ -126,7 +126,8 @@ jobs:
           # before accepting that already-complete state.
           if marker_descriptor=$(descriptor_or_absent "$marker"); then
             marker_layer=$(oras manifest fetch "$marker" | jq -er '.layers[] | select(.mediaType == "application/vnd.higress.plugin-release-batch.v1+json") | .digest')
-            oras blob fetch "$marker" "$marker_layer" -o /tmp/existing-latest-marker.json
+            marker_repo=${marker%:*}
+            oras blob fetch "$marker_repo@$marker_layer" -o /tmp/existing-latest-marker.json
             jq -e --arg sha "$SNAPSHOT_SHA256" '.snapshotSha256 == $sha and .phase == "latest-complete" and (.entries | length > 0)' /tmp/existing-latest-marker.json >/dev/null
             jq -c '.entries[]' /tmp/existing-latest-marker.json | while read -r entry; do
               test "$(oras manifest fetch "$(jq -r .latest <<<"$entry")" --descriptor | jq -r .digest)" = "$(jq -r .digest <<<"$entry")"
@@ -225,7 +226,8 @@ jobs:
           # make no mutable registry write on this retry.
           if marker_descriptor=$(descriptor_or_absent "$marker"); then
             marker_layer=$(oras manifest fetch "$marker" | jq -er '.layers[] | select(.mediaType == "application/vnd.higress.plugin-release-batch.v1+json") | .digest')
-            oras blob fetch "$marker" "$marker_layer" -o "/tmp/plugin-release-latest-$SNAPSHOT_SHA256.json"
+            marker_repo=${marker%:*}
+            oras blob fetch "$marker_repo@$marker_layer" -o "/tmp/plugin-release-latest-$SNAPSHOT_SHA256.json"
             jq -e --arg sha "$SNAPSHOT_SHA256" '.snapshotSha256 == $sha and .phase == "latest-complete" and (.entries | length > 0)' "/tmp/plugin-release-latest-$SNAPSHOT_SHA256.json" >/dev/null
             jq -c '.entries[]' "/tmp/plugin-release-latest-$SNAPSHOT_SHA256.json" | while read -r entry; do
               test "$(oras manifest fetch "$(jq -r .latest <<<"$entry")" --descriptor | jq -r .digest)" = "$(jq -r .digest <<<"$entry")"
@@ -321,7 +323,8 @@ jobs:
           # collision never gets overwritten.
           if marker_descriptor=$(descriptor_or_absent "$marker"); then
             marker_layer=$(oras manifest fetch "$marker" | jq -er '.layers[] | select(.mediaType == "application/vnd.higress.plugin-release-batch.v1+json") | .digest')
-            oras blob fetch "$marker" "$marker_layer" -o /tmp/racing-latest-marker.json
+            marker_repo=${marker%:*}
+            oras blob fetch "$marker_repo@$marker_layer" -o /tmp/racing-latest-marker.json
             cmp /tmp/racing-latest-marker.json "/tmp/plugin-release-latest-$SNAPSHOT_SHA256.json" || { echo "immutable latest marker conflict" >&2; exit 1; }
             marker_digest=$(jq -er .digest <<<"$marker_descriptor")
           else

--- a/tools/plugin-release/plugin_server_workflow_contract_test.go
+++ b/tools/plugin-release/plugin_server_workflow_contract_test.go
@@ -73,6 +73,59 @@ func TestReleaseWorkflowsPairORASSetupMetadataWithPinnedCLI(t *testing.T) {
 	}
 }
 
+func TestReleaseWorkflowsUseSingleReferenceORASBlobFetch(t *testing.T) {
+	required := map[string][]string{
+		"build-plugin-server-from-snapshot.yaml": {
+			`marker_repo=${marker%:*}`,
+			`oras blob fetch "$marker_repo@$marker_layer" -o /tmp/latest-batch-marker.json`,
+			`managed_layer=$(oras manifest fetch "$managed_ref@$managed_digest"`,
+			`oras blob fetch "$managed_ref@$managed_layer" -o /tmp/managed-oci.wasm`,
+		},
+		"promote-plugin-release.yaml": {
+			`oras blob fetch "$marker_repo@$marker_layer" -o /tmp/existing-latest-marker.json`,
+			`oras blob fetch "$marker_repo@$marker_layer" -o "/tmp/plugin-release-latest-$SNAPSHOT_SHA256.json"`,
+			`oras blob fetch "$marker_repo@$marker_layer" -o /tmp/racing-latest-marker.json`,
+		},
+		"authorize-higress-release-tag.yaml": {
+			`oras blob fetch "$console_chart_repo@$console_chart_layer" -o /tmp/console-chart-oci.tgz`,
+			`oras blob fetch "$plugin_server_repo@$config" -o -`,
+		},
+		"dispatch-standalone-release.yaml": {
+			`oras blob fetch "$repo@$config" -o -`,
+		},
+	}
+	for name, commands := range required {
+		data, err := os.ReadFile("../../.github/workflows/" + name)
+		if err != nil {
+			t.Fatal(err)
+		}
+		workflow := string(data)
+		for _, command := range commands {
+			if !strings.Contains(workflow, command) {
+				t.Errorf("%s lacks ORAS single-reference blob fetch contract %q", name, command)
+			}
+		}
+	}
+
+	legacyForms := map[string][]string{
+		"build-plugin-server-from-snapshot.yaml": {`oras blob fetch "$marker" "$marker_layer"`, `oras blob fetch "$managed_ref@$managed_digest"`},
+		"promote-plugin-release.yaml":            {`oras blob fetch "$marker" "$marker_layer"`},
+		"authorize-higress-release-tag.yaml":     {`oras blob fetch "$console_chart_repo@$CONSOLE_CHART_DIGEST"`, `oras blob fetch "$plugin_server_repo@$child"`},
+		"dispatch-standalone-release.yaml":       {`oras blob fetch "$repo@$child"`},
+	}
+	for name, commands := range legacyForms {
+		data, err := os.ReadFile("../../.github/workflows/" + name)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, command := range commands {
+			if strings.Contains(string(data), command) {
+				t.Errorf("%s retains ORAS two-reference blob fetch form %q", name, command)
+			}
+		}
+	}
+}
+
 func TestReleaseAuthorizerRequiresCompleteImmutableEvidence(t *testing.T) {
 	data, err := os.ReadFile("../../.github/workflows/authorize-higress-release-tag.yaml")
 	if err != nil {
@@ -148,7 +201,7 @@ func TestReleaseAuthorizerBindsHTTPSChartPackageToOCIContent(t *testing.T) {
 		`helm pull higress-console --repo "$CONSOLE_HELM_REPOSITORY" --version "$CONSOLE_CHART_VERSION"`,
 		`test "$(helm show chart "$CONSOLE_HTTP_CHART"`,
 		`layers | length == 1`, "application/vnd.cncf.helm.chart.content.v1.tar+gzip",
-		`oras blob fetch "$console_chart_repo@$CONSOLE_CHART_DIGEST" "$console_chart_layer"`,
+		`oras blob fetch "$console_chart_repo@$console_chart_layer"`,
 		`test "sha256:$CONSOLE_CHART_PACKAGE_SHA256" = "$console_chart_layer"`,
 	} {
 		if !strings.Contains(workflow, required) {


### PR DESCRIPTION
## I. Summary

Update every release-workflow ORAS blob read to the single-reference `repository@blobDigest` syntax required by the pinned ORAS CLI. This fixes the plugin-server runtime failure and proactively covers the already-present promotion-marker retry, Higress release authorization, and standalone evidence paths that used the same incompatible two-reference form.

Digest selection, media-type checks, immutable references, and all downstream byte/label comparisons are unchanged.

## II. Related issue

Related to #4022 and #4442 (TASK-4442005 runtime verification). Fixes [run 31748323814](https://github.com/higress-group/higress/actions/runs/31748323814).

## III. Change type

- [x] Bug fix
- [ ] Feature or enhancement
- [ ] Documentation or configuration only
- [x] Refactoring, tests, or maintenance

## IV. Agent participation and issue-spec gate

- [ ] **No agent participation:** This PR is human-only.
- [ ] **Trivial agent-use exception:** Agent use was limited to spelling, punctuation, whitespace, or formatting with no substantive choice or behavioral effect.
- [x] **Verified maintainer/administrator exception:** Material agent participation occurred, and authenticated `gh` verification confirmed a `role_name` of `maintain` or `admin` on `higress-group/higress`, and the verified login matches this PR's GitHub author.
- [ ] **Material agent participation:** An AI or coding agent materially participated without the verified exception.

- [ ] Complete: all three timed obligations above were satisfied.
- [ ] Noncompliant: one or more obligations were not satisfied.
- [x] Verified exception: material agent participation used the verified-maintainer/administrator exception.
- [ ] N/A because the PR is human-only or qualifies for the trivial exception.

**Gate-status explanation (or N/A):** Verified administrator exception for a deterministic release-workflow compatibility bug found during the approved #4442 protected verification.

**Trivial-exception explanation (or N/A):** N/A.

**Verified maintainer/administrator exception evidence (or N/A):**

- This PR number or URL: https://github.com/higress-group/higress/pull/4492
- Authenticated `gh` login: `johnlanni`
- Canonical-repository `role_name`: `admin`
- Actual PR author from gh pr view: johnlanni
- Login/author match: yes (johnlanni = johnlanni)
- Token override attestation (`GH_TOKEN` and `GITHUB_TOKEN` were unset for every verification command; required: `yes`): yes
- Bypass rationale: mechanical CLI syntax correction for all known occurrences of the same protected runtime failure; digest and verification semantics do not change.
- Maintainer live validation: live checks after PR creation, with token override variables removed, returned login johnlanni, role_name admin, PR author johnlanni, and a login/author match.

**Approved Proposal Issue URL (or N/A with explanation):** https://github.com/higress-group/higress/issues/4022

**Approved Design Issue URL (or N/A with explanation):** https://github.com/higress-group/higress/issues/4442

**Maintainer approval link(s) (or N/A with explanation):** Approval is recorded in #4022/#4442 and the maintainer explicitly authorized autonomous runtime remediation and merging for this release operation.

**Authorized implementation TASK link(s) (or N/A with explanation):** TASK-4442005 in #4442 owns protected end-to-end verification and failure remediation; this PR additionally relies on the verified administrator exception.

**Verification Plan and verification TASK/evidence link(s) (or N/A with explanation):** TASK-4442005 in #4442; exact runtime and local evidence is below.

## V. Testing and verification

**Test and deterministic rerun commands (or N/A with explanation):**

```text
env -u GH_TOKEN -u GITHUB_TOKEN go test ./... -run 'TestReleaseWorkflowsUseSingleReferenceORASBlobFetch|TestPluginServerWorkflowFailsClosedBeforeCandidateMutation|TestReleaseAuthorizerBindsHTTPSChartPackageToOCIContent|TestLatestPromotionMarkerSupportsFreshPartialAndCompletedRetries' -count=1
env -u GH_TOKEN -u GITHUB_TOKEN go test ./... -count=1
env -u GH_TOKEN -u GITHUB_TOKEN go vet ./...
env -u GH_TOKEN -u GITHUB_TOKEN go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 ../../.github/workflows/build-plugin-server-from-snapshot.yaml ../../.github/workflows/promote-plugin-release.yaml ../../.github/workflows/authorize-higress-release-tag.yaml ../../.github/workflows/dispatch-standalone-release.yaml
env -u GH_TOKEN -u GITHUB_TOKEN git diff --check origin/main..HEAD
```

All passed at exact head `393e23dbea89c0cc021281b98ae31ab424834b81`.

A read-only real-registry probe with local ORAS 1.1.0 successfully fetched both the 43-entry completion-marker layer and the selected `mcp-server` WASM layer using the new single-reference form. The protected runner pins ORAS 1.2.3.

**Environment and configuration (or N/A with explanation):** Linux amd64; repository Go toolchain; local ORAS 1.1.0 compatibility probe; protected ORAS 1.2.3.

**Exact tested revision, version, image tag/digest, manifests, and values (or N/A with explanation):** base `196496244c10b6c201b9bcf27b8d40d775ac60eb`; head `393e23db`; gateway `2.2.4`; snapshot SHA-256 `09bc798df37e50dae2e684947885c31eb756636c76a98761a9a980fc031e3a1a`; completion marker digest `sha256:ca3ce23b5bccc4588220a932db5c7e909dd5d84c16d248f5bc7ff7fbef6f3d1f`; marker layer `sha256:a0b2bcca32ab56c00d1fde1d3b78ae50bdb391bcda6dc133b088fa4ea87c8a10`; `mcp-server` WASM layer `sha256:8470cf1e9e2089e752405a090dba287cf775bf839b1495c67358562cb97de029`.

**Baseline reproduction evidence for bug fixes (or N/A with explanation):** [run 31748323814](https://github.com/higress-group/higress/actions/runs/31748323814) passed exact snapshot/plugin-server source verification, then failed before Docker login/build with `oras blob fetch requires exactly 1 argument but got 2`. No candidate/public plugin-server image was built or pushed, and Console was not dispatched.

**Fixed-version verification evidence for bug fixes (or N/A with explanation):** exact-head commands and real anonymous blob probes above. The protected formal retry after merge is the runtime acceptance check.

**Wasm source revision and SHA-256 (or N/A with explanation):** no WASM source change; read-only `mcp-server` layer verification is recorded above.

## VI. Special notes for reviewers

The previous two-reference calls supplied a manifest reference and a blob digest separately. The supported equivalent is the same repository plus that exact blob digest as one reference. For image config blobs, the repository remains the image repository and the child config digest remains the manifest-selected digest.

## VII. AI coding disclosure

**Tool(s) used (or N/A):** OpenAI Codex, including an independent exact-head review agent.

### Prompts or instructions

Codex was instructed to diagnose the protected runtime failure, inventory every identical ORAS usage in the release chain, preserve digest and fail-closed semantics, add regression coverage for production commands, verify with token overrides unset, and use a DCO commit.

### AI-assisted work summary

Codex diagnosed the ORAS positional-argument incompatibility, corrected all release-chain occurrences, added a cross-workflow regression contract, ran static/unit/vet validation, and performed read-only real-registry blob probes. No registry credentials were exposed to a review agent.