### PR TITLE
fix: source release notes from canonical repository

### DIFF
--- a/.github/workflows/generate-release-notes.yaml
+++ b/.github/workflows/generate-release-notes.yaml
@@ -9,12 +9,23 @@ on:
 jobs:
   generate-release-notes:
     runs-on: ubuntu-latest
+    environment: higress-release-manager
     env:
       DASHSCOPE_API_KEY: ${{ secrets.HIGRESS_OPENAI_API_KEY }}
       MODEL_NAME: ${{ secrets.HIGRESS_OPENAI_API_MODEL }}
       MODEL_SERVER: ${{ secrets.MODEL_SERVER }}
 
     steps:
+      - name: Create canonical release reader token
+        id: release-reader
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
+        with:
+          app-id: ${{ vars.RELEASE_MANAGER_APP_ID }}
+          private-key: ${{ secrets.RELEASE_MANAGER_APP_PRIVATE_KEY }}
+          owner: higress-group
+          repositories: higress,higress-console
+          permission-contents: write
+
       - name: Checkout code
         uses: actions/checkout@v4
         with:
@@ -35,7 +46,7 @@ jobs:
           chmod u+x github-mcp-serve
 
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.10"
 
@@ -60,40 +71,39 @@ jobs:
           cat > generate_release_report.sh << 'EOF'
           #!/bin/bash
           # Script to generate release notes for Higress projects
+          set -euo pipefail
 
           echo "Fetching GitHub generated release notes for ${GITHUB_REPO_OWNER}/${GITHUB_REPO_NAME}..."
-          curl -L \
-              "https://github.com/${GITHUB_REPO_OWNER}/${GITHUB_REPO_NAME}/releases/tag/${RELEASE_VERSION}" \
-              -o release_page.html
+          payload=$(jq -cn --arg tag "$RELEASE_VERSION" '{tag_name:$tag}')
+          curl --fail-with-body --silent --show-error --location --request POST \
+              -H "Accept: application/vnd.github+json" \
+              -H "Authorization: Bearer ${GITHUB_PERSONAL_ACCESS_TOKEN}" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              "https://api.github.com/repos/${GITHUB_REPO_OWNER}/${GITHUB_REPO_NAME}/releases/generate-notes" \
+              --data "$payload" -o generated_release_notes.json
+          jq -er .body generated_release_notes.json > generated_release_notes.md
 
-          # Extract system prompt content from HTML
+          # Keep the optional operator prompt from the existing release body,
+          # but never use that mutable body as the source of included PRs.
+          curl --fail-with-body --silent --show-error --location \
+              -H "Accept: application/vnd.github+json" \
+              -H "Authorization: Bearer ${GITHUB_PERSONAL_ACCESS_TOKEN}" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              "https://api.github.com/repos/${GITHUB_REPO_OWNER}/${GITHUB_REPO_NAME}/releases/tags/${RELEASE_VERSION}" \
+              -o existing_release.json
+
+          # Extract an optional Markdown `## system prompt` section.
           echo "Extracting system prompt content..."
