### PR TITLE
fix(hgctl): reject unapplied local-docker overlays

### DIFF
--- a/hgctl/pkg/helm/common.go
+++ b/hgctl/pkg/helm/common.go
@@ -19,6 +19,8 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"reflect"
+	"sort"
 	"strings"
 
 	"github.com/alibaba/higress/hgctl/pkg/helm/tpath"
@@ -185,6 +187,70 @@ func overlaySetFlagValues(iopYAML string, setFlags []string) (string, error) {
 	return string(out), nil
 }
 
+// GetProfileOverlay normalizes file and --set input into one Profile overlay.
+// Callers that need to validate user intent must do so before Profile defaulting.
+func GetProfileOverlay(fileOverlayYAML string, setFlags []string) (string, error) {
+	return overlaySetFlagValues(fileOverlayYAML, setFlags)
+}
+
+// UnsupportedLocalDockerUpgradeOverlayPaths returns caller-requested fields that
+// would not be consumed by a local-docker upgrade. The comparison uses the
+// stored typed Profile as the baseline, while the overlay retains only caller
+// input and therefore excludes fields injected by profile generation.
+func UnsupportedLocalDockerUpgradeOverlayPaths(baseline *Profile, overlayYAML string) ([]string, error) {
+	if strings.TrimSpace(overlayYAML) == "" {
+		return nil, nil
+	}
+
+	baselineValues := make(map[string]any)
+	if err := yaml.Unmarshal([]byte(util.ToYAML(baseline)), &baselineValues); err != nil {
+		return nil, err
+	}
+	overlayValues := make(map[string]any)
+	if err := yaml.Unmarshal([]byte(overlayYAML), &overlayValues); err != nil {
+		return nil, err
+	}
+
+	paths := make([]string, 0)
+	collectOverlayDiffPaths(baselineValues, overlayValues, "", &paths)
+	sort.Strings(paths)
+
+	unsupported := make([]string, 0, len(paths))
+	for _, path := range paths {
+		if path != "installPackagePath" && path != "charts.standalone.url" {
+			unsupported = append(unsupported, path)
+		}
+	}
+	if len(unsupported) == 0 {
+		return nil, nil
+	}
+	return unsupported, nil
+}
+
+func collectOverlayDiffPaths(baseline, overlay any, prefix string, paths *[]string) {
+	overlayMap, isMap := overlay.(map[string]any)
+	if !isMap {
+		if !reflect.DeepEqual(baseline, overlay) {
+			*paths = append(*paths, prefix)
+		}
+		return
+	}
+
+	baselineMap, _ := baseline.(map[string]any)
+	keys := make([]string, 0, len(overlayMap))
+	for key := range overlayMap {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		path := key
+		if prefix != "" {
+			path = prefix + "." + key
+		}
+		collectOverlayDiffPaths(baselineMap[key], overlayMap[key], path, paths)
+	}
+}
+
 // getInstallPackagePath returns the installPackagePath in the given IstioOperator YAML string.
 func getInstallPackagePath(profileYAML string) (string, error) {
 	profile, err := UnmarshalProfile(profileYAML)
@@ -302,7 +368,7 @@ func GenProfile(profileOrPath, fileOverlayYAML string, setFlags []string) (strin
 	}
 
 	// Combine file and --set overlays and translate any K8s settings in values to Profile format
-	overlayYAML, err := overlaySetFlagValues(fileOverlayYAML, setFlags)
+	overlayYAML, err := GetProfileOverlay(fileOverlayYAML, setFlags)
 	if err != nil {
 		return "", nil, err
 	}
@@ -338,7 +404,7 @@ func GenProfileFromProfileContent(profileContent, fileOverlayYAML string, setFla
 	}
 
 	// Combine file and --set overlays and translate any K8s settings in values to Profile format
-	overlayYAML, err := overlaySetFlagValues(fileOverlayYAML, setFlags)
+	overlayYAML, err := GetProfileOverlay(fileOverlayYAML, setFlags)
 	if err != nil {
 		return "", nil, err
 	}

--- a/hgctl/pkg/helm/common_test.go
+++ b/hgctl/pkg/helm/common_test.go
@@ -1,0 +1,59 @@
+package helm
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestUnsupportedLocalDockerUpgradeOverlayPaths(t *testing.T) {
+	baseline := &Profile{
+		Profile:            "local-docker",
+		InstallPackagePath: "/opt/higress",
+		HigressVersion:     "2.1.0",
+		Global:             ProfileGlobal{Install: InstallLocalDocker},
+		Console:            ProfileConsole{Port: 8080},
+		Gateway:            ProfileGateway{HttpPort: 80},
+		Storage:            ProfileStorage{Url: "file:///opt/higress", Ns: "higress"},
+		Values:             map[string]any{"feature": map[string]any{"enabled": true}},
+		Charts:             ProfileCharts{Standalone: Chart{Url: "https://example.com/get-higress.sh"}},
+	}
+
+	tests := []struct {
+		name     string
+		file     string
+		setFlags []string
+		want     []string
+	}{
+		{name: "no overlay"},
+		{name: "same value", setFlags: []string{"gateway.httpPort=80"}},
+		{name: "install package path", setFlags: []string{"installPackagePath=/tmp/higress"}},
+		{name: "standalone url", setFlags: []string{"charts.standalone.url=https://example.com/next.sh"}},
+		{name: "gateway", setFlags: []string{"gateway.httpPort=18080"}, want: []string{"gateway.httpPort"}},
+		{name: "storage", setFlags: []string{"storage.ns=other"}, want: []string{"storage.ns"}},
+		{name: "console", setFlags: []string{"console.port=18081"}, want: []string{"console.port"}},
+		{name: "values", file: "values:\n  feature:\n    enabled: false\n", want: []string{"values.feature.enabled"}},
+		{name: "install mode", setFlags: []string{"global.install=k8s"}, want: []string{"global.install"}},
+		{name: "version", setFlags: []string{"higressVersion=9.9.9"}, want: []string{"higressVersion"}},
+		{
+			name:     "sorted paths",
+			setFlags: []string{"storage.ns=other", "gateway.httpPort=18080", "higressVersion=9.9.9"},
+			want:     []string{"gateway.httpPort", "higressVersion", "storage.ns"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			overlay, err := GetProfileOverlay(tt.file, tt.setFlags)
+			if err != nil {
+				t.Fatalf("GetProfileOverlay() error = %v", err)
+			}
+			got, err := UnsupportedLocalDockerUpgradeOverlayPaths(baseline, overlay)
+			if err != nil {
+				t.Fatalf("UnsupportedLocalDockerUpgradeOverlayPaths() error = %v", err)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("UnsupportedLocalDockerUpgradeOverlayPaths() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/hgctl/pkg/helm/common_test.go
+++ b/hgctl/pkg/helm/common_test.go
@@ -1,3 +1,17 @@
+// Copyright (c) 2022 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package helm
 
 import (

--- a/hgctl/pkg/upgrade.go
+++ b/hgctl/pkg/upgrade.go
@@ -74,12 +74,21 @@ func upgrade(writer io.Writer, iArgs *InstallArgs) error {
 	if err != nil {
 		return err
 	}
+	overlayYAML, err := helm.GetProfileOverlay(valuesOverlay, setFlags)
+	if err != nil {
+		return err
+	}
 
 	profileContext := promptProfileContexts(writer, profileContexts)
 
 	_, profile, err := helm.GenProfileFromProfileContent(util.ToYAML(profileContext.Profile), valuesOverlay, setFlags)
 	if err != nil {
 		return err
+	}
+	if profileContext.Profile.Global.Install == helm.InstallLocalDocker {
+		if err := validateLocalDockerUpgradeOverlay(profileContext.Profile, overlayYAML); err != nil {
+			return err
+		}
 	}
 
 	fmt.Fprintf(writer, "\n🧐 Validating Profile: \"%s\" \n", profileContext.PathOrName)
@@ -102,6 +111,17 @@ func upgrade(writer io.Writer, iArgs *InstallArgs) error {
 		_ = os.Remove(oldProfileName)
 	}
 
+	return nil
+}
+
+func validateLocalDockerUpgradeOverlay(baseline *helm.Profile, overlayYAML string) error {
+	unsupported, err := helm.UnsupportedLocalDockerUpgradeOverlayPaths(baseline, overlayYAML)
+	if err != nil {
+		return err
+	}
+	if len(unsupported) > 0 {
+		return fmt.Errorf("local-docker upgrade does not support overlay fields: %s", strings.Join(unsupported, ", "))
+	}
 	return nil
 }
 

--- a/hgctl/pkg/upgrade.go
+++ b/hgctl/pkg/upgrade.go
@@ -33,6 +33,12 @@ type upgradeArgs struct {
 	*InstallArgs
 }
 
+var (
+	getAllProfilesForUpgrade = getAllProfiles
+	promptUpgradeForUpgrade  = promptUpgrade
+	newInstallerForUpgrade   = installer.NewInstaller
+)
+
 func addUpgradeFlags(cmd *cobra.Command, args *upgradeArgs) {
 	cmd.PersistentFlags().StringSliceVarP(&args.InFilenames, "filename", "f", nil, filenameFlagHelpStr)
 	cmd.PersistentFlags().StringArrayVarP(&args.Set, "set", "s", nil, setFlagHelpStr)
@@ -64,7 +70,7 @@ func newUpgradeCmd() *cobra.Command {
 func upgrade(writer io.Writer, iArgs *InstallArgs) error {
 	setFlags := applyFlagAliases(iArgs.Set, iArgs.ManifestsPath)
 	fmt.Fprintf(writer, "⌛️ Checking higress installed profiles...\n")
-	profileContexts, _ := getAllProfiles()
+	profileContexts, _ := getAllProfilesForUpgrade()
 	if len(profileContexts) == 0 {
 		fmt.Fprintf(writer, "\nHigress hasn't been installed yet!\n")
 		return nil
@@ -97,7 +103,7 @@ func upgrade(writer io.Writer, iArgs *InstallArgs) error {
 		return err
 	}
 
-	if !promptUpgrade(writer) {
+	if !promptUpgradeForUpgrade(writer) {
 		return nil
 	}
 
@@ -142,7 +148,7 @@ func promptUpgrade(writer io.Writer) bool {
 }
 
 func upgradeManifests(profile *helm.Profile, writer io.Writer, devel bool) error {
-	installer, err := installer.NewInstaller(profile, writer, false, devel, installer.UpgradeInstallerMode)
+	installer, err := newInstallerForUpgrade(profile, writer, false, devel, installer.UpgradeInstallerMode)
 	if err != nil {
 		return err
 	}

--- a/hgctl/pkg/upgrade_test.go
+++ b/hgctl/pkg/upgrade_test.go
@@ -1,0 +1,21 @@
+package hgctl
+
+import (
+	"testing"
+
+	"github.com/alibaba/higress/hgctl/pkg/helm"
+)
+
+func TestValidateLocalDockerUpgradeOverlay(t *testing.T) {
+	baseline := &helm.Profile{
+		Global:  helm.ProfileGlobal{Install: helm.InstallLocalDocker},
+		Gateway: helm.ProfileGateway{HttpPort: 80},
+	}
+
+	if err := validateLocalDockerUpgradeOverlay(baseline, "gateway:\n  httpPort: 18080\n"); err == nil || err.Error() != "local-docker upgrade does not support overlay fields: gateway.httpPort" {
+		t.Fatalf("validateLocalDockerUpgradeOverlay() error = %v", err)
+	}
+	if err := validateLocalDockerUpgradeOverlay(baseline, "charts:\n  standalone:\n    url: https://example.com/get-higress.sh\n"); err != nil {
+		t.Fatalf("validateLocalDockerUpgradeOverlay() allowed URL error = %v", err)
+	}
+}

--- a/hgctl/pkg/upgrade_test.go
+++ b/hgctl/pkg/upgrade_test.go
@@ -17,6 +17,7 @@ package hgctl
 import (
 	"fmt"
 	"io"
+	"strings"
 	"testing"
 
 	"github.com/alibaba/higress/hgctl/pkg/helm"
@@ -66,40 +67,53 @@ func newLocalDockerProfile(installPackagePath string) *helm.Profile {
 }
 
 func TestUpgradeRejectsLocalDockerOverlayBeforeInstallerConstruction(t *testing.T) {
-	originalProfiles := getAllProfilesForUpgrade
-	originalPrompt := promptUpgradeForUpgrade
-	originalNewInstaller := newInstallerForUpgrade
-	t.Cleanup(func() {
-		getAllProfilesForUpgrade = originalProfiles
-		promptUpgradeForUpgrade = originalPrompt
-		newInstallerForUpgrade = originalNewInstaller
-	})
-
-	baseline := newLocalDockerProfile(t.TempDir())
-	getAllProfilesForUpgrade = func() ([]*installer.ProfileContext, error) {
-		return []*installer.ProfileContext{{Profile: baseline}}, nil
+	tests := []struct {
+		name      string
+		set       string
+		wantField string
+	}{
+		{name: "gateway setting", set: "gateway.httpPort=18080", wantField: "gateway.httpPort"},
+		{name: "higress version", set: "higressVersion=2.2.5", wantField: "higressVersion"},
 	}
 
-	prompted := false
-	promptUpgradeForUpgrade = func(io.Writer) bool {
-		prompted = true
-		return true
-	}
-	constructed := false
-	newInstallerForUpgrade = func(*helm.Profile, io.Writer, bool, bool, installer.InstallerMode) (installer.Installer, error) {
-		constructed = true
-		return &recordingUpgradeInstaller{}, nil
-	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			originalProfiles := getAllProfilesForUpgrade
+			originalPrompt := promptUpgradeForUpgrade
+			originalNewInstaller := newInstallerForUpgrade
+			t.Cleanup(func() {
+				getAllProfilesForUpgrade = originalProfiles
+				promptUpgradeForUpgrade = originalPrompt
+				newInstallerForUpgrade = originalNewInstaller
+			})
 
-	err := upgrade(io.Discard, &InstallArgs{Set: []string{"gateway.httpPort=18080"}})
-	if err == nil {
-		t.Fatal("upgrade() error = nil, want unsupported overlay rejection")
-	}
-	if prompted {
-		t.Fatal("upgrade confirmation was reached after overlay rejection")
-	}
-	if constructed {
-		t.Fatal("installer was constructed after overlay rejection")
+			baseline := newLocalDockerProfile(t.TempDir())
+			getAllProfilesForUpgrade = func() ([]*installer.ProfileContext, error) {
+				return []*installer.ProfileContext{{Profile: baseline}}, nil
+			}
+
+			prompted := false
+			promptUpgradeForUpgrade = func(io.Writer) bool {
+				prompted = true
+				return true
+			}
+			constructed := false
+			newInstallerForUpgrade = func(*helm.Profile, io.Writer, bool, bool, installer.InstallerMode) (installer.Installer, error) {
+				constructed = true
+				return &recordingUpgradeInstaller{}, nil
+			}
+
+			err := upgrade(io.Discard, &InstallArgs{Set: []string{tt.set}})
+			if err == nil || !strings.Contains(err.Error(), tt.wantField) {
+				t.Fatalf("upgrade() error = %v, want unsupported field %q", err, tt.wantField)
+			}
+			if prompted {
+				t.Fatal("upgrade confirmation was reached after overlay rejection")
+			}
+			if constructed {
+				t.Fatal("installer was constructed after overlay rejection")
+			}
+		})
 	}
 }
 

--- a/hgctl/pkg/upgrade_test.go
+++ b/hgctl/pkg/upgrade_test.go
@@ -1,3 +1,17 @@
+// Copyright (c) 2022 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package hgctl
 
 import (

--- a/hgctl/pkg/upgrade_test.go
+++ b/hgctl/pkg/upgrade_test.go
@@ -15,9 +15,12 @@
 package hgctl
 
 import (
+	"fmt"
+	"io"
 	"testing"
 
 	"github.com/alibaba/higress/hgctl/pkg/helm"
+	"github.com/alibaba/higress/hgctl/pkg/installer"
 )
 
 func TestValidateLocalDockerUpgradeOverlay(t *testing.T) {
@@ -31,5 +34,116 @@ func TestValidateLocalDockerUpgradeOverlay(t *testing.T) {
 	}
 	if err := validateLocalDockerUpgradeOverlay(baseline, "charts:\n  standalone:\n    url: https://example.com/get-higress.sh\n"); err != nil {
 		t.Fatalf("validateLocalDockerUpgradeOverlay() allowed URL error = %v", err)
+	}
+}
+
+type recordingUpgradeInstaller struct {
+	upgraded bool
+}
+
+func (i *recordingUpgradeInstaller) Install() error   { return nil }
+func (i *recordingUpgradeInstaller) UnInstall() error { return nil }
+func (i *recordingUpgradeInstaller) Upgrade() error {
+	i.upgraded = true
+	return nil
+}
+
+func newLocalDockerProfile(installPackagePath string) *helm.Profile {
+	return &helm.Profile{
+		InstallPackagePath: installPackagePath,
+		Global:             helm.ProfileGlobal{Install: helm.InstallLocalDocker},
+		Console:            helm.ProfileConsole{Port: 8001},
+		Gateway: helm.ProfileGateway{
+			HttpPort:    80,
+			HttpsPort:   443,
+			MetricsPort: 15020,
+		},
+		Storage: helm.ProfileStorage{
+			Url: "file:///tmp/higress-storage",
+			Ns:  "higress-system",
+		},
+	}
+}
+
+func TestUpgradeRejectsLocalDockerOverlayBeforeInstallerConstruction(t *testing.T) {
+	originalProfiles := getAllProfilesForUpgrade
+	originalPrompt := promptUpgradeForUpgrade
+	originalNewInstaller := newInstallerForUpgrade
+	t.Cleanup(func() {
+		getAllProfilesForUpgrade = originalProfiles
+		promptUpgradeForUpgrade = originalPrompt
+		newInstallerForUpgrade = originalNewInstaller
+	})
+
+	baseline := newLocalDockerProfile(t.TempDir())
+	getAllProfilesForUpgrade = func() ([]*installer.ProfileContext, error) {
+		return []*installer.ProfileContext{{Profile: baseline}}, nil
+	}
+
+	prompted := false
+	promptUpgradeForUpgrade = func(io.Writer) bool {
+		prompted = true
+		return true
+	}
+	constructed := false
+	newInstallerForUpgrade = func(*helm.Profile, io.Writer, bool, bool, installer.InstallerMode) (installer.Installer, error) {
+		constructed = true
+		return &recordingUpgradeInstaller{}, nil
+	}
+
+	err := upgrade(io.Discard, &InstallArgs{Set: []string{"gateway.httpPort=18080"}})
+	if err == nil {
+		t.Fatal("upgrade() error = nil, want unsupported overlay rejection")
+	}
+	if prompted {
+		t.Fatal("upgrade confirmation was reached after overlay rejection")
+	}
+	if constructed {
+		t.Fatal("installer was constructed after overlay rejection")
+	}
+}
+
+func TestUpgradeAllowsLocalDockerOperationalInputs(t *testing.T) {
+	tests := []struct {
+		name string
+		set  []string
+	}{
+		{name: "no overlay"},
+		{name: "install package path", set: []string{"installPackagePath=%s"}},
+		{name: "standalone URL", set: []string{"charts.standalone.url=https://example.com/get-higress.sh"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			originalProfiles := getAllProfilesForUpgrade
+			originalPrompt := promptUpgradeForUpgrade
+			originalNewInstaller := newInstallerForUpgrade
+			t.Cleanup(func() {
+				getAllProfilesForUpgrade = originalProfiles
+				promptUpgradeForUpgrade = originalPrompt
+				newInstallerForUpgrade = originalNewInstaller
+			})
+
+			baseline := newLocalDockerProfile(t.TempDir())
+			getAllProfilesForUpgrade = func() ([]*installer.ProfileContext, error) {
+				return []*installer.ProfileContext{{Profile: baseline}}, nil
+			}
+			promptUpgradeForUpgrade = func(io.Writer) bool { return true }
+			fakeInstaller := &recordingUpgradeInstaller{}
+			newInstallerForUpgrade = func(*helm.Profile, io.Writer, bool, bool, installer.InstallerMode) (installer.Installer, error) {
+				return fakeInstaller, nil
+			}
+
+			set := tt.set
+			if tt.name == "install package path" {
+				set = []string{fmt.Sprintf(tt.set[0], t.TempDir())}
+			}
+			if err := upgrade(io.Discard, &InstallArgs{Set: set}); err != nil {
+				t.Fatalf("upgrade() error = %v", err)
+			}
+			if !fakeInstaller.upgraded {
+				t.Fatal("installer Upgrade() was not called for an allowed local-docker input")
+			}
+		})
 	}
 }


### PR DESCRIPTION
## I. Summary

Reject local-docker upgrade overlays that the standalone `-u` updater cannot
consume. The guard retains caller intent before generated Profile defaults,
compares it structurally against the selected stored Profile, and returns a
stable list of unsupported dot-separated paths before confirmation or installer
construction. `installPackagePath` and `charts.standalone.url` remain allowed.

This intentionally changes unsupported overlays from silent false-success to a
pre-mutation error. It does not persist execution overlays or include #4416's
version-only metadata synchronization.

## II. Related issue

Fixes #4422

Related to #4416

## III. Change type

- [x] Bug fix
- [ ] Feature or enhancement
- [ ] Documentation or configuration only
- [x] Refactoring, tests, or maintenance

## IV. Agent participation and issue-spec gate

- [ ] **No agent participation:** This PR is human-only.
- [ ] **Trivial agent-use exception:** Agent use was limited to spelling,
      punctuation, whitespace, or formatting with no substantive choice or
      behavioral effect; the explanation is below.
- [x] **Material agent participation:** An AI or coding agent materially
      participated in analysis, design, implementation, testing, or PR
      preparation.

- [x] **Before implementation began:** A Higress maintainer had approved the
      Proposal and Design Issues, and authorized implementation TASKs linked the
      work to the applicable SPECs.
- [x] **Before verification began:** The Design contained a concrete
      Verification Plan.
- [x] **Before requesting maintainer review or acceptance:** Applicable
      implementation and verification TASKs were `done` with exact commands,
      results, evidence links, and hashes.

- [x] Complete: all three timed obligations above were satisfied.
- [ ] Noncompliant: one or more obligations were not satisfied; explain below.
- [ ] N/A because the PR is human-only or qualifies for the trivial exception.

**Gate-status explanation (or N/A):** Complete. TASK-4532002 now records both
the command-level mutation-boundary fake and a controlled temporary-home,
loopback-updater red/green run at the exact head.

**Trivial-exception explanation (or N/A):** N/A.

**Approved Proposal Issue URL (or N/A with explanation):**
https://github.com/higress-group/higress/issues/4422

**Approved Design Issue URL (or N/A with explanation):**
https://github.com/higress-group/higress/issues/4532

**Applicable SPEC (or N/A with explanation):**
SPEC-4422001: https://github.com/higress-group/higress/issues/4422#issuecomment-5250076334

**Maintainer approval link(s) (or N/A with explanation):**
https://github.com/higress-group/higress/issues/4532#issuecomment-5301471404

**Authorized implementation TASK link(s) (or N/A with explanation):**
https://github.com/higress-group/higress/issues/4532#issuecomment-5306372929

**Verification Plan and verification TASK/evidence link(s) (or N/A with explanation):**
https://github.com/higress-group/higress/issues/4532#issuecomment-5306373240

## V. Testing and verification

**Test and deterministic rerun commands (or N/A with explanation):**

```text
cd hgctl && go test ./pkg/helm ./pkg -run 'Test(UnsupportedLocalDockerUpgradeOverlayPaths|ValidateLocalDockerUpgradeOverlay|UpgradeRejectsLocalDockerOverlayBeforeInstallerConstruction|UpgradeAllowsLocalDockerOperationalInputs)$' -count=1
cd hgctl && go test ./pkg/installer -count=1
cd hgctl && go test ./... -count=1
git diff --check aae6fbce36a2d1dd7afff007a265ecbebdd8a6f1...3100a8c8c8b3f33c8b7b5933b513c6588474d297
```

The first, second, and diff commands pass. The full `hgctl` suite has two
pre-existing failures, reproduced unchanged on the base revision: a
`pkg/plugin/types` vet diagnostic and `pkg/util/TestOverlayYAML/blank`.

**Environment and configuration (or N/A with explanation):** macOS local Go toolchain; controlled temporary `$HOME`, loopback HTTP updater stub, Docker read-only `ps` check, and an isolated install path. The stub accepts only `-u`, does not invoke Docker, and preserves the existing `VERSION`, so no restart path is entered.

**Exact tested revision, version, image tag/digest, manifests, and values (or N/A with explanation):**
`3100a8c8c8b3f33c8b7b5933b513c6588474d297`; no image, manifest, or values change.

**Baseline reproduction evidence for bug fixes (or N/A with explanation):** The pre-fix path generated an overlaid Profile then invoked standalone `-u`, which consumes neither ordinary Profile settings nor Helm values. The new focused tests assert rejected paths and the deterministic error before installer construction.

**Fixed-version verification evidence for bug fixes (or N/A with explanation):** The focused command-level test rejects both gateway and `higressVersion` overlays before confirmation or installer construction, while no-overlay and the two allowed inputs still reach Upgrade. TASK-4532002 records a controlled temporary-home, loopback-updater red/green run: red produces no fetch, updater artifact, restart artifact, or Profile digest/mtime change; green invokes only the pinned stub with `-u` and keeps the Profile unchanged.

**Wasm source revision and SHA-256 (or N/A with explanation):** N/A.

## VI. Special notes for reviewers

Review focus: caller-intent capture before defaulting, the exact two-field
allowlist, and the controlled red/green transcript linked from TASK-4532002.

## VII. AI coding disclosure

**Tool(s) used (or N/A):** Codex.

### Prompts or instructions

Implement the maintainer-approved Design for #4532/#4422, including structured
pre-mutation local-docker overlay rejection, deterministic tests, DCO, and
issue-spec TASK evidence.

### AI-assisted work summary

The tool inspected the upgrade and standalone paths, added the structured
overlay diff and command guard, wrote focused regression tests, ran local
validation, reproduced baseline suite failures, and prepared this draft PR.