### PR TITLE
fix(release): preserve proxyv2 gateway aliases

### DIFF
--- a/.github/workflows/build-image-and-push.yaml
+++ b/.github/workflows/build-image-and-push.yaml
@@ -324,3 +324,24 @@ jobs:
             fi
             publish_with_provenance "$BUILT_IMAGE" "$image"
           done
+
+          # Keep the historical numeric proxyv2 tag as a compatibility alias.
+          # The alias is copied from the verified gateway stable index, never
+          # from the unverified build intermediary, and immutable conflicts
+          # fail closed.
+          # BEGIN gateway-proxyv2-compatibility-contract
+          if [ "$release_provenance" = true ]; then
+            gateway_stable="${IMAGES[0]%:*}:$version"
+            proxyv2_stable="${BUILT_IMAGE%:*}:$version"
+            desired=$(descriptor_or_absent "$gateway_stable")
+            [[ "$desired" =~ ^sha256:[0-9a-f]{64}$ ]]
+            if existing=$(descriptor_or_absent "$proxyv2_stable"); then
+              test "$existing" = "$desired" || { echo "immutable proxyv2 compatibility tag conflict: $proxyv2_stable" >&2; exit 1; }
+            else
+              status=$?
+              test "$status" = 1 || exit "$status"
+              docker buildx imagetools create --tag "$proxyv2_stable" "$gateway_stable@$desired"
+              test "$(descriptor_or_absent "$proxyv2_stable")" = "$desired"
+            fi
+          fi
+          # END gateway-proxyv2-compatibility-contract

--- a/.github/workflows/recover-gateway-release-images.yaml
+++ b/.github/workflows/recover-gateway-release-images.yaml
@@ -82,12 +82,15 @@ jobs:
           - component: controller
             environment: image-registry-controller
             image_name: higress/higress
+            compat_image_name: ""
           - component: pilot
             environment: image-registry-pilot
             image_name: higress/pilot
+            compat_image_name: ""
           - component: gateway
             environment: image-registry-gateway
             image_name: higress/gateway
+            compat_image_name: higress/proxyv2
     runs-on: ubuntu-latest
     environment:
       name: ${{ matrix.environment }}
@@ -103,6 +106,7 @@ jobs:
         env:
           IMAGE_REGISTRY: ${{ vars.IMAGE_REGISTRY || 'higress-registry.cn-hangzhou.cr.aliyuncs.com' }}
           IMAGE_NAME: ${{ matrix.image_name }}
+          COMPAT_IMAGE_NAME: ${{ matrix.compat_image_name }}
           GATEWAY_VERSION: ${{ inputs.gateway_version }}
           RELEASE_COMMIT: ${{ inputs.release_commit }}
           SNAPSHOT_SHA256: ${{ inputs.snapshot_sha256 }}
@@ -166,3 +170,23 @@ jobs:
             test "$(descriptor_or_absent "$target")" = "$desired"
             echo "Created $target@$desired" >>"$GITHUB_STEP_SUMMARY"
           done
+
+          # BEGIN gateway-proxyv2-recovery-contract
+          if [ -n "$COMPAT_IMAGE_NAME" ]; then
+            compat_target="$IMAGE_REGISTRY/$COMPAT_IMAGE_NAME:$GATEWAY_VERSION"
+            if existing=$(descriptor_or_absent "$compat_target"); then
+              test "$existing" = "$desired" || { echo "immutable proxyv2 compatibility tag conflict: $compat_target" >&2; exit 1; }
+              echo "Verified existing $compat_target@$existing" >>"$GITHUB_STEP_SUMMARY"
+            else
+              status=$?
+              test "$status" = 1 || exit "$status"
+              if [ "$DRY_RUN" = true ]; then
+                echo "Dry run: would create $compat_target@$desired" >>"$GITHUB_STEP_SUMMARY"
+              else
+                docker buildx imagetools create --tag "$compat_target" "$staging@$desired"
+                test "$(descriptor_or_absent "$compat_target")" = "$desired"
+                echo "Created $compat_target@$desired" >>"$GITHUB_STEP_SUMMARY"
+              fi
+            fi
+          fi
+          # END gateway-proxyv2-recovery-contract

