### PR TITLE
fix: configure release tagger identity

### DIFF
--- a/.github/workflows/authorize-higress-release-tag.yaml
+++ b/.github/workflows/authorize-higress-release-tag.yaml
@@ -263,4 +263,6 @@ jobs:
           fi
           [[ -z "$existing" || "$existing" =~ ^[0-9a-f]{40}$ ]]
           if [ -n "$existing" ] && [ "$existing" != "$RELEASE_COMMIT" ]; then echo "immutable tag conflict: $tag" >&2; exit 1; fi
+          git config user.name "higress-release-manager[bot]"
+          git config user.email "higress-release-manager[bot]@users.noreply.github.com"
           if [ -z "$existing" ]; then git tag -a "$tag" "$RELEASE_COMMIT" -m "Higress $tag"; git push origin "refs/tags/$tag"; fi

--- a/tools/plugin-release/plugin_server_workflow_contract_test.go
+++ b/tools/plugin-release/plugin_server_workflow_contract_test.go
@@ -1253,6 +1253,20 @@ func TestReleaseAuthorizerBindsConsoleLockToCanonicalPluginServer(t *testing.T) 
 	}
 }
 
+func TestReleaseAuthorizerConfiguresTaggerIdentityBeforeAnnotatedTag(t *testing.T) {
+	data, err := os.ReadFile("../../.github/workflows/authorize-higress-release-tag.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	workflow := string(data)
+	name := strings.Index(workflow, `git config user.name "higress-release-manager[bot]"`)
+	email := strings.Index(workflow, `git config user.email "higress-release-manager[bot]@users.noreply.github.com"`)
+	tag := strings.Index(workflow, `git tag -a "$tag" "$RELEASE_COMMIT"`)
+	if name < 0 || email < 0 || tag < 0 || name > email || email > tag {
+		t.Fatal("release authorizer must configure a local App tagger identity before creating the annotated tag")
+	}
+}
+
 func TestReleaseWorkflowsUseORAS12ManifestOutput(t *testing.T) {
 	required := map[string][]string{
 		"authorize-higress-release-tag.yaml": {


### PR DESCRIPTION
## Summary

Configure repository-local `user.name` and `user.email` for the release-manager App immediately before annotated tag creation. The formal 2.2.4 run https://github.com/higress-group/higress/actions/runs/31754222904 passed every readiness and canonical evidence assertion, then failed only because `git tag -a` had no committer identity. No tag was created.

## Related issue

Release-specific remediation for #4442.

## Change type

- [x] Bug fix
- [x] Tests or maintenance

## Agent participation / verified exception

- [x] Verified maintainer/administrator exception; `johnlanni`, canonical `role_name=admin`, and PR author match are verified with both GH_TOKEN/GITHUB_TOKEN unset. OpenAI Codex implemented the narrow recovery after the formal failure. The maintainer authorized autonomous release-specific remediation and merges.

## Verification

Exact head `063b3ba6e1425f8d8695b01613e861171df9c275`. Full `go test ./... -count=1`, `go vet ./...`, and `git diff --check` passed. The contract test requires local App identity before the annotated tag command. Formal rerun remains the runtime evidence and must reproduce approved readiness SHA `d4f7e68621ab289df7ecec4a44f02e5aeeffe4949b68ae3cdd8c806d4ba7c069`. Unrelated CI need not block this authorized release recovery.

## AI coding disclosure

Codex inspected the exact failed tag step, confirmed the absence of git identity as the sole failure after successful evidence matching, added local App identity and a production-order regression test. No artifact, snapshot, release commit, or evidence input changed.