### PR TITLE
fix: recover standalone dispatch after release builds

### DIFF
--- a/.github/workflows/dispatch-standalone-release.yaml
+++ b/.github/workflows/dispatch-standalone-release.yaml
@@ -2,17 +2,31 @@ name: Dispatch Exact Released Higress Inputs to Standalone
 on:
   release:
     types: [published]
+  workflow_run:
+    workflows: ["Build Docker Images and Push to Image Registry"]
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: "Published Higress release tag to recover or replay"
+        required: true
+        type: string
 permissions:
   contents: read
 jobs:
   dispatch:
-    if: ${{ startsWith(github.event.release.tag_name, 'v') }}
+    if: >-
+      ${{
+        (github.event_name == 'release' && startsWith(github.event.release.tag_name, 'v')) ||
+        (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && startsWith(github.event.workflow_run.head_branch, 'v')) ||
+        (github.event_name == 'workflow_dispatch' && startsWith(inputs.release_tag, 'v'))
+      }}
     runs-on: ubuntu-latest
     environment: standalone-dispatch
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
-          ref: ${{ github.event.release.tag_name }}
+          ref: ${{ github.event_name == 'release' && github.event.release.tag_name || github.event_name == 'workflow_run' && github.event.workflow_run.head_branch || inputs.release_tag }}
           fetch-depth: 0
       - uses: oras-project/setup-oras@8d34698a59f5ffe24821f0b48ab62a3de8b64b20 # v1.2.3
         with:
@@ -27,8 +41,8 @@ jobs:
       - name: Resolve canonical immutable release evidence and dispatch
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          TAG: ${{ github.event.release.tag_name }}
-          RELEASE_ID: ${{ github.event.release.id }}
+          TAG: ${{ github.event_name == 'release' && github.event.release.tag_name || github.event_name == 'workflow_run' && github.event.workflow_run.head_branch || inputs.release_tag }}
+          EVENT_RELEASE_ID: ${{ github.event_name == 'release' && github.event.release.id || '' }}
           CONSOLE_CHART_REGISTRY: ${{ vars.CONSOLE_CHART_REGISTRY }}
           PLUGIN_SERVER_REGISTRY: ${{ vars.PLUGIN_SERVER_REGISTRY }}
           GATEWAY_REGISTRY: ${{ vars.GATEWAY_REGISTRY }}
@@ -53,7 +67,13 @@ jobs:
             ' "$1" >/dev/null
           }
           # END plugin-server-index-contract
-          release=$(gh api "repos/higress-group/higress/releases/$RELEASE_ID")
+          if [ -n "$EVENT_RELEASE_ID" ]; then
+            RELEASE_ID=$EVENT_RELEASE_ID
+            release=$(gh api "repos/higress-group/higress/releases/$RELEASE_ID")
+          else
+            release=$(gh api "repos/higress-group/higress/releases/tags/$TAG")
+            RELEASE_ID=$(jq -er .id <<<"$release")
+          fi
           test "$(jq -r .tag_name <<<"$release")" = "$TAG"
           test "$(jq -r .draft <<<"$release")" = false; test "$(jq -r .prerelease <<<"$release")" = false
           tag_ref=$(gh api "repos/higress-group/higress/git/ref/tags/$TAG")

--- a/tools/plugin-release/plugin_server_workflow_contract_test.go
+++ b/tools/plugin-release/plugin_server_workflow_contract_test.go
@@ -1337,6 +1337,31 @@ func TestStandaloneDispatchBindsUniqueConsoleEvidenceToPluginServer(t *testing.T
 	}
 }
 
