### PR TITLE
bugfix: fix panics in hgctl GlobalConfAsker and ParseLatestVersion

### DIFF
--- a/hgctl/pkg/helm/render.go
+++ b/hgctl/pkg/helm/render.go
@@ -629,6 +629,9 @@ func ParseLatestVersion(repoUrl string, version string, devel bool) (string, err
 
 	// get higress helm chart latest version
 	if entries, ok := indexFile.Entries[RepoChartIndexYamlHigressIndex]; ok {
+		if len(entries) == 0 {
+			return "", errors.New("no versions found for higress chart in repository index")
+		}
 		if devel {
 			return entries[0].AppVersion, nil
 		}

--- a/hgctl/pkg/plugin/install/asker.go
+++ b/hgctl/pkg/plugin/install/asker.go
@@ -342,7 +342,11 @@ func (g *GlobalConfAsker) Ask() error {
 		return nil
 	}
 
-	g.resp = as.(map[string]interface{})
+	resp, ok := as.(map[string]interface{})
+	if !ok {
+		return fmt.Errorf("failed to convert configuration to map[string]interface{}")
+	}
+	g.resp = resp
 	g.printer.Yesln(addConfSuccessful)
 
 	return nil


### PR DESCRIPTION
## Ⅰ. Describe what this PR does

Fixes two panic bugs in the `hgctl` CLI tool:

### Bug 1: Naked type assertion in `GlobalConfAsker.Ask()` (asker.go)

In `GlobalConfAsker.Ask()`, the result of `recursivePrompt` is asserted as `map[string]interface{}` without a comma-ok check:
```go
g.resp = as.(map[string]interface{})
```
When `recursivePrompt` returns `nil` (which happens when the user leaves all config fields empty — `doPrompt` returns `nil` for empty objects), this panics with "interface conversion: interface is nil, not map[string]interface{}".

**Fix**: Changed to comma-ok pattern with error return.

### Bug 2: `entries[0]` without length check in `ParseLatestVersion` (render.go)

In `ParseLatestVersion`, when `devel` mode is enabled, the code accesses `entries[0].AppVersion` without checking if `entries` is empty:
```go
if devel {
    return entries[0].AppVersion, nil
}
```
If the helm repository index contains a "higress" entry but the version list is empty, this panics with "index out of range".

**Fix**: Added `len(entries) == 0` check before accessing `entries[0]`.

## Ⅱ. Does this PR fix any issue

fixes #4512

## Ⅲ. Why not add test cases

Bug 1 requires interactive survey input (mocking the survey library is complex). Bug 2 requires a malformed helm repo index. Both fixes are straightforward defensive checks.

## Ⅳ. How to verify

1. `go build ./pkg/plugin/install/...` passes
2. `go build ./pkg/helm/...` passes
3. `gofmt -e` passes on both files

## Ⅴ. Special notes for reviewers

- Bug 1 is triggered by normal interactive usage (leaving all Global config fields empty in `hgctl install`)
- Bug 2 is triggered by a corrupted or partially synced helm repository index

## Ⅵ. AI Coding Tool Usage Checklist

- [x] I used AI coding tools to help analyze the panic vectors
- [x] I reviewed and verified all AI-generated code changes before submitting