-          pip install beautifulsoup4 markdownify
-          SYSTEM_PROMPT=$(python3 -c "
-          import sys
-          from bs4 import BeautifulSoup
-          from markdownify import markdownify
+          SYSTEM_PROMPT=$(python3 - <<'PY'
+          import json
+          import re
 
-          with open('release_page.html', 'r') as f:
-              soup = BeautifulSoup(f, 'html.parser')
-          
-          system_prompt_header = soup.find('h2', string='system prompt')
-          if system_prompt_header:
-              content = []
-              for sibling in system_prompt_header.next_siblings:
-                  if sibling.name == 'h2':
-                      break
-                  content.append(str(sibling))
-              html_content = ''.join(content).strip()
-              # Convert HTML to Markdown
-              if html_content:
-                  markdown_content = markdownify(html_content)
-                  print(markdown_content.strip())
-              else:
-                  print('')
-          else:
-              print('')
-          ")
+          with open("existing_release.json", encoding="utf-8") as stream:
+              body = json.load(stream).get("body") or ""
+          match = re.search(r"(?ims)^##\s+system prompt\s*$\n(.*?)(?=^##\s|\Z)", body)
+          print(match.group(1).strip() if match else "")
+          PY
+          )
           if [ -z "${SYSTEM_PROMPT}" ]; then
               echo "No system prompt found in release notes."
           else
@@ -101,19 +111,35 @@ jobs:
           fi
 
           echo "Extracting PR numbers from ${GITHUB_REPO_OWNER}/${GITHUB_REPO_NAME} release notes..."
-          PR_NUMS=$(cat release_page.html | grep -o "/${GITHUB_REPO_OWNER}/${GITHUB_REPO_NAME}/pull/[0-9]*" | grep -o "[0-9]*$" | sort -n | uniq | tr '\n' ',')
-          PR_NUMS=${PR_NUMS%,}
+          PR_NUMS=$(python3 - "$GITHUB_REPO_OWNER" "$GITHUB_REPO_NAME" <<'PY'
+          import re
+          import sys
+
+          owner, repo = sys.argv[1:]
+          body = open("generated_release_notes.md", encoding="utf-8").read()
+          values = sorted({int(value) for value in re.findall(rf"https://github\.com/{re.escape(owner)}/{re.escape(repo)}/pull/(\d+)", body)})
+          print(",".join(map(str, values)))
+          PY
+          )
           if [ -z "${PR_NUMS}" ]; then
               echo "No PR numbers found in release notes for ${GITHUB_REPO_OWNER}/${GITHUB_REPO_NAME} tag=${RELEASE_VERSION}."
-              rm release_page.html
-              exit 0
+              exit 1
           fi
 
           echo "Identifying important PRs..."
-          IMPORTANT_PR_NUMS=$(cat release_page.html | grep -o "<strong>.*/${GITHUB_REPO_OWNER}/${GITHUB_REPO_NAME}/pull/[0-9]*.*</strong>" | grep -o "pull/[0-9]*" | grep -o "[0-9]*" | sort -n | uniq | tr '\n' ',')
-          IMPORTANT_PR_NUMS=${IMPORTANT_PR_NUMS%,}
+          IMPORTANT_PR_NUMS=$(python3 - "$GITHUB_REPO_OWNER" "$GITHUB_REPO_NAME" <<'PY'
+          import re
+          import sys
 
-          rm release_page.html
+          owner, repo = sys.argv[1:]
+          body = open("generated_release_notes.md", encoding="utf-8").read()
+          pattern = rf"(?m)^.*\*\*.*https://github\.com/{re.escape(owner)}/{re.escape(repo)}/pull/(\d+).*\*\*.*$"
+          values = sorted({int(value) for value in re.findall(pattern, body)})
+          print(",".join(map(str, values)))
+          PY
+          )
+
+          rm generated_release_notes.json generated_release_notes.md existing_release.json
 
           echo "Extracted PR numbers for ${GITHUB_REPO_OWNER}/${GITHUB_REPO_NAME}: ${PR_NUMS}"
           echo "Important PR numbers: ${IMPORTANT_PR_NUMS}"
@@ -167,9 +193,9 @@ jobs:
 
       - name: Generate Release Notes for Higress
         env:
-          GITHUB_REPO_OWNER: alibaba
+          GITHUB_REPO_OWNER: higress-group
           GITHUB_REPO_NAME: higress
-          GITHUB_PERSONAL_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_PERSONAL_ACCESS_TOKEN: ${{ steps.release-reader.outputs.token }}
           REPORT_TITLE: Higress
         run: |
           export MAIN_RELEASE_VERSION=$(cat ${GITHUB_WORKSPACE}/VERSION)
@@ -180,7 +206,7 @@ jobs:
         env:
           GITHUB_REPO_OWNER: higress-group
           GITHUB_REPO_NAME: higress-console
-          GITHUB_PERSONAL_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_PERSONAL_ACCESS_TOKEN: ${{ steps.release-reader.outputs.token }}
           REPORT_TITLE: Higress Console
         run: |
           export MAIN_RELEASE_VERSION=$(cat ${GITHUB_WORKSPACE}/VERSION)
@@ -236,7 +262,7 @@ jobs:
 
       - name: Update Release Notes
         env:
-          GITHUB_REPO_OWNER: alibaba
+          GITHUB_REPO_OWNER: higress-group
           GITHUB_REPO_NAME: higress
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/tools/plugin-release/release_docs_contract_test.go
+++ b/tools/plugin-release/release_docs_contract_test.go
@@ -40,3 +40,40 @@ func TestReleaseDocsCreateMetadataPRAfterDependenciesConverge(t *testing.T) {
 		}
 	}
 }