+func TestStandaloneDispatchSurvivesGitHubTokenReleaseSuppression(t *testing.T) {
+	data, err := os.ReadFile("../../.github/workflows/dispatch-standalone-release.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	workflow := string(data)
+	for _, required := range []string{
+		`workflow_run:`,
+		`workflows: ["Build Docker Images and Push to Image Registry"]`,
+		`github.event.workflow_run.conclusion == 'success'`,
+		`github.event.workflow_run.head_branch`,
+		`workflow_dispatch:`,
+		`release_tag:`,
+		`release=$(gh api "repos/higress-group/higress/releases/tags/$TAG")`,
+		`RELEASE_ID=$(jq -er .id <<<"$release")`,
+	} {
+		if !strings.Contains(workflow, required) {
+			t.Fatalf("standalone dispatch lacks release-event recovery contract %q", required)
+		}
+	}
+	if !strings.Contains(workflow, `(github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && startsWith(github.event.workflow_run.head_branch, 'v'))`) {
+		t.Fatal("standalone dispatch must reject failed or non-release image workflow runs")
+	}
+}
+
 func TestPreparationBootstrapReusesProtectedCandidateRegistryCredential(t *testing.T) {
 	data, err := os.ReadFile("../../.github/workflows/prepare-plugin-release.yaml")
 	if err != nil {


### PR DESCRIPTION
## I. Summary

Recover the exact standalone release dispatch when the Higress GitHub Release is created by a workflow `GITHUB_TOKEN`, whose resulting `release: published` event is intentionally suppressed by GitHub.

The dispatcher now also runs after a successful tagged `Build Docker Images and Push to Image Registry` workflow, and exposes an idempotent `workflow_dispatch` recovery input. Every path retains the existing immutable release, Console provenance, plugin-server, and gateway-image verification before dispatch.

## II. Related issue

Related to #4442.

## III. Change type

- [x] Bug fix
- [ ] Feature or enhancement
- [ ] Documentation or configuration only
- [x] Refactoring, tests, or maintenance

## IV. Agent participation and issue-spec gate

- [ ] **No agent participation:** This PR is human-only.
- [ ] **Trivial agent-use exception:** Agent use was limited to spelling, punctuation, whitespace, or formatting with no substantive choice or behavioral effect; the explanation is below.
- [x] **Verified maintainer/administrator exception:** Material agent participation occurred, and authenticated `gh` verification confirmed a `role_name` of `maintain` or `admin` on `higress-group/higress`, and the verified login matches this PR's GitHub author; record the required evidence and rationale below.
- [ ] **Material agent participation:** An AI or coding agent materially participated in analysis, design, implementation, testing, or PR preparation.

- [ ] Complete: all three timed obligations above were satisfied.
- [ ] Noncompliant: one or more obligations were not satisfied; explain below.
- [x] Verified exception: material agent participation used the verified-maintainer/administrator exception; provide the required evidence and rationale below.
- [ ] N/A because the PR is human-only or qualifies for the trivial exception.

**Gate-status explanation (or N/A):** Verified maintainer/administrator exception for a release-blocking workflow bug discovered during the approved 2.2.4 release execution.

**Trivial-exception explanation (or N/A):** N/A.

**Verified maintainer/administrator exception evidence (or N/A):**

- This PR's number or URL: https://github.com/higress-group/higress/pull/4497
- Authenticated `gh` login: `johnlanni`
- Canonical-repository `role_name`: `admin`
- Actual PR author from `gh pr view`: johnlanni
- Login/author match: yes
- Token override attestation (`GH_TOKEN` and `GITHUB_TOKEN` were unset for every verification command; required: `yes`): yes
- Bypass rationale: release-specific recovery for a GitHub event-suppression behavior; immutable artifact and provenance gates remain unchanged.
- Maintainer live validation (review URL or N/A until performed): https://github.com/higress-group/higress/pull/4497#issuecomment-5287749581

**Approved Proposal Issue URL (or N/A with explanation):** https://github.com/higress-group/higress/issues/4442

**Approved Design Issue URL (or N/A with explanation):** Covered by the maintainer-approved release automation design tracked from #4442; this bug fix uses the verified exception.

**Maintainer approval link(s) (or N/A with explanation):** Maintainer authorization is recorded in the active release task; verified exception applies.

**Authorized implementation TASK link(s) (or N/A with explanation):** TASK-4442005; verified exception used for this release-blocking fix.

**Verification Plan and verification TASK/evidence link(s) (or N/A with explanation):** TASK-4442005. Exact runtime evidence will be the replayed 2.2.4 dispatcher run after merge.

## V. Testing and verification

**Test and deterministic rerun commands (or N/A with explanation):**

```text
go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 .github/workflows/dispatch-standalone-release.yaml
(cd tools/plugin-release && go test ./... -count=1)
git diff --check
```

All passed at `46ac8482`.

**Environment and configuration (or N/A with explanation):** Linux amd64; Go from the repository toolchain; actionlint v1.7.7.

**Exact tested revision, version, image tag/digest, manifests, and values (or N/A with explanation):** Head `46ac8482`; recovery target `v2.2.4`, exact release commit `58666ac985cee19a0a9a353421c63cead6d0cb47`.

**Baseline reproduction evidence for bug fixes (or N/A with explanation):** Higress `v2.2.4` Release ID `370271059` was published by the CRD workflow, but no `Dispatch Exact Released Higress Inputs to Standalone` run was created because GitHub suppresses recursive workflow events from `GITHUB_TOKEN`.

**Fixed-version verification evidence for bug fixes (or N/A with explanation):** Static and contract tests passed; exact 2.2.4 recovery run will be linked after merge.

**Wasm source revision and SHA-256 (or N/A with explanation):** No WASM source changed. The retained release gate binds snapshot SHA-256 `09bc798df37e50dae2e684947885c31eb756636c76a98761a9a980fc031e3a1a`.

## VI. Special notes for reviewers

Review event selection and trust boundaries: `workflow_run` requires a successful tagged image workflow; manual replay still resolves the immutable published release by tag and executes every existing provenance assertion before repository dispatch.

## VII. AI coding disclosure

**Tool(s) used (or N/A):** OpenAI Codex.

### Prompts or instructions

Diagnose and autonomously recover the approved Higress 2.2.4 release pipeline without waiting for unrelated CI; do not bypass artifact, source, signature, or release correctness.

### AI-assisted work summary

Codex diagnosed GitHub's recursive event suppression, added a successful image-workflow completion trigger plus a manual idempotent recovery trigger, retained exact tag/release/provenance verification, and added a regression contract test.