### PR TITLE
feat: recover verified gateway release aliases

### DIFF
--- a/.github/workflows/recover-gateway-release-images.yaml
+++ b/.github/workflows/recover-gateway-release-images.yaml
@@ -1,0 +1,168 @@
+name: Recover Verified Gateway Release Image Aliases
+
+on:
+  workflow_dispatch:
+    inputs:
+      gateway_version:
+        description: "Stable Higress version whose verified staging indexes already exist"
+        required: true
+        type: string
+      release_commit:
+        description: "Exact commit targeted by the published annotated release tag"
+        required: true
+        type: string
+      snapshot_sha256:
+        description: "SHA-256 of the committed plugin snapshot"
+        required: true
+        type: string
+      dry_run:
+        description: "Verify all staging indexes without creating missing aliases"
+        required: true
+        default: true
+        type: boolean
+
+permissions:
+  contents: read
+
+concurrency:
+  group: recover-gateway-release-images-${{ inputs.gateway_version }}
+  cancel-in-progress: false
+
+jobs:
+  preflight:
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.release.outputs.tag }}
+      short_commit: ${{ steps.release.outputs.short_commit }}
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          ref: refs/tags/v${{ inputs.gateway_version }}
+          fetch-depth: 0
+      - name: Resolve exact published release and snapshot
+        id: release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GATEWAY_VERSION: ${{ inputs.gateway_version }}
+          RELEASE_COMMIT: ${{ inputs.release_commit }}
+          SNAPSHOT_SHA256: ${{ inputs.snapshot_sha256 }}
+        run: |
+          set -euo pipefail
+          [[ "$GATEWAY_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]
+          [[ "$RELEASE_COMMIT" =~ ^[0-9a-f]{40}$ ]]
+          [[ "$SNAPSHOT_SHA256" =~ ^[0-9a-f]{64}$ ]]
+          tag="v$GATEWAY_VERSION"
+          release=$(gh api "repos/higress-group/higress/releases/tags/$tag")
+          test "$(jq -er .tag_name <<<"$release")" = "$tag"
+          test "$(jq -r .draft <<<"$release")" = false
+          test "$(jq -r .prerelease <<<"$release")" = false
+          tag_ref=$(gh api "repos/higress-group/higress/git/ref/tags/$tag")
+          tag_type=$(jq -er .object.type <<<"$tag_ref"); tag_object=$(jq -er .object.sha <<<"$tag_ref")
+          if [ "$tag_type" = tag ]; then
+            resolved=$(gh api "repos/higress-group/higress/git/tags/$tag_object" --jq .object.sha)
+          else
+            test "$tag_type" = commit
+            resolved=$tag_object
+          fi
+          test "$resolved" = "$RELEASE_COMMIT"
+          test "$(git rev-parse HEAD)" = "$RELEASE_COMMIT"
+          snapshot="plugins/release/snapshots/$GATEWAY_VERSION.json"
+          test -f "$snapshot"
+          test "$(jq -er .gatewayVersion "$snapshot")" = "$GATEWAY_VERSION"
+          test "$(sha256sum "$snapshot" | awk '{print $1}')" = "$SNAPSHOT_SHA256"
+          echo "tag=$tag" >>"$GITHUB_OUTPUT"
+          echo "short_commit=${RELEASE_COMMIT:0:7}" >>"$GITHUB_OUTPUT"
+
+  recover:
+    needs: preflight
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - component: controller
+            environment: image-registry-controller
+            image_name: higress/higress
+          - component: pilot
+            environment: image-registry-pilot
+            image_name: higress/pilot
+          - component: gateway
+            environment: image-registry-gateway
+            image_name: higress/gateway
+    runs-on: ubuntu-latest
+    environment:
+      name: ${{ matrix.environment }}
+    steps:
+      - uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3
+      - name: Login to production registry
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        with:
+          registry: ${{ vars.IMAGE_REGISTRY || 'higress-registry.cn-hangzhou.cr.aliyuncs.com' }}
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+      - name: Verify staging index and recover missing aliases
+        env:
+          IMAGE_REGISTRY: ${{ vars.IMAGE_REGISTRY || 'higress-registry.cn-hangzhou.cr.aliyuncs.com' }}
+          IMAGE_NAME: ${{ matrix.image_name }}
+          GATEWAY_VERSION: ${{ inputs.gateway_version }}
+          RELEASE_COMMIT: ${{ inputs.release_commit }}
+          SNAPSHOT_SHA256: ${{ inputs.snapshot_sha256 }}
+          SHORT_COMMIT: ${{ needs.preflight.outputs.short_commit }}
+          DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          set -euo pipefail
+          repo="$IMAGE_REGISTRY/$IMAGE_NAME"
+          staging="$repo:release-provenance-$RELEASE_COMMIT"
+          docker buildx imagetools inspect "$staging" --raw >/tmp/staging-index.json
+          jq -e --arg commit "$RELEASE_COMMIT" --arg snapshot "$SNAPSHOT_SHA256" --arg version "$GATEWAY_VERSION" '
+            .annotations["org.opencontainers.image.revision"] == $commit and
+            .annotations["io.higress.higress-source-commit"] == $commit and
+            .annotations["io.higress.plugin-snapshot-sha256"] == $snapshot and
+            .annotations["io.higress.gateway-version"] == $version and
+            (.manifests | length == 2) and
+            ([.manifests[] | .platform.os + "/" + .platform.architecture] | sort == ["linux/amd64","linux/arm64"]) and
+            all(.manifests[];
+              .annotations["org.opencontainers.image.revision"] == $commit and
+              .annotations["io.higress.higress-source-commit"] == $commit and
+              .annotations["io.higress.plugin-snapshot-sha256"] == $snapshot and
+              .annotations["io.higress.gateway-version"] == $version)
+          ' /tmp/staging-index.json >/dev/null
+          desired=$(docker buildx imagetools inspect "$staging" --format '{{json .Manifest.Digest}}' | tr -d '"')
+          [[ "$desired" =~ ^sha256:[0-9a-f]{64}$ ]]
+
+          # BEGIN gateway-recovery-descriptor-contract
+          descriptor_or_absent() {
+            local ref=$1 out err classified_error
+            err=$(mktemp)
+            if out=$(docker buildx imagetools inspect "$ref" --format '{{json .Manifest.Digest}}' 2>"$err"); then
+              rm -f "$err"; printf '%s' "$out" | tr -d '"'; return 0
+            fi
+            classified_error=$(<"$err")
+            classified_error=${classified_error//"$ref"/}
+            if grep -Eiq 'unauthorized|forbidden|denied|authentication required|authorization required|HTTP[^[:digit:]]*(401|403)|response status( code)?[^[:digit:]]*(401|403)|status code[^[:digit:]]*(401|403)' <<<"$classified_error"; then
+              cat "$err" >&2; rm -f "$err"; echo "release alias lookup was refused: $ref" >&2; return 2
+            fi
+            if grep -Eiq 'HTTP[^[:digit:]]*404|response status( code)?[^[:digit:]]*404|status code[^[:digit:]]*404|404 Not Found|manifest unknown|name unknown|repository does not exist' <<<"$classified_error" || grep -Fqx "ERROR: $ref: not found" "$err"; then
+              rm -f "$err"; return 1
+            fi
+            cat "$err" >&2; rm -f "$err"; echo "release alias lookup failed; refusing mutation: $ref" >&2; return 2
+          }
+          # END gateway-recovery-descriptor-contract
+
+          for alias in "$GATEWAY_VERSION" "v$GATEWAY_VERSION" "sha-$SHORT_COMMIT"; do
+            target="$repo:$alias"
+            if existing=$(descriptor_or_absent "$target"); then
+              test "$existing" = "$desired" || { echo "immutable release alias conflict: $target" >&2; exit 1; }
+              echo "Verified existing $target@$existing" >>"$GITHUB_STEP_SUMMARY"
+              continue
+            else
+              status=$?
+              test "$status" = 1 || exit "$status"
+            fi
+            if [ "$DRY_RUN" = true ]; then
+              echo "Dry run: would create $target@$desired" >>"$GITHUB_STEP_SUMMARY"
+              continue
+            fi
+            docker buildx imagetools create --tag "$target" "$staging@$desired"
+            test "$(descriptor_or_absent "$target")" = "$desired"
+            echo "Created $target@$desired" >>"$GITHUB_STEP_SUMMARY"
+          done

--- a/tools/plugin-release/plugin_server_workflow_contract_test.go
+++ b/tools/plugin-release/plugin_server_workflow_contract_test.go
@@ -1475,3 +1475,97 @@ func TestGatewayStableAliasesAreStagedAndImmutable(t *testing.T) {
 		t.Fatal("every controller/pilot/gateway publisher must use its own fail-closed lookup and staging acceptance helper")
 	}
 }
+
+func TestGatewayReleaseAliasRecoveryPromotesOnlyVerifiedStaging(t *testing.T) {
+	data, err := os.ReadFile("../../.github/workflows/recover-gateway-release-images.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	workflow := string(data)
+	for _, required := range []string{
+		`workflow_dispatch:`,
+		`ref: refs/tags/v${{ inputs.gateway_version }}`,
+		`test "$resolved" = "$RELEASE_COMMIT"`,
+		`test "$(git rev-parse HEAD)" = "$RELEASE_COMMIT"`,
+		`test "$(sha256sum "$snapshot" | awk '{print $1}')" = "$SNAPSHOT_SHA256"`,
+		`staging="$repo:release-provenance-$RELEASE_COMMIT"`,
+		`docker buildx imagetools inspect "$staging" --raw`,
+		`(.manifests | length == 2)`,
+		`["linux/amd64","linux/arm64"]`,
+		`grep -Fqx "ERROR: $ref: not found" "$err"`,
+		`immutable release alias conflict`,
+		`docker buildx imagetools create --tag "$target" "$staging@$desired"`,
+		`test "$(descriptor_or_absent "$target")" = "$desired"`,
+	} {
+		if !strings.Contains(workflow, required) {
+			t.Fatalf("gateway image recovery lacks immutable staging contract %q", required)
+		}
+	}
+	for _, forbidden := range []string{"docker build ", "make docker", "make build-istio", "make build-gateway"} {
+		if strings.Contains(workflow, forbidden) {
+			t.Fatalf("gateway image recovery must never rebuild release images: found %q", forbidden)
+		}
+	}
+	if strings.Index(workflow, `docker buildx imagetools inspect "$staging" --raw`) > strings.Index(workflow, `docker buildx imagetools create --tag "$target"`) {
+		t.Fatal("gateway image recovery must validate staging before any alias mutation")
+	}
+}
+
+func runGatewayRecoveryDescriptorContract(t *testing.T, contract, mode, ref string) int {
+	t.Helper()
+	tmp := t.TempDir()
+	bin := filepath.Join(tmp, "bin")
+	if err := os.MkdirAll(bin, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeExecutableFixture(t, filepath.Join(bin, "docker"), `#!/usr/bin/env bash
+set -euo pipefail
+ref=$4
+case "$RECOVERY_MODE" in
+  absent-acr) echo "ERROR: $ref: not found" >&2; exit 1 ;;
+  absent-http-404) echo "response status code 404: Not Found" >&2; exit 1 ;;
+  transport-with-ref) echo "transport error while resolving $ref: dial tcp: i/o timeout" >&2; exit 1 ;;
+  auth-401-status) echo "response status code 401" >&2; exit 1 ;;
+  auth-403-http) echo "HTTP/1.1 403 Forbidden" >&2; exit 1 ;;
+  generic-not-found) echo "lookup failed: artifact not found" >&2; exit 1 ;;
+  *) echo "unsupported fixture mode" >&2; exit 3 ;;
+esac
+`)
+	script := "set -euo pipefail\n" + contract + fmt.Sprintf("\ndescriptor_or_absent %q\n", ref)
+	cmd := exec.Command("bash", "-c", script)
+	cmd.Env = append(os.Environ(), "PATH="+bin+":"+os.Getenv("PATH"), "RECOVERY_MODE="+mode)
+	output, err := cmd.CombinedOutput()
+	if err == nil {
+		return 0
+	}
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		t.Fatalf("gateway recovery descriptor fixture failed to execute: %v\n%s", err, output)
+	}
+	return exitErr.ExitCode()
+}
+
+func TestGatewayReleaseAliasRecoveryDescriptorClassifierFailsClosed(t *testing.T) {
+	contracts := workflowShellContracts(t, "recover-gateway-release-images.yaml", "gateway-recovery-descriptor-contract")
+	if len(contracts) != 1 {
+		t.Fatalf("gateway recovery workflow has %d descriptor contracts, want 1", len(contracts))
+	}
+	const ref = "registry.example.invalid/higress/gateway:sha-401403404"
+	for _, tc := range []struct {
+		mode string
+		want int
+	}{
+		{mode: "absent-acr", want: 1},
+		{mode: "absent-http-404", want: 1},
+		{mode: "transport-with-ref", want: 2},
+		{mode: "auth-401-status", want: 2},
+		{mode: "auth-403-http", want: 2},
+		{mode: "generic-not-found", want: 2},
+	} {
+		t.Run(tc.mode, func(t *testing.T) {
+			if status := runGatewayRecoveryDescriptorContract(t, contracts[0], tc.mode, ref); status != tc.want {
+				t.Fatalf("descriptor status for %s = %d, want %d", tc.mode, status, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## I. Summary

Add a fail-closed recovery workflow for gateway release image aliases when a tagged build already produced and verified immutable `release-provenance-<commit>` staging indexes but stopped before creating stable aliases.

The workflow never rebuilds. It resolves a published non-draft/non-prerelease annotated Higress release tag to the exact input commit, checks out that exact commit, hashes its committed plugin snapshot, and independently validates each controller/pilot/gateway staging index's digest, exact two platforms, and commit/snapshot/version annotations. It then either verifies an identical existing alias or creates a missing `version`, `vversion`, and commit-SHA alias from the digest-pinned staging index. Conflicts and unknown lookup errors fail closed. Dry run is the default.

## II. Related issue

Related to #4442. Runtime trigger: https://github.com/higress-group/higress/actions/runs/31755222277

## III. Change type

- [x] Bug fix
- [x] Feature or enhancement
- [ ] Documentation or configuration only
- [x] Refactoring, tests, or maintenance

## IV. Agent participation and issue-spec gate

- [ ] **No agent participation:** This PR is human-only.
- [ ] **Trivial agent-use exception:** Agent use was limited to spelling, punctuation, whitespace, or formatting with no substantive choice or behavioral effect; the explanation is below.
- [x] **Verified maintainer/administrator exception:** Material agent participation occurred, and authenticated `gh` verification confirmed a `role_name` of `maintain` or `admin` on `higress-group/higress`, and the verified login matches this PR's GitHub author; record the required evidence and rationale below.
- [ ] **Material agent participation:** An AI or coding agent materially participated in analysis, design, implementation, testing, or PR preparation.

- [ ] Complete: all three timed obligations above were satisfied.
- [ ] Noncompliant: one or more obligations were not satisfied; explain below.
- [x] Verified exception: material agent participation used the verified-maintainer/administrator exception; provide the required evidence and rationale below.
- [ ] N/A because the PR is human-only or qualifies for the trivial exception.

**Gate-status explanation (or N/A):** Verified maintainer/administrator exception for runtime recovery of already-built, already-verified 2.2.4 staging indexes.

**Trivial-exception explanation (or N/A):** N/A.

**Verified maintainer/administrator exception evidence (or N/A):**

- This PR's number or URL: https://github.com/higress-group/higress/pull/4500
- Authenticated `gh` login: `johnlanni`
- Canonical-repository `role_name`: `admin`
- Actual PR author from `gh pr view`: johnlanni
- Login/author match: yes
- Token override attestation (`GH_TOKEN` and `GITHUB_TOKEN` were unset for every verification command; required: `yes`): yes
- Bypass rationale: the immutable tag cannot consume workflow fixes merged after its exact release commit, while rebuilding is unnecessary and risks diverging artifacts; recovery promotes only independently reverified staging digests.
- Maintainer live validation (review URL or N/A until performed): https://github.com/higress-group/higress/pull/4500#issuecomment-5287991960

**Approved Proposal Issue URL (or N/A with explanation):** https://github.com/higress-group/higress/issues/4442

**Approved Design Issue URL (or N/A with explanation):** Release automation design tracked from #4442; verified exception used for this focused operational recovery.

**Maintainer approval link(s) (or N/A with explanation):** Maintainer authorization is recorded in the active release task; verified exception applies.

**Authorized implementation TASK link(s) (or N/A with explanation):** TASK-4442005.

**Verification Plan and verification TASK/evidence link(s) (or N/A with explanation):** TASK-4442005; dry-run and production runs will be linked after merge.

## V. Testing and verification

**Test and deterministic rerun commands (or N/A with explanation):**

```text
git diff --check
go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 .github/workflows/recover-gateway-release-images.yaml
(cd tools/plugin-release && go test ./... -count=1)
docker buildx imagetools inspect <each exact 2.2.4 staging ref> --raw
```

All passed at `a18a982c`.

**Environment and configuration (or N/A with explanation):** Linux amd64; actionlint v1.7.7; repository Go toolchain; anonymous ACR staging inspection, with protected production registry environments for mutations.

**Exact tested revision, version, image tag/digest, manifests, and values (or N/A with explanation):** Release commit `58666ac985cee19a0a9a353421c63cead6d0cb47`; version `2.2.4`; snapshot SHA-256 `09bc798df37e50dae2e684947885c31eb756636c76a98761a9a980fc031e3a1a`. Verified staging digests: controller `sha256:0a5b7809a107cbec150f41352a156e31160b8a92df787798e2a9a06cdd5587da`; pilot `sha256:f742ed20f938c5c1eaf6f8c36c6481a87052d06e903ab6cb0c079165ac0c8284`; gateway `sha256:3dbd609df5db3fca61653eafe0e2310705e485190c4f8cd02d9aab8f07dcf329`.

**Baseline reproduction evidence for bug fixes (or N/A with explanation):** Run 31755222277 built and verified all staging indexes, then each job failed while classifying ACR's exact missing stable-tag response.

**Fixed-version verification evidence for bug fixes (or N/A with explanation):** Static/contract and live staging validation passed. Dry-run and production recovery runs will provide the mutation evidence.

**Wasm source revision and SHA-256 (or N/A with explanation):** No WASM source changed; the recovery is bound to snapshot SHA-256 `09bc798df37e50dae2e684947885c31eb756636c76a98761a9a980fc031e3a1a`.

## VI. Special notes for reviewers

Review that the exact release tag/commit/snapshot and all staging provenance gates precede mutation, no build path exists, existing aliases are accepted only at identical digests, and all unknown/auth lookup errors fail closed.

## VII. AI coding disclosure

**Tool(s) used (or N/A):** OpenAI Codex.

### Prompts or instructions

Recover the failed 2.2.4 release images without changing the immutable tag or rebuilding divergent artifacts, preserving all artifact/source/provenance correctness gates.

### AI-assisted work summary

Codex inspected the failed jobs and live staging indexes, designed a generic verify-only/promote recovery path, implemented exact release and OCI provenance gates, and added regression contract coverage.