### PR TITLE
bugfix: fix slice out of bounds panic in createRuleKey for crafted annotation keys

### DIFF
--- a/pkg/ingress/kube/ingress/controller.go
+++ b/pkg/ingress/kube/ingress/controller.go
@@ -1505,12 +1505,21 @@ func createRuleKey(annots map[string]string, hostAndPath string) string {
 	// headers && params
 	for k, val := range annots {
 		if idx := strings.Index(k, annotations.MatchHeader); idx != -1 {
+			if idx < start || idx+len(annotations.MatchHeader)+1 > len(k) {
+				continue
+			}
 			key := k[start:idx] + k[idx+len(annotations.MatchHeader)+1:]
 			headers = append(headers, [2]string{key, val})
 		} else if idx := strings.Index(k, annotations.MatchPseudoHeader); idx != -1 {
+			if idx < start || idx+len(annotations.MatchPseudoHeader)+1 > len(k) {
+				continue
+			}
 			key := k[start:idx] + ":" + k[idx+len(annotations.MatchPseudoHeader)+1:]
 			headers = append(headers, [2]string{key, val})
 		} else if idx := strings.Index(k, annotations.MatchQuery); idx != -1 {
+			if idx < start || idx+len(annotations.MatchQuery)+1 > len(k) {
+				continue
+			}
 			key := k[start:idx] + k[idx+len(annotations.MatchQuery)+1:]
 			params = append(params, [2]string{key, val})
 		}

--- a/pkg/ingress/kube/ingressv1/controller.go
+++ b/pkg/ingress/kube/ingressv1/controller.go
@@ -1455,12 +1455,21 @@ func createRuleKey(annots map[string]string, hostAndPath string) string {
 	// headers && params
 	for k, val := range annots {
 		if idx := strings.Index(k, annotations.MatchHeader); idx != -1 {
+			if idx < start || idx+len(annotations.MatchHeader)+1 > len(k) {
+				continue
+			}
 			key := k[start:idx] + k[idx+len(annotations.MatchHeader)+1:]
 			headers = append(headers, [2]string{key, val})
 		} else if idx := strings.Index(k, annotations.MatchPseudoHeader); idx != -1 {
+			if idx < start || idx+len(annotations.MatchPseudoHeader)+1 > len(k) {
+				continue
+			}
 			key := k[start:idx] + ":" + k[idx+len(annotations.MatchPseudoHeader)+1:]
 			headers = append(headers, [2]string{key, val})
 		} else if idx := strings.Index(k, annotations.MatchQuery); idx != -1 {
+			if idx < start || idx+len(annotations.MatchQuery)+1 > len(k) {
+				continue
+			}
 			key := k[start:idx] + k[idx+len(annotations.MatchQuery)+1:]
 			params = append(params, [2]string{key, val})
 		}

--- a/pkg/ingress/kube/ingressv1/controller_test.go
+++ b/pkg/ingress/kube/ingressv1/controller_test.go
@@ -1096,3 +1096,73 @@ func ingressRule(host string, paths ...v1.HTTPIngressPath) v1.IngressRule {
 		},
 	}
 }
+
+func TestCreateRuleKey(t *testing.T) {
+	tests := []struct {
+		name        string
+		annots      map[string]string
+		hostAndPath string
+		wantPanic   bool
+	}{
+		{
+			name:        "normal header annotation",
+			annots:      map[string]string{"higress.io/exact-match-header-x": "val1"},
+			hostAndPath: "example.com/foo",
+			wantPanic:   false,
+		},
+		{
+			name:        "match-header before higress prefix position",
+			annots:      map[string]string{"foo/match-header-x": "val"},
+			hostAndPath: "example.com/foo",
+			wantPanic:   false,
+		},
+		{
+			name:        "match-header at end with no suffix key",
+			annots:      map[string]string{"higress.io/match-header": "val"},
+			hostAndPath: "example.com/foo",
+			wantPanic:   false,
+		},
+		{
+			name:        "match-query before higress prefix position",
+			annots:      map[string]string{"x/match-query-foo": "val"},
+			hostAndPath: "example.com/bar",
+			wantPanic:   false,
+		},
+		{
+			name:        "match-pseudo-header at end with no suffix",
+			annots:      map[string]string{"higress.io/match-pseudo-header": "val"},
+			hostAndPath: "example.com/baz",
+			wantPanic:   false,
+		},
+		{
+			name:        "empty annotations",
+			annots:      nil,
+			hostAndPath: "example.com/path",
+			wantPanic:   false,
+		},
+		{
+			name:        "normal query annotation",
+			annots:      map[string]string{"higress.io/exact-match-query-param": "value"},
+			hostAndPath: "example.com/test",
+			wantPanic:   false,
+		},
+		{
+			name:        "normal pseudo-header annotation",
+			annots:      map[string]string{"higress.io/exact-match-pseudo-header-foo": "val"},
+			hostAndPath: "example.com/test",
+			wantPanic:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// createRuleKey should not panic on any of these inputs
+			defer func() {
+				if r := recover(); r != nil {
+					t.Fatalf("createRuleKey panicked: %v", r)
+				}
+			}()
+			_ = createRuleKey(tt.annots, tt.hostAndPath)
+		})
+	}
+}

--- a/pkg/ingress/kube/kingress/controller.go
+++ b/pkg/ingress/kube/kingress/controller.go
@@ -673,12 +673,21 @@ func createRuleKey(annots map[string]string, hostAndPath string) string {
 	// headers && params
 	for k, val := range annots {
 		if idx := strings.Index(k, annotations.MatchHeader); idx != -1 {
+			if idx < start || idx+len(annotations.MatchHeader)+1 > len(k) {
+				continue
+			}
 			key := k[start:idx] + k[idx+len(annotations.MatchHeader)+1:]
 			headers = append(headers, [2]string{key, val})
 		} else if idx := strings.Index(k, annotations.MatchPseudoHeader); idx != -1 {
+			if idx < start || idx+len(annotations.MatchPseudoHeader)+1 > len(k) {
+				continue
+			}
 			key := k[start:idx] + ":" + k[idx+len(annotations.MatchPseudoHeader)+1:]
 			headers = append(headers, [2]string{key, val})
 		} else if idx := strings.Index(k, annotations.MatchQuery); idx != -1 {
+			if idx < start || idx+len(annotations.MatchQuery)+1 > len(k) {
+				continue
+			}
 			key := k[start:idx] + k[idx+len(annotations.MatchQuery)+1:]
 			params = append(params, [2]string{key, val})
 		}


### PR DESCRIPTION
## Ⅰ. Describe what this PR does

Fixes a slice out of bounds panic in the `createRuleKey` function that exists identically in three controller files:
- `pkg/ingress/kube/ingressv1/controller.go`
- `pkg/ingress/kube/ingress/controller.go`
- `pkg/ingress/kube/kingress/controller.go`

The `createRuleKey` function iterates over all annotation keys and uses `strings.Index` to find match patterns (`match-header`, `match-pseudo-header`, `match-query`). When a match is found, it slices the annotation key as:

```go
start := len(annotations.HigressAnnotationsPrefix) + 1 // 11
key := k[start:idx] + k[idx+len(annotations.MatchHeader)+1:]
```

This has two panic vectors:

1. **`k[start:idx]` when `idx < start`**: If an annotation key contains `match-header` before position 11 (e.g., `foo/match-header-bar` where idx=4 < start=11), the slice `k[11:4]` panics.

2. **`k[idx+len(pattern)+1:]` out of bounds**: If an annotation key ends at the match pattern with no suffix (e.g., `higress.io/match-header` where idx=11, 11+12+1=24 > len=23), the slice panics.

Both vectors can be triggered by any Kubernetes user who can create or update Ingress resources with custom annotations, causing the Higress ingress controller to crash.

### Fix

Added bounds checks before slicing in all three controller files:
- Skip annotation keys where `idx < start` (match pattern appears before the Higress prefix position)
- Skip annotation keys where `idx + len(pattern) + 1 > len(k)` (no suffix key after the match pattern)

Also added `TestCreateRuleKey` to `ingressv1/controller_test.go` with test cases covering both panic vectors.

## Ⅱ. Does this PR fix any issue

fixes #4508

## Ⅲ. Why not add test cases

Test cases are included: `TestCreateRuleKey` in `controller_test.go` verifies that `createRuleKey` does not panic on crafted annotation keys that previously triggered the slice out of bounds panic.

## Ⅳ. How to verify

1. `gofmt -e` passes on all modified files
2. `TestCreateRuleKey` test passes (verifies no panic on crafted inputs)
3. Manual verification: Create an Ingress with annotation `foo/match-header-x: "bar"` — the controller no longer crashes

## Ⅴ. Special notes for reviewers

- The fix is applied to all three controller files (`ingressv1`, `ingress`, `kingress`) since they share identical `createRuleKey` implementations
- The fix is minimal: only adds bounds checks (`continue` on invalid keys) without changing the behavior for valid annotation keys
- The test file only covers `ingressv1` since the function is identical across all three packages; the fix in `ingress` and `kingress` follows the same pattern

## Ⅵ. AI Coding Tool Usage Checklist

- [x] I used AI coding tools to help analyze the panic vectors and generate the fix
- [x] I reviewed and verified all AI-generated code changes before submitting