### PR TITLE
fix: distinguish plugin snapshot carrier commit

### DIFF
--- a/.github/workflows/dispatch-standalone-release.yaml
+++ b/.github/workflows/dispatch-standalone-release.yaml
@@ -88,9 +88,6 @@ jobs:
           SNAPSHOT_SOURCE_COMMIT=$(jq -er .sourceCommit "$snapshot")
           [[ "$SNAPSHOT_SOURCE_COMMIT" =~ ^[0-9a-f]{40}$ ]]
           git merge-base --is-ancestor "$SNAPSHOT_SOURCE_COMMIT" "$COMMIT"
-          git show "$SNAPSHOT_SOURCE_COMMIT:$snapshot" > /tmp/plugin-server-source-snapshot.json
-          test "$(sha256sum /tmp/plugin-server-source-snapshot.json | awk '{print $1}')" = "$sha"
-          cmp /tmp/plugin-server-source-snapshot.json "$snapshot"
           plugin_server_ref="$PLUGIN_SERVER_REGISTRY/higress/plugin-server:${TAG#v}"
           plugin_server=$(oras manifest fetch "$plugin_server_ref" --descriptor | jq -r .digest)
           [[ "$plugin_server" =~ ^sha256:[0-9a-f]{64}$ ]]
@@ -127,13 +124,22 @@ jobs:
             verify_plugin_server_index /tmp/index.json
             platforms=$(jq -c '[.manifests[] | select(.platform.os == "linux" and (.platform.architecture == "amd64" or .platform.architecture == "arm64")) | .platform.os + "/" + .platform.architecture] | sort' /tmp/index.json)
             labels='{}'
+            PLUGIN_SERVER_HIGRESS_COMMIT=""
             while IFS=$'\t' read -r platform child; do
               manifest=$(oras manifest fetch "$repo@$child")
               config=$(jq -er .config.digest <<<"$manifest")
               label=$(oras blob fetch "$repo@$config" -o - | jq -c '.config.Labels // {}')
-              jq -e --arg plugin "$PLUGIN_SERVER_COMMIT" --arg source "$SNAPSHOT_SOURCE_COMMIT" --arg snapshot "$sha" --arg version "${TAG#v}" '."org.opencontainers.image.revision" == $plugin and ."io.higress.higress-source-commit" == $source and ."io.higress.plugin-snapshot-sha256" == $snapshot and ."io.higress.gateway-version" == $version' <<<"$label" >/dev/null
+              child_higress_commit=$(jq -er '."io.higress.higress-source-commit"' <<<"$label")
+              [[ "$child_higress_commit" =~ ^[0-9a-f]{40}$ ]]
+              if [ -z "$PLUGIN_SERVER_HIGRESS_COMMIT" ]; then PLUGIN_SERVER_HIGRESS_COMMIT=$child_higress_commit; else test "$child_higress_commit" = "$PLUGIN_SERVER_HIGRESS_COMMIT"; fi
+              jq -e --arg plugin "$PLUGIN_SERVER_COMMIT" --arg snapshot "$sha" --arg version "${TAG#v}" '."org.opencontainers.image.revision" == $plugin and ."io.higress.plugin-snapshot-sha256" == $snapshot and ."io.higress.gateway-version" == $version' <<<"$label" >/dev/null
               labels=$(jq --arg platform "$platform" --argjson label "$label" '.[$platform]=$label' <<<"$labels")
             done < <(jq -r '.manifests[] | select(.platform.os == "linux" and (.platform.architecture == "amd64" or .platform.architecture == "arm64")) | [(.platform.os + "/" + .platform.architecture), .digest] | @tsv' /tmp/index.json)
+            [[ "$PLUGIN_SERVER_HIGRESS_COMMIT" =~ ^[0-9a-f]{40}$ ]]
+            git merge-base --is-ancestor "$PLUGIN_SERVER_HIGRESS_COMMIT" "$COMMIT"
+            git show "$PLUGIN_SERVER_HIGRESS_COMMIT:$snapshot" > /tmp/plugin-server-carrier-snapshot.json
+            test "$(sha256sum /tmp/plugin-server-carrier-snapshot.json | awk '{print $1}')" = "$sha"
+            cmp /tmp/plugin-server-carrier-snapshot.json "$snapshot"
             jq -cn --arg ref "$ref" --arg digest "$digest" --argjson platforms "$platforms" --argjson labels "$labels" '{ref:$ref,digest:$digest,platforms:$platforms,labelsByPlatform:$labels}'
           }
           plugin_json=$(inspect_plugin_server "$plugin_server_ref")