+
+func TestReleaseNotesUseCanonicalGeneratedNotesAPI(t *testing.T) {
+	data, err := os.ReadFile("../../.github/workflows/generate-release-notes.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	workflow := string(data)
+	for _, required := range []string{
+		`GITHUB_REPO_OWNER: higress-group`,
+		`environment: higress-release-manager`,
+		`actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547`,
+		`repositories: higress,higress-console`,
+		`permission-contents: write`,
+		`GITHUB_PERSONAL_ACCESS_TOKEN: ${{ steps.release-reader.outputs.token }}`,
+		`/releases/generate-notes`,
+		`Authorization: Bearer ${GITHUB_PERSONAL_ACCESS_TOKEN}`,
+		`jq -er .body generated_release_notes.json`,
+		`No PR numbers found in release notes`,
+		`exit 1`,
+		`never use that mutable body as the source of included PRs`,
+	} {
+		if !strings.Contains(workflow, required) {
+			t.Fatalf("release notes workflow lacks generated-notes contract %q", required)
+		}
+	}
+	for _, forbidden := range []string{
+		`GITHUB_REPO_OWNER: alibaba`,
+		`GITHUB_PERSONAL_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}`,
+		`https://github.com/${GITHUB_REPO_OWNER}/${GITHUB_REPO_NAME}/releases/tag/`,
+		`release_page.html`,
+		`exit 0`,
+	} {
+		if strings.Contains(workflow, forbidden) {
+			t.Fatalf("release notes workflow retains mutable/legacy source %q", forbidden)
+		}
+	}
+}


### PR DESCRIPTION
## I. Summary

Fix Higress release-note generation so the main repository PR set comes from the canonical `higress-group/higress` repository and from GitHub's authenticated `releases/generate-notes` API.

The 2.2.4 run queried the legacy `alibaba/higress` owner, followed an HTML redirect, then searched the redirected page for legacy-owner PR links. It silently found none, generated only the Console section, overwrote the GitHub Release body, and created incomplete archive PR #4020.

This change makes generated notes independent of the mutable Release body, preserves only an optional operator `## system prompt` section from that body, parses canonical PR URLs deterministically, and fails instead of publishing an incomplete report when no PRs are found.

## II. Related issue

Related to #4442. Baseline: https://github.com/higress-group/higress/actions/runs/31755222281/job/94629433870

## III. Change type

- [x] Bug fix
- [ ] Feature or enhancement
- [ ] Documentation or configuration only
- [x] Refactoring, tests, or maintenance

## IV. Agent participation and issue-spec gate

- [ ] **No agent participation:** This PR is human-only.
- [ ] **Trivial agent-use exception:** Agent use was limited to spelling, punctuation, whitespace, or formatting with no substantive choice or behavioral effect; the explanation is below.
- [x] **Verified maintainer/administrator exception:** Material agent participation occurred, and authenticated `gh` verification confirmed a `role_name` of `maintain` or `admin` on `higress-group/higress`, and the verified login matches this PR's GitHub author; record the required evidence and rationale below.
- [ ] **Material agent participation:** An AI or coding agent materially participated in analysis, design, implementation, testing, or PR preparation.

- [ ] Complete: all three timed obligations above were satisfied.
- [ ] Noncompliant: one or more obligations were not satisfied; explain below.
- [x] Verified exception: material agent participation used the verified-maintainer/administrator exception; provide the required evidence and rationale below.
- [ ] N/A because the PR is human-only or qualifies for the trivial exception.

**Gate-status explanation (or N/A):** Verified maintainer/administrator exception for a runtime-observed release-note bug and 2.2.4 recovery.

**Trivial-exception explanation (or N/A):** N/A.

**Verified maintainer/administrator exception evidence (or N/A):**

- This PR's number or URL: https://github.com/higress-group/higress/pull/4499
- Authenticated `gh` login: `johnlanni`
- Canonical-repository `role_name`: `admin`
- Actual PR author from `gh pr view`: johnlanni
- Login/author match: yes
- Token override attestation (`GH_TOKEN` and `GITHUB_TOKEN` were unset for every verification command; required: `yes`): yes
- Bypass rationale: recover incomplete published 2.2.4 notes and prevent a repeat; no runtime gateway/plugin behavior changes.
- Maintainer live validation (review URL or N/A until performed): N/A until exact-head review.

**Approved Proposal Issue URL (or N/A with explanation):** https://github.com/higress-group/higress/issues/4442

**Approved Design Issue URL (or N/A with explanation):** Release automation design tracked from #4442; verified exception used for this focused runtime bug fix.

**Maintainer approval link(s) (or N/A with explanation):** Maintainer authorization is recorded in the active release task; verified exception applies.

**Authorized implementation TASK link(s) (or N/A with explanation):** TASK-4442005.

**Verification Plan and verification TASK/evidence link(s) (or N/A with explanation):** TASK-4442005; baseline run above and the recovery run/PR will provide fixed evidence.

## V. Testing and verification

**Test and deterministic rerun commands (or N/A with explanation):**

```text
git diff --check
go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 .github/workflows/generate-release-notes.yaml
(cd tools/plugin-release && go test ./... -count=1)
gh api --method POST repos/higress-group/higress/releases/generate-notes -f tag_name=v2.2.4 -f previous_tag_name=v2.2.3
```

All passed at `717bdf777343740f26d0c6e75846bf42a9ce162b`. The canonical generated-notes response contains 96 unique Higress PRs, including #4449 and #4495.

**Environment and configuration (or N/A with explanation):** Linux amd64; actionlint v1.7.7; repository Go toolchain; GitHub REST API.

**Exact tested revision, version, image tag/digest, manifests, and values (or N/A with explanation):** Head `717bdf777343740f26d0c6e75846bf42a9ce162b`; release `v2.2.4`; previous tag `v2.2.3`; exact tag commit `58666ac985cee19a0a9a353421c63cead6d0cb47`.

**Baseline reproduction evidence for bug fixes (or N/A with explanation):** Baseline log prints `Fetching ... alibaba/higress` followed by `No PR numbers found ...`, then continues successfully and archives only 18 Console changes.

**Fixed-version verification evidence for bug fixes (or N/A with explanation):** Canonical API live probe recovered 96 Higress PRs. After merge, a workflow-dispatch recovery will update the Release and create a replacement archive PR.

**Wasm source revision and SHA-256 (or N/A with explanation):** N/A; no WASM source or artifact changes.

## VI. Special notes for reviewers

Review the source-of-truth boundary: included PRs must come only from authenticated generated notes for the exact tag. The mutable Release body is read solely for an optional operator prompt. Empty PR sets are fatal.

## VII. AI coding disclosure

**Tool(s) used (or N/A):** OpenAI Codex.

### Prompts or instructions

Diagnose the incomplete 2.2.4 release note action, repair future generation, and supplement both the published release and merged archive.

### AI-assisted work summary

Codex inspected the exact job log and merged archive, identified the legacy-owner redirect mismatch, validated the canonical GitHub generated-notes result, implemented an authenticated deterministic source, and added fail-closed regression coverage.