--- a/helm/core/values.yaml
+++ b/helm/core/values.yaml
@@ -149,7 +149,7 @@ global:
   priorityClassName: ""
 
   proxy:
-    image: proxyv2
+    image: gateway
 
     # -- This controls the 'policy' in the sidecar injector.
     autoInject: enabled
@@ -229,7 +229,7 @@ global:
 
   proxy_init:
     # -- Base name for the proxy_init container, used to configure iptables.
-    image: proxyv2
+    image: gateway
     resources:
       limits:
         cpu: 2000m

--- a/helm/higress/README.md
+++ b/helm/higress/README.md
@@ -219,7 +219,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | global.proxy.excludeInboundPorts | string | `""` |  |
 | global.proxy.excludeOutboundPorts | string | `""` |  |
 | global.proxy.holdApplicationUntilProxyStarts | bool | `false` | Controls if sidecar is injected at the front of the container list and blocks the start of the other containers until the proxy is ready |
-| global.proxy.image | string | `"proxyv2"` |  |
+| global.proxy.image | string | `"gateway"` |  |
 | global.proxy.includeIPRanges | string | `"*"` | istio egress capture allowlist https://istio.io/docs/tasks/traffic-management/egress.html#calling-external-services-directly example: includeIPRanges: "172.30.0.0/16,172.20.0.0/16" would only capture egress traffic on those two IP Ranges, all other outbound traffic would be allowed by the sidecar |
 | global.proxy.includeInboundPorts | string | `"*"` |  |
 | global.proxy.includeOutboundPorts | string | `""` |  |
@@ -234,7 +234,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | global.proxy.resources | object | `{"limits":{"cpu":"2000m","memory":"1024Mi"},"requests":{"cpu":"100m","memory":"128Mi"}}` | Resources for the sidecar. |
 | global.proxy.statusPort | int | `15020` | Default port for Pilot agent health checks. A value of 0 will disable health checking. |
 | global.proxy.tracer | string | `""` | Specify which tracer to use. One of: lightstep, datadog, stackdriver. If using stackdriver tracer outside GCP, set env GOOGLE_APPLICATION_CREDENTIALS to the GCP credential file. |
-| global.proxy_init.image | string | `"proxyv2"` | Base name for the proxy_init container, used to configure iptables. |
+| global.proxy_init.image | string | `"gateway"` | Base name for the proxy_init container, used to configure iptables. |
 | global.proxy_init.resources.limits.cpu | string | `"2000m"` |  |
 | global.proxy_init.resources.limits.memory | string | `"1024Mi"` |  |
 | global.proxy_init.resources.requests.cpu | string | `"10m"` |  |

--- a/tools/plugin-release/plugin_server_workflow_contract_test.go
+++ b/tools/plugin-release/plugin_server_workflow_contract_test.go
@@ -1557,6 +1557,145 @@ func TestGatewayStableAliasesAreStagedAndImmutable(t *testing.T) {
 	}
 }
 
