### PR TITLE
bugfix: fix panic bugs in triggerRollout, accessDockerCompose, and convertServiceEntry

### DIFF
--- a/hgctl/pkg/code_debug.go
+++ b/hgctl/pkg/code_debug.go
@@ -290,6 +290,9 @@ func triggerRollout(clientset *kubernetes.Clientset, deploymentName string) erro
 	}
 
 	// Increment the deployment's revision to trigger a rollout
+	if deployment.Spec.Template.ObjectMeta.Labels == nil {
+		deployment.Spec.Template.ObjectMeta.Labels = make(map[string]string)
+	}
 	deployment.Spec.Template.ObjectMeta.Labels["version"] = time.Now().Format("20060102150405")
 
 	// Update the deployment

--- a/hgctl/pkg/dashboard.go
+++ b/hgctl/pkg/dashboard.go
@@ -208,7 +208,7 @@ func accessDockerCompose(cmd *cobra.Command) error {
 	for _, container := range list {
 		if strings.Contains(container.Service, "console") {
 			// not support define ip address
-			if container.Publishers != nil {
+			if len(container.Publishers) > 0 {
 				url := fmt.Sprintf("http://localhost:%d", container.Publishers[0].PublishedPort)
 				openBrowser(url, cmd.OutOrStdout(), browser)
 			}

--- a/pkg/ingress/config/ingress_config.go
+++ b/pkg/ingress/config/ingress_config.go
@@ -868,6 +868,10 @@ func (m *IngressConfig) convertServiceEntry([]common.WrapperConfig) []config.Con
 	out := make([]config.Config, 0, len(serviceEntries))
 	hostSets := sets.Set[string]{}
 	for _, se := range serviceEntries {
+		if len(se.ServiceEntry.Hosts) == 0 {
+			IngressLog.Warnf("skip service entry with empty hosts from registry %s", se.RegistryName)
+			continue
+		}
 		out = append(out, config.Config{
 			Meta: config.Meta{
 				GroupVersionKind:  gvk.ServiceEntry,
@@ -886,7 +890,15 @@ func (m *IngressConfig) convertServiceEntry([]common.WrapperConfig) []config.Con
 	// add service entry by host from nacos3 for mcp server
 	seFromMcp := m.RegistryReconciler.GetAllConfigs(gvk.ServiceEntry)
 	for _, cfg := range seFromMcp {
-		se := cfg.Spec.(*networking.ServiceEntry)
+		se, ok := cfg.Spec.(*networking.ServiceEntry)
+		if !ok {
+			IngressLog.Warnf("skip config %s/%s with unexpected spec type", cfg.Namespace, cfg.Name)
+			continue
+		}
+		if len(se.Hosts) == 0 {
+			IngressLog.Warnf("skip config %s/%s with empty hosts", cfg.Namespace, cfg.Name)
+			continue
+		}
 		if !hostSets.Contains(se.Hosts[0]) {
 			out = append(out, *cfg)
 		}


### PR DESCRIPTION
## Ⅰ. Describe what this PR does

Fixes three panic bugs across different modules:

### Bug 1: nil map write in `triggerRollout` (hgctl/pkg/code_debug.go)

In `triggerRollout`, the code writes to the deployment's `Labels` map without initializing it:
```go
deployment.Spec.Template.ObjectMeta.Labels["version"] = time.Now().Format("20060102150405")
```
If `Labels` is nil (deployment template has no labels), writing to a nil map panics.

**Fix**: Added nil check and initialization before writing.

### Bug 2: empty slice access in `accessDockerCompose` (hgctl/pkg/dashboard.go)

The code checks `container.Publishers != nil` but not `len > 0`:
```go
if container.Publishers != nil {
    url := fmt.Sprintf("http://localhost:%d", container.Publishers[0].PublishedPort)
```
If `Publishers` is an empty non-nil slice, `Publishers[0]` panics.

**Fix**: Changed `!= nil` to `len > 0`.

### Bug 3: empty `Hosts` access in `convertServiceEntry` (pkg/ingress/config/ingress_config.go)

The code accesses `se.ServiceEntry.Hosts[0]` without checking if `Hosts` is empty. If a registry reconciler returns a ServiceEntry with empty `Hosts`, this panics and crashes the ingress controller.

Also fixed `cfg.Spec.(*networking.ServiceEntry)` naked type assertion with comma-ok pattern.

**Fix**: Added `len(Hosts) == 0` guard to skip ServiceEntries with empty hosts, and comma-ok pattern for the type assertion.

## Ⅱ. Does this PR fix any issue

fixes #4514

## Ⅲ. Why not add test cases

- Bug 1 requires a Kubernetes deployment with nil Labels (mocking K8s client)
- Bug 2 requires a Docker container with empty Publishers (mocking Docker client)
- Bug 3 requires a misconfigured registry reconciler (mocking registry)
- All three fixes are straightforward defensive checks

## Ⅳ. How to verify

1. `gofmt -e` passes on all modified files
2. The changes are minimal defensive checks that don't alter existing behavior

## Ⅴ. Special notes for reviewers

- Bug 3 is HIGH severity: crashes the Higress ingress controller when a registry returns a ServiceEntry with empty hosts
- Bugs 1 and 2 are MEDIUM severity: crash the hgctl CLI tool
- The fix for Bug 3 also adds a warning log for skipped ServiceEntries to aid debugging

## Ⅵ. AI Coding Tool Usage Checklist

- [x] I used AI coding tools to help analyze the panic vectors
- [x] I reviewed and verified all AI-generated code changes before submitting