--- a/tools/plugin-release/plugin_server_workflow_contract_test.go
+++ b/tools/plugin-release/plugin_server_workflow_contract_test.go
@@ -1305,13 +1305,17 @@ func TestStandaloneDispatchBindsUniqueConsoleEvidenceToPluginServer(t *testing.T
 		`test "$(jq -er .gatewayVersion "$snapshot")" = "${TAG#v}"`,
 		`SNAPSHOT_SOURCE_COMMIT=$(jq -er .sourceCommit "$snapshot")`,
 		`git merge-base --is-ancestor "$SNAPSHOT_SOURCE_COMMIT" "$COMMIT"`,
-		`git show "$SNAPSHOT_SOURCE_COMMIT:$snapshot"`,
-		`cmp /tmp/plugin-server-source-snapshot.json "$snapshot"`,
 		`plugin_server_image="$plugin_server_ref@$plugin_server"`,
 		`PLUGIN_SERVER_COMMIT=$(jq -er .pluginLock.pluginServerCommit /tmp/console-provenance.json)`,
 		`.pluginLock.sourceCommit == $sourceCommit and .pluginLock.snapshotSha256 == $snapshot`,
 		`.pluginLock.pluginServerCommit == $pluginCommit and .pluginLock.pluginServerImage == $pluginImage`,
 		`test "$digest" = "$plugin_server"`,
+		`PLUGIN_SERVER_HIGRESS_COMMIT=""`,
+		`child_higress_commit=$(jq -er '."io.higress.higress-source-commit"' <<<"$label")`,
+		`test "$child_higress_commit" = "$PLUGIN_SERVER_HIGRESS_COMMIT"`,
+		`git merge-base --is-ancestor "$PLUGIN_SERVER_HIGRESS_COMMIT" "$COMMIT"`,
+		`git show "$PLUGIN_SERVER_HIGRESS_COMMIT:$snapshot"`,
+		`cmp /tmp/plugin-server-carrier-snapshot.json "$snapshot"`,
 		`jq -cn --arg ref "$ref" --arg digest "$digest"`,
 		`plugin_json=$(inspect_plugin_server "$plugin_server_ref")`,
 		`io.higress.higress-source-commit`,
@@ -1332,8 +1336,8 @@ func TestStandaloneDispatchBindsUniqueConsoleEvidenceToPluginServer(t *testing.T
 	if strings.Contains(workflow, `jq -cn --arg ref "$plugin_server_image"`) {
 		t.Fatal("standalone evidence must keep pluginServer.ref as the gateway-version tag and carry its digest separately")
 	}
-	if strings.Contains(workflow, `--arg sourceCommit "$COMMIT"`) || strings.Contains(workflow, `--arg source "$COMMIT" --arg snapshot`) {
-		t.Fatal("standalone dispatch must bind plugin-server provenance to the snapshot source ancestor, not the later release commit")
+	if strings.Contains(workflow, `git show "$SNAPSHOT_SOURCE_COMMIT:$snapshot"`) || strings.Contains(workflow, `--arg source "$SNAPSHOT_SOURCE_COMMIT" --arg snapshot`) {
+		t.Fatal("standalone dispatch must not confuse the plugin source baseline with the later snapshot carrier commit proven by plugin-server labels")
 	}
 }
 


### PR DESCRIPTION
## I. Summary

Fix standalone release evidence dispatch to distinguish the plugin source baseline recorded inside a snapshot from the later Higress carrier commit that first contains that immutable snapshot.

The failed v2.2.4 recovery proved the old dispatcher tried to read `plugins/release/snapshots/2.2.4.json` from the baseline source commit, where the generated snapshot cannot yet exist. The corrected path follows the pre-tag authorizer: it keeps Console provenance bound to `snapshot.sourceCommit`, independently reads `io.higress.higress-source-commit` from both runnable plugin-server platform configs, requires both platforms to agree, proves that carrier is an ancestor of the release, and hashes/compares the snapshot from that carrier before dispatching.

## II. Related issue

Related to #4442. Runtime reproduction: https://github.com/higress-group/higress/actions/runs/31758210726

## III. Change type

- [x] Bug fix
- [ ] Feature or enhancement
- [ ] Documentation or configuration only
- [x] Refactoring, tests, or maintenance

## IV. Agent participation and issue-spec gate

- [ ] **No agent participation:** This PR is human-only.
- [ ] **Trivial agent-use exception:** Agent use was limited to spelling, punctuation, whitespace, or formatting with no substantive choice or behavioral effect; the explanation is below.
- [x] **Verified maintainer/administrator exception:** Material agent participation occurred, and authenticated `gh` verification confirmed a `role_name` of `maintain` or `admin` on `higress-group/higress`, and the verified login matches this PR's GitHub author; record the required evidence and rationale below.
- [ ] **Material agent participation:** An AI or coding agent materially participated in analysis, design, implementation, testing, or PR preparation.

- [ ] Complete: all three timed obligations above were satisfied.
- [ ] Noncompliant: one or more obligations were not satisfied; explain below.
- [x] Verified exception: material agent participation used the verified-maintainer/administrator exception; provide the required evidence and rationale below.
- [ ] N/A because the PR is human-only or qualifies for the trivial exception.

**Gate-status explanation (or N/A):** Verified maintainer/administrator exception for a runtime-verified release dispatcher bug in the active v2.2.4 chain.

**Trivial-exception explanation (or N/A):** N/A.

**Verified maintainer/administrator exception evidence (or N/A):**

- This PR’s number or URL: https://github.com/higress-group/higress/pull/4502
- Authenticated `gh` login: `johnlanni`
- Canonical-repository `role_name`: `admin`
- Actual PR author from `gh pr view`: `johnlanni`
- Login/author match: yes
- Token override attestation (`GH_TOKEN` and `GITHUB_TOKEN` were unset for every verification command; required: `yes`): yes
- Bypass rationale: the exact v2.2.4 runtime failed because the dispatcher conflated two separately proven commits; this focused fix restores the same provenance boundary already enforced by the pre-tag authorizer.
- Maintainer live validation (review URL or N/A until performed): https://github.com/higress-group/higress/pull/4502#issuecomment-5288095204

**Approved Proposal Issue URL (or N/A with explanation):** https://github.com/higress-group/higress/issues/4442

**Approved Design Issue URL (or N/A with explanation):** Release automation design tracked from #4442; verified exception used for this focused runtime correction.

**Maintainer approval link(s) (or N/A with explanation):** Maintainer authorization is recorded in the active release task; verified exception applies.

**Authorized implementation TASK link(s) (or N/A with explanation):** TASK-4442005.

**Verification Plan and verification TASK/evidence link(s) (or N/A with explanation):** TASK-4442005 and linked runtime reproduction; replay will be linked after merge.

## V. Testing and verification

**Test and deterministic rerun commands (or N/A with explanation):**

```text
git diff --check
/tmp/actionlint .github/workflows/dispatch-standalone-release.yaml
(cd tools/plugin-release && go test ./... -count=1)
oras manifest/blob inspection of both v2.2.4 plugin-server runnable platforms
```

All passed at `5949f279`.

**Environment and configuration (or N/A with explanation):** Linux amd64; actionlint v1.7.7; repository Go toolchain; public ACR verification.

**Exact tested revision, version, image tag/digest, manifests, and values (or N/A with explanation):** Head `5949f279`; v2.2.4 plugin-server digest `sha256:05a3e3615434befdb89928e491a8833255733c099dd24faefe82fea4d63165bb`. Both linux/amd64 and linux/arm64 labels resolve carrier `27debc8b2e065dace2ee9edd280963a560c7fee5`; its committed snapshot hashes to `09bc798df37e50dae2e684947885c31eb756636c76a98761a9a980fc031e3a1a`. Snapshot source baseline remains `7774663e4353652f5c3cecd7e98a1a43b05ee15c`.

**Baseline reproduction evidence for bug fixes (or N/A with explanation):** Run 31758210726 fails with `fatal: path 'plugins/release/snapshots/2.2.4.json' exists on disk, but not in '7774663...'`.

**Fixed-version verification evidence for bug fixes (or N/A with explanation):** Static/contract tests and live two-platform carrier/snapshot checks pass. Runtime replay will be linked after merge.

**Wasm source revision and SHA-256 (or N/A with explanation):** No WASM source changed; snapshot SHA-256 is `09bc798df37e50dae2e684947885c31eb756636c76a98761a9a980fc031e3a1a`.

## VI. Special notes for reviewers

Review that the source baseline remains the value compared with Console provenance, while only the cross-platform plugin-server label is trusted as the snapshot carrier and is ancestor/hash/byte checked before dispatch.

## VII. AI coding disclosure

**Tool(s) used (or N/A):** OpenAI Codex.

### Prompts or instructions

Continue the approved v2.2.4 release automatically, diagnose failures, and merge focused fixes after independent exact-head review.

### AI-assisted work summary

Codex diagnosed the exact runtime failure, compared it with the established pre-tag authorizer contract, separated baseline and carrier provenance, and added regression checks.
