### PR TITLE
fix: accept plugin server build attestations

### DIFF
--- a/.github/workflows/authorize-higress-release-tag.yaml
+++ b/.github/workflows/authorize-higress-release-tag.yaml
@@ -96,6 +96,24 @@ jobs:
           APPROVED_EVIDENCE_SHA256: ${{ inputs.approved_readiness_evidence_sha256 }}
         run: |
           set -euo pipefail
+          # BEGIN plugin-server-index-contract
+          verify_plugin_server_index() {
+            jq -e '
+              def runnable: (.platform.os == "linux" and (.platform.architecture == "amd64" or .platform.architecture == "arm64"));
+              [.manifests[] | select(runnable)] as $runnable |
+              [.manifests[] | select(runnable | not)] as $extra |
+              (([$runnable[] | .platform.os + "/" + .platform.architecture] | sort) == ["linux/amd64","linux/arm64"]) and
+              (($runnable | length) == 2) and
+              (($extra | length) == 0 or
+                (($extra | length) == 2 and
+                 all($extra[];
+                   .mediaType == "application/vnd.oci.image.manifest.v1+json" and
+                   .platform.os == "unknown" and .platform.architecture == "unknown" and
+                   .annotations["vnd.docker.reference.type"] == "attestation-manifest") and
+                 (([$extra[].annotations["vnd.docker.reference.digest"]] | sort) == ([$runnable[].digest] | sort))))
+            ' "$1" >/dev/null
+          }
+          # END plugin-server-index-contract
           [[ "$GATEWAY_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]
           [[ "$RELEASE_COMMIT" =~ ^[0-9a-f]{40}$ ]]
           [[ "$PLUGIN_SERVER_COMMIT" =~ ^[0-9a-f]{40}$ ]]
@@ -178,7 +196,7 @@ jobs:
             '.pluginLock.pluginServerCommit == $plugin and .pluginLock.pluginServerImage == $image' \
             /tmp/console-provenance.json >/dev/null
           oras manifest fetch "$PLUGIN_SERVER_IMAGE" --raw >/tmp/plugin-server-index.json
-          jq -e '.manifests | length == 2 and ([.[] | .platform.os + "/" + .platform.architecture] | sort == ["linux/amd64","linux/arm64"])' /tmp/plugin-server-index.json >/dev/null
+          verify_plugin_server_index /tmp/plugin-server-index.json
           PLUGIN_SERVER_HIGRESS_COMMIT=""
           while IFS=$'\t' read -r platform child; do
             manifest=$(oras manifest fetch "$plugin_server_repo@$child"); config=$(jq -er .config.digest <<<"$manifest")
@@ -187,7 +205,7 @@ jobs:
             [[ "$child_higress_commit" =~ ^[0-9a-f]{40}$ ]]
             if [ -z "$PLUGIN_SERVER_HIGRESS_COMMIT" ]; then PLUGIN_SERVER_HIGRESS_COMMIT=$child_higress_commit; else test "$child_higress_commit" = "$PLUGIN_SERVER_HIGRESS_COMMIT"; fi
             jq -e --arg plugin "$PLUGIN_SERVER_COMMIT" --arg snapshot "$SNAPSHOT_SHA256" --arg version "$GATEWAY_VERSION" '."org.opencontainers.image.revision" == $plugin and ."io.higress.plugin-snapshot-sha256" == $snapshot and ."io.higress.gateway-version" == $version' <<<"$labels" >/dev/null
-          done < <(jq -r '.manifests[] | [(.platform.os + "/" + .platform.architecture), .digest] | @tsv' /tmp/plugin-server-index.json)
+          done < <(jq -r '.manifests[] | select(.platform.os == "linux" and (.platform.architecture == "amd64" or .platform.architecture == "arm64")) | [(.platform.os + "/" + .platform.architecture), .digest] | @tsv' /tmp/plugin-server-index.json)
           [[ "$PLUGIN_SERVER_HIGRESS_COMMIT" =~ ^[0-9a-f]{40}$ ]]
           git merge-base --is-ancestor "$PLUGIN_SERVER_HIGRESS_COMMIT" "$RELEASE_COMMIT"
           git show "$PLUGIN_SERVER_HIGRESS_COMMIT:$SNAPSHOT_PATH" > /tmp/plugin-server-source-snapshot.json

--- a/.github/workflows/build-plugin-server-from-snapshot.yaml
+++ b/.github/workflows/build-plugin-server-from-snapshot.yaml
@@ -118,6 +118,24 @@ jobs:
           PLUGIN_PUBLIC_REGISTRY: ${{ vars.PLUGIN_PUBLIC_REGISTRY }}
         run: |
           set -euo pipefail
+          # BEGIN plugin-server-index-contract
+          verify_plugin_server_index() {
+            jq -e '
+              def runnable: (.platform.os == "linux" and (.platform.architecture == "amd64" or .platform.architecture == "arm64"));
+              [.manifests[] | select(runnable)] as $runnable |
+              [.manifests[] | select(runnable | not)] as $extra |
+              (([$runnable[] | .platform.os + "/" + .platform.architecture] | sort) == ["linux/amd64","linux/arm64"]) and
+              (($runnable | length) == 2) and
+              (($extra | length) == 0 or
+                (($extra | length) == 2 and
+                 all($extra[];
+                   .mediaType == "application/vnd.oci.image.manifest.v1+json" and
+                   .platform.os == "unknown" and .platform.architecture == "unknown" and
+                   .annotations["vnd.docker.reference.type"] == "attestation-manifest") and
+                 (([$extra[].annotations["vnd.docker.reference.digest"]] | sort) == ([$runnable[].digest] | sort))))
+            ' "$1" >/dev/null
+          }
+          # END plugin-server-index-contract
           [[ "$(git -C plugin-server rev-parse HEAD)" = "$PLUGIN_SERVER_COMMIT" ]]
           test -n "$REGISTRY"; test -n "$REGISTRY_USERNAME"; test -n "$REGISTRY_PASSWORD"
           test -n "$PLUGIN_PUBLIC_REGISTRY"
@@ -148,22 +166,38 @@ jobs:
             echo "public tag lookup failed; refusing candidate/public mutation" >&2
             exit 1
           fi
-          docker buildx build --platform linux/amd64,linux/arm64 --push -t "$candidate" \
-            --build-arg SNAPSHOT_SHA256="$SNAPSHOT_SHA256" --build-arg HIGRESS_SOURCE_COMMIT="$HIGRESS_COMMIT" \
-            --build-arg PLUGIN_SERVER_SOURCE_COMMIT="$PLUGIN_SERVER_COMMIT" --build-arg GATEWAY_VERSION="$GATEWAY_VERSION" plugin-server
-          candidate_digest=$(docker buildx imagetools inspect "$candidate" --format '{{json .Manifest.Digest}}' | tr -d '"')
+          candidate_lookup_error=/tmp/candidate-tag-lookup.err
+          if candidate_json=$(oras manifest fetch "$candidate" --descriptor 2>"$candidate_lookup_error"); then
+            candidate_digest=$(jq -er .digest <<<"$candidate_json")
+            echo "Reusing immutable plugin-server candidate $candidate@$candidate_digest" >> "$GITHUB_STEP_SUMMARY"
+          elif grep -Eqi '401|403|unauthorized|forbidden|denied|authentication required|authorization required' "$candidate_lookup_error"; then
+            cat "$candidate_lookup_error" >&2
+            echo "candidate tag lookup was refused; authorization failure is never absence" >&2
+            exit 1
+          elif grep -Eqi '404|manifest unknown|name unknown|repository does not exist' "$candidate_lookup_error" ||
+               { grep -Fq 'Error response from registry:' "$candidate_lookup_error" && grep -Fq "$candidate: not found" "$candidate_lookup_error"; }; then
+            docker buildx build --platform linux/amd64,linux/arm64 --push -t "$candidate" \
+              --build-arg SNAPSHOT_SHA256="$SNAPSHOT_SHA256" --build-arg HIGRESS_SOURCE_COMMIT="$HIGRESS_COMMIT" \
+              --build-arg PLUGIN_SERVER_SOURCE_COMMIT="$PLUGIN_SERVER_COMMIT" --build-arg GATEWAY_VERSION="$GATEWAY_VERSION" plugin-server
+            candidate_digest=$(docker buildx imagetools inspect "$candidate" --format '{{json .Manifest.Digest}}' | tr -d '"')
+          else
+            cat "$candidate_lookup_error" >&2
+            echo "candidate tag lookup failed; refusing candidate/public mutation" >&2
+            exit 1
+          fi
           test -n "$candidate_digest"
           if [ -n "$existing" ] && [ "$existing" != "$candidate_digest" ]; then echo "immutable plugin-server tag conflict" >&2; exit 1; fi
           # Candidate acceptance happens before the public tag is created. It
-          # requires exactly amd64+arm64, the immutable labels on each
-          # platform image, and actual served byte checks on this runner.
+          # requires exactly amd64+arm64 runnable images, permits only the
+          # standard Buildx attestation paired with each runnable digest, and
+          # verifies immutable labels and actual served bytes on this runner.
           docker buildx imagetools inspect "$candidate" --raw > /tmp/candidate-index.json
-          jq -e '.manifests | length == 2 and ([.[] | .platform.os + "/" + .platform.architecture] | sort == ["linux/amd64","linux/arm64"])' /tmp/candidate-index.json
+          verify_plugin_server_index /tmp/candidate-index.json
           while read -r platform_digest; do
             labels=$(docker buildx imagetools inspect "$candidate@$platform_digest" --format '{{json .Image.Config.Labels}}')
             jq -e --arg plugin "$PLUGIN_SERVER_COMMIT" --arg higress "$HIGRESS_COMMIT" --arg snapshot "$SNAPSHOT_SHA256" --arg version "$GATEWAY_VERSION" \
               '."org.opencontainers.image.revision" == $plugin and ."io.higress.higress-source-commit" == $higress and ."io.higress.plugin-snapshot-sha256" == $snapshot and ."io.higress.gateway-version" == $version' <<<"$labels" >/dev/null
-          done < <(jq -r '.manifests[].digest' /tmp/candidate-index.json)
+          done < <(jq -r '.manifests[] | select(.platform.os == "linux" and (.platform.architecture == "amd64" or .platform.architecture == "arm64")) | .digest' /tmp/candidate-index.json)
           docker pull "$candidate@$candidate_digest"
           container=$(docker run -d --rm -p 127.0.0.1:18080:8080 "$candidate@$candidate_digest")
           trap 'docker rm -f "$container" >/dev/null 2>&1 || true' EXIT
@@ -187,12 +221,13 @@ jobs:
           if [ -z "$existing" ]; then docker buildx imagetools create --tag "$image" "$candidate@$candidate_digest"; fi
           test "$(docker buildx imagetools inspect "$image" --format '{{json .Manifest.Digest}}' | tr -d '"')" = "$candidate_digest"
           docker buildx imagetools inspect "$image" --raw > /tmp/public-index.json
-          cmp /tmp/candidate-index.json /tmp/public-index.json || jq -e --arg digest "$candidate_digest" '.manifests | length == 2' /tmp/public-index.json
+          cmp /tmp/candidate-index.json /tmp/public-index.json
+          verify_plugin_server_index /tmp/public-index.json
           while read -r platform_digest; do
             labels=$(docker buildx imagetools inspect "$image@$platform_digest" --format '{{json .Image.Config.Labels}}')
             jq -e --arg plugin "$PLUGIN_SERVER_COMMIT" --arg higress "$HIGRESS_COMMIT" --arg snapshot "$SNAPSHOT_SHA256" --arg version "$GATEWAY_VERSION" \
               '."org.opencontainers.image.revision" == $plugin and ."io.higress.higress-source-commit" == $higress and ."io.higress.plugin-snapshot-sha256" == $snapshot and ."io.higress.gateway-version" == $version' <<<"$labels" >/dev/null
-          done < <(jq -r '.manifests[].digest' /tmp/public-index.json)
+          done < <(jq -r '.manifests[] | select(.platform.os == "linux" and (.platform.architecture == "amd64" or .platform.architecture == "arm64")) | .digest' /tmp/public-index.json)
           printf 'PLUGIN_SERVER_IMAGE=%s@%s\n' "$image" "$candidate_digest" >> "$GITHUB_ENV"
       - name: Create Console dispatch token after public acceptance
         if: ${{ !inputs.dry_run }}

--- a/.github/workflows/dispatch-standalone-release.yaml
+++ b/.github/workflows/dispatch-standalone-release.yaml
@@ -35,6 +35,24 @@ jobs:
           STANDALONE_BASE_COMMIT: ${{ vars.STANDALONE_RELEASE_BASE_COMMIT }}
         run: |
           set -euo pipefail
+          # BEGIN plugin-server-index-contract
+          verify_plugin_server_index() {
+            jq -e '
+              def runnable: (.platform.os == "linux" and (.platform.architecture == "amd64" or .platform.architecture == "arm64"));
+              [.manifests[] | select(runnable)] as $runnable |
+              [.manifests[] | select(runnable | not)] as $extra |
+              (([$runnable[] | .platform.os + "/" + .platform.architecture] | sort) == ["linux/amd64","linux/arm64"]) and
+              (($runnable | length) == 2) and
+              (($extra | length) == 0 or
+                (($extra | length) == 2 and
+                 all($extra[];
+                   .mediaType == "application/vnd.oci.image.manifest.v1+json" and
+                   .platform.os == "unknown" and .platform.architecture == "unknown" and
+                   .annotations["vnd.docker.reference.type"] == "attestation-manifest") and
+                 (([$extra[].annotations["vnd.docker.reference.digest"]] | sort) == ([$runnable[].digest] | sort))))
+            ' "$1" >/dev/null
+          }
+          # END plugin-server-index-contract
           release=$(gh api "repos/higress-group/higress/releases/$RELEASE_ID")
           test "$(jq -r .tag_name <<<"$release")" = "$TAG"
           test "$(jq -r .draft <<<"$release")" = false; test "$(jq -r .prerelease <<<"$release")" = false
@@ -86,8 +104,8 @@ jobs:
             digest=$(oras manifest fetch "$ref" --descriptor | jq -r .digest)
             test "$digest" = "$plugin_server"
             oras manifest fetch "$repo@$digest" --raw >/tmp/index.json
-            platforms=$(jq -c '[.manifests[] | .platform.os + "/" + .platform.architecture] | sort' /tmp/index.json)
-            test "$platforms" = '["linux/amd64","linux/arm64"]'
+            verify_plugin_server_index /tmp/index.json
+            platforms=$(jq -c '[.manifests[] | select(.platform.os == "linux" and (.platform.architecture == "amd64" or .platform.architecture == "arm64")) | .platform.os + "/" + .platform.architecture] | sort' /tmp/index.json)
             labels='{}'
             while IFS=$'\t' read -r platform child; do
               manifest=$(oras manifest fetch "$repo@$child")
@@ -95,7 +113,7 @@ jobs:
               label=$(oras blob fetch "$repo@$config" -o - | jq -c '.config.Labels // {}')
               jq -e --arg plugin "$PLUGIN_SERVER_COMMIT" --arg source "$SNAPSHOT_SOURCE_COMMIT" --arg snapshot "$sha" --arg version "${TAG#v}" '."org.opencontainers.image.revision" == $plugin and ."io.higress.higress-source-commit" == $source and ."io.higress.plugin-snapshot-sha256" == $snapshot and ."io.higress.gateway-version" == $version' <<<"$label" >/dev/null
               labels=$(jq --arg platform "$platform" --argjson label "$label" '.[$platform]=$label' <<<"$labels")
-            done < <(jq -r '.manifests[] | [(.platform.os + "/" + .platform.architecture), .digest] | @tsv' /tmp/index.json)
+            done < <(jq -r '.manifests[] | select(.platform.os == "linux" and (.platform.architecture == "amd64" or .platform.architecture == "arm64")) | [(.platform.os + "/" + .platform.architecture), .digest] | @tsv' /tmp/index.json)
             jq -cn --arg ref "$ref" --arg digest "$digest" --argjson platforms "$platforms" --argjson labels "$labels" '{ref:$ref,digest:$digest,platforms:$platforms,labelsByPlatform:$labels}'
           }
           plugin_json=$(inspect_plugin_server "$plugin_server_ref")

--- a/tools/plugin-release/plugin_server_workflow_contract_test.go
+++ b/tools/plugin-release/plugin_server_workflow_contract_test.go
@@ -29,7 +29,7 @@ func TestPluginServerWorkflowFailsClosedBeforeCandidateMutation(t *testing.T) {
 	}
 	for _, required := range []string{
 		"docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392", "docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435", "oras-project/setup-oras@8d34698a59f5ffe24821f0b48ab62a3de8b64b20",
-		"length == 2", "linux/amd64", "linux/arm64", "org.opencontainers.image.revision",
+		"attestation-manifest", "linux/amd64", "linux/arm64", "org.opencontainers.image.revision",
 		"snapshot-inventory.json", "jsonrpc-converter", "unmanaged-plugins.lock.json",
 	} {
 		if !strings.Contains(workflow, required) {
@@ -39,6 +39,75 @@ func TestPluginServerWorkflowFailsClosedBeforeCandidateMutation(t *testing.T) {
 	buildData, err := os.ReadFile("../../.github/workflows/build-plugin-server-from-snapshot.yaml")
 	if err != nil || !strings.Contains(string(buildData), "plugin-release-batches:$SNAPSHOT_SHA256") {
 		t.Fatal("plugin-server build must require the immutable latest-completion marker")
+	}
+}
+
+func TestPluginServerIndexContractAcceptsOnlyTwoRunnablePlatformsAndPairedAttestations(t *testing.T) {
+	workflows := []string{
+		"build-plugin-server-from-snapshot.yaml",
+		"authorize-higress-release-tag.yaml",
+		"dispatch-standalone-release.yaml",
+	}
+	fixtures := map[string]struct {
+		json string
+		want bool
+	}{
+		"two-runnable":         {json: `{"manifests":[{"digest":"sha256:amd","platform":{"os":"linux","architecture":"amd64"}},{"digest":"sha256:arm","platform":{"os":"linux","architecture":"arm64"}}]}`, want: true},
+		"paired-attestations":  {json: `{"manifests":[{"digest":"sha256:amd","platform":{"os":"linux","architecture":"amd64"}},{"digest":"sha256:arm","platform":{"os":"linux","architecture":"arm64"}},{"mediaType":"application/vnd.oci.image.manifest.v1+json","platform":{"os":"unknown","architecture":"unknown"},"annotations":{"vnd.docker.reference.type":"attestation-manifest","vnd.docker.reference.digest":"sha256:amd"}},{"mediaType":"application/vnd.oci.image.manifest.v1+json","platform":{"os":"unknown","architecture":"unknown"},"annotations":{"vnd.docker.reference.type":"attestation-manifest","vnd.docker.reference.digest":"sha256:arm"}}]}`, want: true},
+		"missing-arm64":        {json: `{"manifests":[{"digest":"sha256:amd","platform":{"os":"linux","architecture":"amd64"}}]}`},
+		"unexpected-platform":  {json: `{"manifests":[{"digest":"sha256:amd","platform":{"os":"linux","architecture":"amd64"}},{"digest":"sha256:arm","platform":{"os":"linux","architecture":"arm64"}},{"digest":"sha256:ppc","platform":{"os":"linux","architecture":"ppc64le"}}]}`},
+		"unpaired-attestation": {json: `{"manifests":[{"digest":"sha256:amd","platform":{"os":"linux","architecture":"amd64"}},{"digest":"sha256:arm","platform":{"os":"linux","architecture":"arm64"}},{"mediaType":"application/vnd.oci.image.manifest.v1+json","platform":{"os":"unknown","architecture":"unknown"},"annotations":{"vnd.docker.reference.type":"attestation-manifest","vnd.docker.reference.digest":"sha256:amd"}},{"mediaType":"application/vnd.oci.image.manifest.v1+json","platform":{"os":"unknown","architecture":"unknown"},"annotations":{"vnd.docker.reference.type":"attestation-manifest","vnd.docker.reference.digest":"sha256:other"}}]}`},
+		"unexpected-extra":     {json: `{"manifests":[{"digest":"sha256:amd","platform":{"os":"linux","architecture":"amd64"}},{"digest":"sha256:arm","platform":{"os":"linux","architecture":"arm64"}},{"mediaType":"application/vnd.oci.image.manifest.v1+json","platform":{"os":"unknown","architecture":"unknown"},"annotations":{"vnd.docker.reference.type":"other","vnd.docker.reference.digest":"sha256:amd"}},{"mediaType":"application/vnd.oci.image.manifest.v1+json","platform":{"os":"unknown","architecture":"unknown"},"annotations":{"vnd.docker.reference.type":"attestation-manifest","vnd.docker.reference.digest":"sha256:arm"}}]}`},
+	}
+
+	var canonical string
+	for _, workflow := range workflows {
+		contract := workflowShellContract(t, workflow, "plugin-server-index-contract")
+		if canonical == "" {
+			canonical = contract
+		} else if contract != canonical {
+			t.Fatalf("%s does not use the canonical plugin-server index contract", workflow)
+		}
+		for name, fixture := range fixtures {
+			t.Run(workflow+"/"+name, func(t *testing.T) {
+				path := filepath.Join(t.TempDir(), "index.json")
+				if err := os.WriteFile(path, []byte(fixture.json), 0o600); err != nil {
+					t.Fatal(err)
+				}
+				cmd := exec.Command("bash", "-c", "set -euo pipefail\n"+contract+fmt.Sprintf("\nverify_plugin_server_index %q", path))
+				output, err := cmd.CombinedOutput()
+				if fixture.want && err != nil {
+					t.Fatalf("valid plugin-server index rejected: %v\n%s", err, output)
+				}
+				if !fixture.want && err == nil {
+					t.Fatalf("invalid plugin-server index accepted: %s", fixture.json)
+				}
+			})
+		}
+	}
+}
+
+func TestPluginServerWorkflowReusesImmutableCandidateBeforeBuild(t *testing.T) {
+	data, err := os.ReadFile("../../.github/workflows/build-plugin-server-from-snapshot.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	workflow := string(data)
+	lookup := strings.Index(workflow, `if candidate_json=$(oras manifest fetch "$candidate" --descriptor`)
+	build := strings.Index(workflow, `docker buildx build --platform linux/amd64,linux/arm64`)
+	acceptance := strings.Index(workflow, `verify_plugin_server_index /tmp/candidate-index.json`)
+	if lookup < 0 || build < 0 || acceptance < 0 || !(lookup < build && build < acceptance) {
+		t.Fatal("plugin-server workflow must reuse or build its immutable candidate before the same acceptance boundary")
+	}
+	for _, required := range []string{
+		`candidate_digest=$(jq -er .digest <<<"$candidate_json")`,
+		`Reusing immutable plugin-server candidate`,
+		`candidate tag lookup was refused; authorization failure is never absence`,
+		`candidate tag lookup failed; refusing candidate/public mutation`,
+	} {
+		if !strings.Contains(workflow, required) {
+			t.Fatalf("immutable candidate retry contract lacks %q", required)
+		}
 	}
 }
 


### PR DESCRIPTION
## I. Summary

Fix the plugin-server release retry after Buildx emitted standard provenance attestation manifests. Release verification now requires exactly the `linux/amd64` and `linux/arm64` runnable manifests and permits either no extra manifests or exactly one paired Buildx attestation for each runnable digest. Label and runtime checks operate only on runnable manifests. A retry reuses the existing immutable candidate before attempting a build, so the ACR immutable tag is never overwritten.

## II. Related issue

Follow-up release-specific fix for #4442. The failing baseline is https://github.com/higress-group/higress/actions/runs/31749256836.

## III. Change type

- [x] Bug fix
- [ ] Feature or enhancement
- [ ] Documentation or configuration only
- [x] Refactoring, tests, or maintenance

## IV. Agent participation and issue-spec gate

- [ ] **No agent participation:** This PR is human-only.
- [ ] **Trivial agent-use exception:** Agent use was limited to spelling, punctuation, whitespace, or formatting with no substantive choice or behavioral effect.
- [x] **Verified maintainer/administrator exception:** Material agent participation occurred, and authenticated `gh` verification confirmed a `role_name` of `maintain` or `admin` on `higress-group/higress`, and the verified login matches this PR's GitHub author.
- [ ] **Material agent participation:** An AI or coding agent materially participated without the verified exception.

- [ ] Complete: all three timed obligations above were satisfied.
- [ ] Noncompliant: one or more obligations were not satisfied.
- [x] Verified exception: material agent participation used the verified-maintainer/administrator exception.
- [ ] N/A because the PR is human-only or qualifies for the trivial exception.

**Gate-status explanation (or N/A):** The repository administrator is using the policy's verified exception for this narrowly scoped release bug fix. Runtime verification remains mandatory and is recorded below.

**Trivial-exception explanation (or N/A):** N/A.

**Verified maintainer/administrator exception evidence (or N/A):**

- This PR's number or URL: https://github.com/higress-group/higress/pull/4493
- Authenticated `gh` login: `johnlanni`
- Canonical-repository `role_name`: `admin`
- Actual PR author from `gh pr view`: `johnlanni`
- Login/author match: yes
- Token override attestation (`GH_TOKEN` and `GITHUB_TOKEN` were unset for every verification command; required: `yes`): yes
- Bypass rationale: unblock the active 2.2.4 release after the immutable candidate was successfully built with Buildx provenance but the old verifier incorrectly required the OCI index to contain only two total manifests.
- Maintainer live validation (review URL or N/A until performed): https://github.com/higress-group/higress/pull/4493#issuecomment-5287216570

**Approved Proposal Issue URL (or N/A with explanation):** N/A under verified administrator exception; broader release automation is tracked by #4442.

**Approved Design Issue URL (or N/A with explanation):** N/A under verified administrator exception.

**Maintainer approval link(s) (or N/A with explanation):** N/A under verified administrator exception; user explicitly authorized autonomous release-specific remediation and merges in the active task.

**Authorized implementation TASK link(s) (or N/A with explanation):** #4442 TASK-4442005 tracks end-to-end release verification; this fix is a release-specific remediation under the verified exception.

**Verification Plan and verification TASK/evidence link(s) (or N/A with explanation):** Re-run the formal plugin-server workflow with the exact 2.2.4 snapshot and source commits, confirm immutable candidate reuse, runnable manifest/label/runtime acceptance, public digest equality, and Console dispatch. Evidence will be added to #4442 TASK-4442005.

## V. Testing and verification

**Test and deterministic rerun commands (or N/A with explanation):**

```text
cd tools/plugin-release && go test ./... -count=1
cd tools/plugin-release && go vet ./...
actionlint .github/workflows/build-plugin-server-from-snapshot.yaml .github/workflows/authorize-higress-release-tag.yaml .github/workflows/dispatch-standalone-release.yaml
git diff --check
# Extract the exact helper from the production workflow and execute it against the real candidate index fetched anonymously with ORAS.
```

All commands passed at exact head `a1a6d5584edfd8145786f3ec68677c283fda5338`.

**Environment and configuration (or N/A with explanation):** Linux amd64; Go and actionlint from the repository validation environment; ORAS 1.2.3; anonymous ACR read for the exact immutable candidate.

**Exact tested revision, version, image tag/digest, manifests, and values (or N/A with explanation):**

- Revision: `a1a6d5584edfd8145786f3ec68677c283fda5338`
- Gateway version: `2.2.4`
- Snapshot SHA-256: `09bc798df37e50dae2e684947885c31eb756636c76a98761a9a980fc031e3a1a`
- Candidate digest: `sha256:05a3e3615434befdb89928e491a8833255733c099dd24faefe82fea4d63165bb`
- Runnable manifests: `linux/amd64` `sha256:26629e961e9e31313a8ddbe903447db5ec13ce3e088d7ed773ebe946d892be12`; `linux/arm64` `sha256:dc82d36dd6256b298ad20be0e410498d70fad10c90ff55a6c7029f0eddbbeccc`
- The real index includes two `unknown/unknown` Buildx attestation manifests, each referencing exactly one runnable digest; the production helper accepted it.

**Baseline reproduction evidence for bug fixes (or N/A with explanation):** Formal run https://github.com/higress-group/higress/actions/runs/31749256836 built and pushed the candidate, then failed because it asserted total manifest count equals two.

**Fixed-version verification evidence for bug fixes (or N/A with explanation):** Static/unit/actionlint checks pass; formal workflow rerun will be the release-level runtime verification immediately after merge.

**Wasm source revision and SHA-256 (or N/A with explanation):** Snapshot source commit `7774663e4353652f5c3cecd7e98a1a43b05ee15c`; snapshot SHA-256 `09bc798df37e50dae2e684947885c31eb756636c76a98761a9a980fc031e3a1a`.

## VI. Special notes for reviewers

Review the fail-closed extras contract and immutable-candidate lookup classification. The change deliberately preserves Buildx provenance and does not accept arbitrary platform or auxiliary manifests. Unrelated CI is not a release blocker; exact-head local checks and the formal release rerun are the acceptance evidence.

## VII. AI coding disclosure

**Tool(s) used (or N/A):** OpenAI Codex.

### Prompts or instructions

Continue the approved 2.2.4 release autonomously, diagnose release workflow failures, fix them through PRs, independently review exact heads, merge, approve GitHub environments, and complete the release chain. The user later clarified that unrelated CI need not all pass.

### AI-assisted work summary

Codex inspected the failed formal run and the exact OCI candidate index, identified Buildx provenance attestations as the mismatch, implemented a canonical fail-closed index contract across all plugin-server consumers, added immutable candidate reuse for retries, and added contract tests covering valid and invalid indexes. The formal release workflow must still be rerun after merge to produce final runtime evidence.
