### PR TITLE
fix: verify standalone OSS event hash bytes

### DIFF
--- a/.github/workflows/deploy-standalone-to-oss.yaml
+++ b/.github/workflows/deploy-standalone-to-oss.yaml
@@ -60,7 +60,13 @@ jobs:
             if [ "$tag_type" = tag ]; then resolved=$(gh api "repos/higress-group/higress-standalone/git/tags/$tag_object" --jq .object.sha); else test "$tag_type" = commit; resolved=$tag_object; fi
             test "$resolved" = "$COMMIT"
             payload=$(jq -cn --argjson releaseId "$RELEASE_ID" --arg tag "$TAG" --arg commit "$COMMIT" --arg archive "$ARCHIVE_SHA256" --arg installer "$INSTALLER_SHA256" '{releaseId:$releaseId,tag:$tag,commit:$commit,archiveSha256:$archive,installerSha256:$installer,dryRun:false}')
-            test "$(printf '%s' "$payload" | jq -cS . | sha256sum | awk '{print $1}')" = "$EVENT_KEY"
+            # BEGIN standalone-oss-idempotency-canonical-contract
+            canonical_standalone_oss_payload() {
+              jq -cS .
+            }
+            # END standalone-oss-idempotency-canonical-contract
+            canonical=$(printf '%s' "$payload" | canonical_standalone_oss_payload)
+            test "$(printf '%s' "$canonical" | sha256sum | awk '{print $1}')" = "$EVENT_KEY"
           fi
       - id: package
         name: Download one exact Standalone tag

--- a/tools/plugin-release/plugin_server_workflow_contract_test.go
+++ b/tools/plugin-release/plugin_server_workflow_contract_test.go
@@ -1401,6 +1401,48 @@ func TestStandaloneDispatchCanonicalEvidenceMatchesPythonReceiverBytes(t *testin
 	}
 }
 