+func TestGatewayReleasePublishesProxyV2CompatibilityAlias(t *testing.T) {
+	data, err := os.ReadFile("../../.github/workflows/build-image-and-push.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	workflow := string(data)
+	for _, required := range []string{
+		`gateway_stable="${IMAGES[0]%:*}:$version"`,
+		`proxyv2_stable="${BUILT_IMAGE%:*}:$version"`,
+		`immutable proxyv2 compatibility tag conflict`,
+		`docker buildx imagetools create --tag "$proxyv2_stable" "$gateway_stable@$desired"`,
+		`test "$(descriptor_or_absent "$proxyv2_stable")" = "$desired"`,
+	} {
+		if !strings.Contains(workflow, required) {
+			t.Fatalf("gateway release publication lacks proxyv2 compatibility contract %q", required)
+		}
+	}
+	if strings.Count(workflow, "# BEGIN gateway-proxyv2-compatibility-contract") != 1 {
+		t.Fatal("gateway release publication must contain exactly one proxyv2 compatibility contract")
+	}
+	buildGateway := strings.Index(workflow, "make build-gateway")
+	compatibility := strings.Index(workflow, "# BEGIN gateway-proxyv2-compatibility-contract")
+	if buildGateway < 0 || compatibility < buildGateway {
+		t.Fatal("proxyv2 compatibility alias must be derived after the gateway image publication")
+	}
+}
+
+func runGatewayProxyV2PublicationContract(t *testing.T, contract, mode string, release bool) (int, string) {
+	t.Helper()
+	tmp := t.TempDir()
+	state := filepath.Join(tmp, "created")
+	log := filepath.Join(tmp, "docker.log")
+	desired := "sha256:" + strings.Repeat("a", 64)
+	conflict := "sha256:" + strings.Repeat("b", 64)
+	script := `set -euo pipefail
+descriptor_or_absent() {
+  local ref=$1
+  if [ "$ref" = "registry.example.invalid/higress/gateway:2.2.4" ]; then
+    printf '%s' "$PUBLICATION_DESIRED"
+    return 0
+  fi
+  case "$PUBLICATION_MODE" in
+    absent)
+      if [ -f "$PUBLICATION_STATE" ]; then printf '%s' "$PUBLICATION_DESIRED"; else return 1; fi
+      ;;
+    identical) printf '%s' "$PUBLICATION_DESIRED" ;;
+    conflict) printf '%s' "$PUBLICATION_CONFLICT" ;;
+    lookup-error) return 2 ;;
+    *) return 3 ;;
+  esac
+}
+docker() {
+  printf '%s\n' "$*" >>"$PUBLICATION_LOG"
+  touch "$PUBLICATION_STATE"
+}
+IMAGES=(registry.example.invalid/higress/gateway:sha-deadbeef)
+BUILT_IMAGE=registry.example.invalid/higress/proxyv2:release-build-deadbeef
+version=2.2.4
+` + fmt.Sprintf("release_provenance=%t\n", release) + contract
+	cmd := exec.Command("bash", "-c", script)
+	cmd.Env = append(os.Environ(),
+		"PUBLICATION_MODE="+mode,
+		"PUBLICATION_STATE="+state,
+		"PUBLICATION_LOG="+log,
+		"PUBLICATION_DESIRED="+desired,
+		"PUBLICATION_CONFLICT="+conflict,
+	)
+	output, err := cmd.CombinedOutput()
+	status := 0
+	if err != nil {
+		var exitErr *exec.ExitError
+		if !errors.As(err, &exitErr) {
+			t.Fatalf("gateway proxyv2 publication fixture failed to execute: %v\n%s", err, output)
+		}
+		status = exitErr.ExitCode()
+	}
+	logData, readErr := os.ReadFile(log)
+	if readErr != nil && !os.IsNotExist(readErr) {
+		t.Fatal(readErr)
+	}
+	return status, string(logData)
+}
+
+func TestGatewayProxyV2PublicationContractIsIdempotentAndFailsClosed(t *testing.T) {
+	contract := workflowShellContract(t, "build-image-and-push.yaml", "gateway-proxyv2-compatibility-contract")
+	wantCreate := "buildx imagetools create --tag registry.example.invalid/higress/proxyv2:2.2.4 registry.example.invalid/higress/gateway:2.2.4@sha256:" + strings.Repeat("a", 64)
+	for _, tc := range []struct {
+		name       string
+		mode       string
+		release    bool
+		wantStatus int
+		wantLog    string
+	}{
+		{name: "missing creates from gateway stable digest", mode: "absent", release: true, wantLog: wantCreate + "\n"},
+		{name: "existing identical alias is idempotent", mode: "identical", release: true},
+		{name: "existing conflicting alias fails closed", mode: "conflict", release: true, wantStatus: 1},
+		{name: "lookup errors fail closed", mode: "lookup-error", release: true, wantStatus: 2},
+		{name: "non-release build does not create compatibility alias", mode: "absent"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			status, log := runGatewayProxyV2PublicationContract(t, contract, tc.mode, tc.release)
+			if status != tc.wantStatus || log != tc.wantLog {
+				t.Fatalf("status/log = %d/%q, want %d/%q", status, log, tc.wantStatus, tc.wantLog)
+			}
+		})
+	}
+}
+
+func TestGatewayHelmDefaultsUsePublishedGatewayImage(t *testing.T) {
+	values, err := os.ReadFile("../../helm/core/values.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(values), "image: proxyv2") {
+		t.Fatal("Helm values must not advertise the legacy proxyv2 repository as a runtime default")
+	}
+	for _, required := range []string{
+		"  proxy:\n    image: gateway\n",
+		"  proxy_init:\n    # -- Base name for the proxy_init container, used to configure iptables.\n    image: gateway\n",
+	} {
+		if !strings.Contains(string(values), required) {
+			t.Fatalf("Helm values lack gateway proxy default %q", required)
+		}
+	}
+
+	readme, err := os.ReadFile("../../helm/higress/README.md")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, required := range []string{
+		`| global.proxy.image | string | ` + "`\"gateway\"`" + ` |`,
+		`| global.proxy_init.image | string | ` + "`\"gateway\"`" + ` |`,
+	} {
+		if !strings.Contains(string(readme), required) {
+			t.Fatalf("generated Helm documentation lacks gateway default %q", required)
+		}
+	}
+}
+
 func TestGatewayReleaseAliasRecoveryPromotesOnlyVerifiedStaging(t *testing.T) {
 	data, err := os.ReadFile("../../.github/workflows/recover-gateway-release-images.yaml")
 	if err != nil {
@@ -1577,6 +1716,12 @@ func TestGatewayReleaseAliasRecoveryPromotesOnlyVerifiedStaging(t *testing.T) {
 		`immutable release alias conflict`,
 		`docker buildx imagetools create --tag "$target" "$staging@$desired"`,
 		`test "$(descriptor_or_absent "$target")" = "$desired"`,
+		`compat_image_name: higress/proxyv2`,
+		`COMPAT_IMAGE_NAME: ${{ matrix.compat_image_name }}`,
+		`compat_target="$IMAGE_REGISTRY/$COMPAT_IMAGE_NAME:$GATEWAY_VERSION"`,
+		`immutable proxyv2 compatibility tag conflict`,
+		`docker buildx imagetools create --tag "$compat_target" "$staging@$desired"`,
+		`test "$(descriptor_or_absent "$compat_target")" = "$desired"`,
 	} {
 		if !strings.Contains(workflow, required) {
 			t.Fatalf("gateway image recovery lacks immutable staging contract %q", required)
@@ -1589,6 +1734,88 @@ func TestGatewayReleaseAliasRecoveryPromotesOnlyVerifiedStaging(t *testing.T) {
 	}
 	if strings.Index(workflow, `docker buildx imagetools inspect "$staging" --raw`) > strings.Index(workflow, `docker buildx imagetools create --tag "$target"`) {
 		t.Fatal("gateway image recovery must validate staging before any alias mutation")
+	}
+}
+
+func runGatewayProxyV2RecoveryContract(t *testing.T, contract, mode string, dryRun bool) (int, string) {
+	t.Helper()
+	tmp := t.TempDir()
+	state := filepath.Join(tmp, "created")
+	log := filepath.Join(tmp, "docker.log")
+	summary := filepath.Join(tmp, "summary")
+	desired := "sha256:" + strings.Repeat("a", 64)
+	conflict := "sha256:" + strings.Repeat("b", 64)
+	script := `set -euo pipefail
+descriptor_or_absent() {
+  local ref=$1
+  case "$RECOVERY_MODE" in
+    absent)
+      if [ -f "$RECOVERY_STATE" ]; then printf '%s' "$RECOVERY_DESIRED"; else return 1; fi
+      ;;
+    identical) printf '%s' "$RECOVERY_DESIRED" ;;
+    conflict) printf '%s' "$RECOVERY_CONFLICT" ;;
+    lookup-error) return 2 ;;
+    *) return 3 ;;
+  esac
+}
+docker() {
+  printf '%s\n' "$*" >>"$RECOVERY_LOG"
+  touch "$RECOVERY_STATE"
+}
+` + contract
+	cmd := exec.Command("bash", "-c", script)
+	cmd.Env = append(os.Environ(),
+		"RECOVERY_MODE="+mode,
+		"RECOVERY_STATE="+state,
+		"RECOVERY_LOG="+log,
+		"RECOVERY_DESIRED="+desired,
+		"RECOVERY_CONFLICT="+conflict,
+		"GITHUB_STEP_SUMMARY="+summary,
+		"IMAGE_REGISTRY=registry.example.invalid",
+		"COMPAT_IMAGE_NAME=higress/proxyv2",
+		"GATEWAY_VERSION=2.2.4",
+		"DRY_RUN="+fmt.Sprint(dryRun),
+		"staging=registry.example.invalid/higress/gateway:release-provenance-deadbeef",
+		"desired="+desired,
+	)
+	output, err := cmd.CombinedOutput()
+	status := 0
+	if err != nil {
+		var exitErr *exec.ExitError
+		if !errors.As(err, &exitErr) {
+			t.Fatalf("gateway proxyv2 recovery fixture failed to execute: %v\n%s", err, output)
+		}
+		status = exitErr.ExitCode()
+	}
+	logData, readErr := os.ReadFile(log)
+	if readErr != nil && !os.IsNotExist(readErr) {
+		t.Fatal(readErr)
+	}
+	return status, string(logData)
+}
+
+func TestGatewayProxyV2RecoveryContractIsIdempotentAndFailsClosed(t *testing.T) {
+	contract := workflowShellContract(t, "recover-gateway-release-images.yaml", "gateway-proxyv2-recovery-contract")
+	wantCreate := "buildx imagetools create --tag registry.example.invalid/higress/proxyv2:2.2.4 registry.example.invalid/higress/gateway:release-provenance-deadbeef@sha256:" + strings.Repeat("a", 64)
+	for _, tc := range []struct {
+		name       string
+		mode       string
+		dryRun     bool
+		wantStatus int
+		wantLog    string
+	}{
+		{name: "missing creates from verified staging digest", mode: "absent", wantLog: wantCreate + "\n"},
+		{name: "existing identical alias is idempotent", mode: "identical"},
+		{name: "existing conflicting alias fails closed", mode: "conflict", wantStatus: 1},
+		{name: "lookup errors fail closed", mode: "lookup-error", wantStatus: 2},
+		{name: "dry run does not mutate", mode: "absent", dryRun: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			status, log := runGatewayProxyV2RecoveryContract(t, contract, tc.mode, tc.dryRun)
+			if status != tc.wantStatus || log != tc.wantLog {
+				t.Fatalf("status/log = %d/%q, want %d/%q", status, log, tc.wantStatus, tc.wantLog)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## I. Summary

Restore the historical numeric `proxyv2` compatibility image contract without rebuilding or publishing a second gateway artifact:

- Release publication now creates `proxyv2:<version>` from the verified immutable `gateway:<version>` OCI index digest.
- The protected recovery workflow can idempotently backfill a missing numeric compatibility tag, while rejecting conflicts and lookup/auth failures.
- Helm's legacy `global.proxy.image` and `global.proxy_init.image` defaults now name the actually published `gateway` repository.
- Executable shell-contract tests cover missing, identical, conflicting, lookup-error, dry-run, and non-release behavior.

Only the numeric compatibility tag is maintained. This does not create `v<version>`, `sha-*`, or `latest` aliases in `proxyv2`.

## II. Related issue

Fixes #4505

## III. Change type

- [x] Bug fix
- [ ] Feature or enhancement
- [x] Documentation or configuration only
- [x] Refactoring, tests, or maintenance

## IV. Agent participation and issue-spec gate

- [ ] **No agent participation:** This PR is human-only.
- [ ] **Trivial agent-use exception:** Agent use was limited to spelling, punctuation, whitespace, or formatting with no substantive choice or behavioral effect; the explanation is below.
- [x] **Verified maintainer/administrator exception:** Material agent participation occurred, and authenticated `gh` verification confirmed a `role_name` of `maintain` or `admin` on `higress-group/higress`, and the verified login matches this PR's GitHub author; record the required evidence and rationale below.
- [ ] **Material agent participation:** An AI or coding agent materially participated in analysis, design, implementation, testing, or PR preparation.

For material participation that does not use the verified maintainer/administrator exception, check each timed obligation:

- [ ] **Before implementation began:** A Higress maintainer had approved the Proposal and Design Issues, and authorized implementation TASKs linked the work to the applicable SPECs.
- [ ] **Before verification began:** The Design contained a concrete Verification Plan.
- [ ] **Before requesting maintainer review or acceptance:** Applicable implementation and verification TASKs were `done` with exact commands, results, evidence links, and hashes.

- [ ] Complete: all three timed obligations above were satisfied.
- [ ] Noncompliant: one or more obligations were not satisfied; explain below.
- [x] Verified exception: material agent participation used the verified-maintainer/administrator exception; provide the required evidence and rationale below.
- [ ] N/A because the PR is human-only or qualifies for the trivial exception.

**Gate-status explanation (or N/A):** Verified administrator exception; live evidence is recorded below before review is requested.

**Trivial-exception explanation (or N/A):** N/A; material agent participation occurred.

**Verified maintainer/administrator exception evidence (or N/A):**

- This PR's number or URL: https://github.com/higress-group/higress/pull/4506
- Authenticated `gh` login: johnlanni
- Canonical-repository `role_name`: admin
- Actual PR author from `gh pr view`: johnlanni
- Login/author match: yes
- Token override attestation (`GH_TOKEN` and `GITHUB_TOKEN` were unset for every verification command; required: `yes`): yes
- Bypass rationale: The authenticated contributor is a Higress administrator and is handling an urgent release-artifact regression. The exception is limited to this PR; agent participation and verification remain disclosed.
- Maintainer live validation (review URL or N/A until performed): N/A until performed

**Approved Proposal Issue URL (or N/A with explanation):** N/A; verified administrator exception.

**Approved Design Issue URL (or N/A with explanation):** N/A; verified administrator exception.

**Maintainer approval link(s) (or N/A with explanation):** N/A; verified administrator exception.

**Authorized implementation TASK link(s) (or N/A with explanation):** N/A; verified administrator exception.

**Verification Plan and verification TASK/evidence link(s) (or N/A with explanation):** N/A; verified administrator exception. Deterministic verification evidence is recorded below.

## V. Testing and verification

**Test and deterministic rerun commands (or N/A with explanation):**

```text
env -u GH_TOKEN -u GITHUB_TOKEN go test -count=1 ./...  # from tools/plugin-release
env -u GH_TOKEN -u GITHUB_TOKEN go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 .github/workflows/build-image-and-push.yaml .github/workflows/recover-gateway-release-images.yaml
env -u GH_TOKEN -u GITHUB_TOKEN helm lint helm/core
env -u GH_TOKEN -u GITHUB_TOKEN helm template proxyv2-fix helm/core
env -u GH_TOKEN -u GITHUB_TOKEN go run github.com/norwoodj/helm-docs/cmd/helm-docs@v1.14.2 -c "$PWD/helm/higress" -f ../core/values.yaml
git diff --exit-code
env -u GH_TOKEN -u GITHUB_TOKEN oras manifest fetch --descriptor higress-registry.cn-hangzhou.cr.aliyuncs.com/higress/proxyv2:2.2.4
env -u GH_TOKEN -u GITHUB_TOKEN oras manifest fetch --descriptor higress-registry.cn-hangzhou.cr.aliyuncs.com/higress/gateway:2.2.4
```

**Environment and configuration (or N/A with explanation):** Linux amd64; Go 1.26.0; Helm 3.15.1; ORAS 1.1.0; actionlint 1.7.7. `GH_TOKEN` and `GITHUB_TOKEN` were unset for every verification command.

**Exact tested revision, version, image tag/digest, manifests, and values (or N/A with explanation):** Commit `84183fb9a2fbfa7d93da69c8d373908c43cda961`; Higress `2.2.4`; release commit `58666ac985cee19a0a9a353421c63cead6d0cb47`; snapshot SHA-256 `09bc798df37e50dae2e684947885c31eb756636c76a98761a9a980fc031e3a1a`; verified gateway staging and stable digest `sha256:3dbd609df5db3fca61653eafe0e2310705e485190c4f8cd02d9aab8f07dcf329`.

**Baseline reproduction evidence for bug fixes (or N/A with explanation):** The issue's exact `proxyv2:2.2.4` reference still returns `not found` from ACR. In contrast, `gateway:2.2.4` and `gateway:release-provenance-58666ac985cee19a0a9a353421c63cead6d0cb47` both resolve to `sha256:3dbd609df5db3fca61653eafe0e2310705e485190c4f8cd02d9aab8f07dcf329`. The unverified intermediary `proxyv2:release-build-58666ac985cee19a0a9a353421c63cead6d0cb47` resolves to a different digest, so it is intentionally not used as the backfill source.

**Fixed-version verification evidence for bug fixes (or N/A with explanation):** At the exact tested revision, executable workflow-contract tests pass for missing-tag creation, identical-tag idempotency, conflicting-tag rejection, lookup-error rejection, recovery dry-run, and non-release behavior. `actionlint` and `helm lint` pass; Helm renders `gateway:2.2.4` and no `proxyv2` runtime image. Live ACR backfill will be performed through the protected recovery workflow after this workflow change is merged, then the exact target digest will be verified.

**Wasm source revision and SHA-256 (or N/A with explanation):** N/A; no WASM source or plugin artifact changes.

## VI. Special notes for reviewers

The recovery must run only after merge with `gateway_version=2.2.4`, release commit `58666ac985cee19a0a9a353421c63cead6d0cb47`, and snapshot SHA-256 `09bc798df37e50dae2e684947885c31eb756636c76a98761a9a980fc031e3a1a`. It copies the already verified final gateway index, performs no rebuild, and fails closed if the compatibility tag already points elsewhere.

An independent exact-head review found no P0/P1/P2 issues. The reviewer specifically checked release/recovery alias safety, Helm defaults, executable edge-case coverage, actionlint, and exact-head cleanliness.

## VII. AI coding disclosure

**Tool(s) used (or N/A):** OpenAI Codex, including one independent Codex reviewer.

### Prompts or instructions

The maintainer asked the agent to analyze issue #4505, identify all dependencies on the missing image, fix the release path, open a PR, and backfill the missing 2.2.4 compatibility image. Repository `AGENTS.md`, the agent-assisted contribution policy, and the verified maintainer/administrator exception were followed. No credentials are included here.

### AI-assisted work summary

The agent traced the regression to the provenance-aware gateway publication flow, verified published OCI digests, implemented immutable/idempotent compatibility aliases for normal and recovery paths, updated Helm defaults and generated documentation, added executable workflow tests, and ran deterministic verification. A separate agent reviewed the exact commit; its only initial test-coverage suggestion was implemented and the final re-review reported no remaining findings.