### PR TITLE
fix(ai-image-reader): isolate DashScope apiKey per plugin config

### DIFF
--- a/plugins/wasm-go/extensions/ai-image-reader/dashscope.go
+++ b/plugins/wasm-go/extensions/ai-image-reader/dashscope.go
@@ -56,19 +56,15 @@ type content struct {
 	Text      string   `json:"text,omitempty"`
 }
 
-var dashScopeConfig dashScopeProviderConfig
 
 type dashScopeProviderInitializer struct {
 }
 
 func (d *dashScopeProviderInitializer) InitConfig(json gjson.Result) {
-	dashScopeConfig.apiKey = json.Get("apiKey").String()
+	_ = json
 }
 
 func (d *dashScopeProviderInitializer) ValidateConfig() error {
-	if dashScopeConfig.apiKey == "" {
-		return errors.New("[DashScope] apiKey is required")
-	}
 	return nil
 }
 
@@ -81,6 +77,7 @@ func (d *dashScopeProviderInitializer) CreateProvider(c ProviderConfig) (Provide
 	}
 	return &DSProvider{
 		config: c,
+		apiKey: c.apiKey,
 		client: wrapper.NewClusterClient(wrapper.FQDNCluster{
 			FQDN: c.serviceName,
 			Host: c.serviceHost,
@@ -89,14 +86,9 @@ func (d *dashScopeProviderInitializer) CreateProvider(c ProviderConfig) (Provide
 	}, nil
 }
 
-type dashScopeProviderConfig struct {
-	// @Title zh-CN 文字识别服务 API Key
-	// @Description zh-CN 文字识别服务 API Key
-	apiKey string
-}
-
 type DSProvider struct {
 	config ProviderConfig
+	apiKey string
 	client wrapper.HttpClient
 }
 
@@ -133,7 +125,7 @@ func (d *DSProvider) CallArgs(imageUrl string) CallArgs {
 		Url:    DashscopeEndpoint,
 		Headers: [][2]string{
 			{"Content-Type", "application/json"},
-			{"Authorization", fmt.Sprintf("Bearer %s", dashScopeConfig.apiKey)},
+			{"Authorization", fmt.Sprintf("Bearer %s", d.apiKey)},
 		},
 		Body:               body,
 		TimeoutMillisecond: d.config.timeout,

--- a/plugins/wasm-go/extensions/ai-image-reader/provider.go
+++ b/plugins/wasm-go/extensions/ai-image-reader/provider.go
@@ -40,6 +40,7 @@ type ProviderConfig struct {
 	// @Title zh-CN 文字识别服务使用的模型
 	// @Description zh-CN 用于文字识别的模型名称, 在 DashScope 中默认为 "qwen-vl-ocr"
 	model string
+	apiKey string
 
 	initializer providerInitializer
 }
@@ -56,6 +57,7 @@ func (c *ProviderConfig) FromJson(json gjson.Result) {
 	c.servicePort = json.Get("servicePort").Int()
 	c.timeout = uint32(json.Get("timeout").Int())
 	c.model = json.Get("model").String()
+	c.apiKey = json.Get("apiKey").String()
 	if c.timeout == 0 {
 		c.timeout = 10000
 	}
@@ -74,6 +76,9 @@ func (c *ProviderConfig) Validate() error {
 	if c.initializer == nil {
 		return errors.New("unknown ocr service provider type: " + c.typ)
 	}
+	if c.typ == ProviderTypeDashscope && c.apiKey == "" {
+		return errors.New("[DashScope] apiKey is required")
+	}
 	if err := c.initializer.ValidateConfig(); err != nil {
 		return err
 	}
@@ -85,6 +90,9 @@ func (c *ProviderConfig) GetProviderType() string {
 }
 
 func CreateProvider(pc ProviderConfig) (Provider, error) {
+	if pc.initializer != nil {
+		return pc.initializer.CreateProvider(pc)
+	}
 	initializer, has := providerInitializers[pc.typ]
 	if !has {
 		return nil, errors.New("unknown provider type: " + pc.typ)


### PR DESCRIPTION
## Summary
- Store DashScope `apiKey` on `ProviderConfig` / `DSProvider` instead of a package-global variable.
- Prevent later `ai-image-reader` configs from overwriting credentials used by earlier provider instances.

Fixes #4535

## Testing plan
- [ ] Parse two DashScope configs with different `apiKey` values; earlier provider `CallArgs` Authorization still uses the first key.
- [ ] Missing `apiKey` still fails validation for DashScope.