+func TestStandaloneOSSReceiverHashesTheExactNoNewlineSenderPayload(t *testing.T) {
+	data, err := os.ReadFile("../../.github/workflows/deploy-standalone-to-oss.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	workflow := string(data)
+	for _, required := range []string{
+		`canonical=$(printf '%s' "$payload" | canonical_standalone_oss_payload)`,
+		`test "$(printf '%s' "$canonical" | sha256sum`,
+	} {
+		if !strings.Contains(workflow, required) {
+			t.Fatalf("standalone OSS receiver lacks exact canonical-byte contract %q", required)
+		}
+	}
+	if strings.Contains(workflow, `printf '%s' "$payload" | jq -cS . | sha256sum`) {
+		t.Fatal("standalone OSS receiver must not hash jq's terminal newline")
+	}
+
+	contract := workflowShellContract(t, "deploy-standalone-to-oss.yaml", "standalone-oss-idempotency-canonical-contract")
+	script := "set -euo pipefail\n" + contract + `
+payload=$(jq -cn --argjson releaseId 370295985 --arg tag v2.2.4 --arg commit 9b83988013d80aa82527600841b1ce7c8fdb67b9 --arg archive 92e30705b8479a829b9b82ca95b90e0115b01e00f0ffcc5af30e0623b728d17c --arg installer e648f63ec13f0cbe54eb50e2aadb518df69f5df77e6926e31418d020fa3231fb '{releaseId:$releaseId,tag:$tag,commit:$commit,archiveSha256:$archive,installerSha256:$installer,dryRun:false}')
+canonical=$(printf '%s' "$payload" | canonical_standalone_oss_payload)
+printf '%s\n' "$(printf '%s' "$canonical" | sha256sum | awk '{print $1}')"
+printf '%s\n' "$(printf '%s\n' "$canonical" | sha256sum | awk '{print $1}')"
+`
+	output, err := exec.Command("bash", "-c", script).CombinedOutput()
+	if err != nil {
+		t.Fatalf("standalone OSS canonical hash fixture failed: %v\n%s", err, output)
+	}
+	lines := strings.Fields(string(output))
+	if len(lines) != 2 {
+		t.Fatalf("standalone OSS canonical hash fixture returned %q", output)
+	}
+	const eventKey = "90427933289ee0646f707db301328db9d917b1fcb9bc5c293f8d6b718881f755"
+	if lines[0] != eventKey {
+		t.Fatalf("no-newline canonical hash = %s, want dispatched event key %s", lines[0], eventKey)
+	}
+	if lines[1] == eventKey {
+		t.Fatal("newline-terminated jq bytes must not match the dispatched event key")
+	}
+}
+
 func TestPreparationBootstrapReusesProtectedCandidateRegistryCredential(t *testing.T) {
 	data, err := os.ReadFile("../../.github/workflows/prepare-plugin-release.yaml")
 	if err != nil {


### PR DESCRIPTION
## I. Summary

Hash the standalone OSS repository-dispatch payload after command substitution has removed jq's terminal newline. The standalone sender already hashes and dispatches that exact no-newline canonical string, while the Higress receiver previously piped jq's newline-terminated output directly into `sha256sum`. Every otherwise-valid release event therefore failed before artifact download.

## II. Related issue

Related to #4442. Runtime reproduction: https://github.com/higress-group/higress/actions/runs/31760558276

## III. Change type

- [x] Bug fix
- [ ] Feature or enhancement
- [ ] Documentation or configuration only
- [x] Refactoring, tests, or maintenance

## IV. Agent participation and issue-spec gate

- [ ] **No agent participation:** This PR is human-only.
- [ ] **Trivial agent-use exception:** Agent use was limited to spelling, punctuation, whitespace, or formatting with no substantive choice or behavioral effect; the explanation is below.
- [x] **Verified maintainer/administrator exception:** Material agent participation occurred, and authenticated `gh` verification confirmed a `role_name` of `maintain` or `admin` on `higress-group/higress`, and the verified login matches this PR's GitHub author; record the required evidence and rationale below.
- [ ] **Material agent participation:** An AI or coding agent materially participated in analysis, design, implementation, testing, or PR preparation.

- [ ] Complete: all three timed obligations above were satisfied.
- [ ] Noncompliant: one or more obligations were not satisfied; explain below.
- [x] Verified exception: material agent participation used the verified-maintainer/administrator exception; provide the required evidence and rationale below.
- [ ] N/A because the PR is human-only or qualifies for the trivial exception.

**Gate-status explanation (or N/A):** Verified maintainer/administrator exception for an exact runtime bug in the active v2.2.4 release chain.

**Trivial-exception explanation (or N/A):** N/A.

**Verified maintainer/administrator exception evidence (or N/A):**

- This PR's number or URL: https://github.com/higress-group/higress/pull/4504
- Authenticated `gh` login: `johnlanni`
- Canonical-repository `role_name`: `admin`
- Actual PR author from `gh pr view`: `johnlanni`
- Login/author match: yes
- Token override attestation (`GH_TOKEN` and `GITHUB_TOKEN` were unset for every verification command; required: `yes`): yes
- Bypass rationale: sender and receiver hashed different byte sequences for the same validated standalone OSS event, blocking the protected v2.2.4 chain after Release, tag, archive, and installer checks passed.
- Maintainer live validation (review URL or N/A until performed): https://github.com/higress-group/higress/pull/4504#issuecomment-5288374348

**Approved Proposal Issue URL (or N/A with explanation):** https://github.com/higress-group/higress/issues/4022

**Approved Design Issue URL (or N/A with explanation):** https://github.com/higress-group/higress/issues/4442

**Maintainer approval link(s) (or N/A with explanation):** https://github.com/higress-group/higress/issues/4442#issuecomment-5260786221

**Authorized implementation TASK link(s) (or N/A with explanation):** TASK-4442005: https://github.com/higress-group/higress/issues/4442#issuecomment-5255965383

**Verification Plan and verification TASK/evidence link(s) (or N/A with explanation):** TASK-4442005 and runtime failure linked above; protected replay will be linked after merge.

## V. Testing and verification

**Test and deterministic rerun commands (or N/A with explanation):**

```text
git diff --check
/tmp/actionlint .github/workflows/deploy-standalone-to-oss.yaml
(cd tools/plugin-release && go test ./... -count=1)
```

All passed at `8b164d30bf8c5f692005f1239c30c5854d3c1217`.

**Environment and configuration (or N/A with explanation):** Linux amd64; actionlint v1.7.7; repository Go toolchain; jq from the GitHub-hosted runner contract.

**Exact tested revision, version, image tag/digest, manifests, and values (or N/A with explanation):** Base `03f4b9629a11d1ab1166df00c5cd2bb1fcdc0fd9`; head `8b164d30bf8c5f692005f1239c30c5854d3c1217`; Standalone tag/commit `v2.2.4` / `9b83988013d80aa82527600841b1ce7c8fdb67b9`; dispatched event key `90427933289ee0646f707db301328db9d917b1fcb9bc5c293f8d6b718881f755`.

**Baseline reproduction evidence for bug fixes (or N/A with explanation):** Run 31760558276 validated tag, Release ID 370295985, commit, archive SHA `92e30705b8479a829b9b82ca95b90e0115b01e00f0ffcc5af30e0623b728d17c`, and installer SHA `e648f63ec13f0cbe54eb50e2aadb518df69f5df77e6926e31418d020fa3231fb`, then rejected the correct no-newline event key because the receiver hashed jq's terminal newline.

**Fixed-version verification evidence for bug fixes (or N/A with explanation):** The regression test extracts and executes the production shell marker with the exact failed event. It reproduces the dispatched event key only from no-newline canonical bytes and proves the newline-terminated hash differs. Protected replay follows merge.

**Wasm source revision and SHA-256 (or N/A with explanation):** No Wasm source or artifact changed; v2.2.4 snapshot SHA remains `09bc798df37e50dae2e684947885c31eb756636c76a98761a9a980fc031e3a1a`.

## VI. Special notes for reviewers

Review only the byte boundary around the standalone OSS event idempotency key. Release/tag, archive, installer, dry-run, and upload gates are unchanged.

## VII. AI coding disclosure

**Tool(s) used (or N/A):** OpenAI Codex.

### Prompts or instructions

Continue the approved v2.2.4 release, diagnose protected runtime failures, and merge focused fixes only after exact-head review.

### AI-assisted work summary

Codex traced the OSS receiver failure to jq's terminal newline, aligned it with the sender's exact no-newline byte definition, and added an executable regression fixture using the failed production event.