### PR TITLE
fix(hgctl): fail closed on Helm ownership errors

### DIFF
--- a/hgctl/pkg/installer/helm_agent.go
+++ b/hgctl/pkg/installer/helm_agent.go
@@ -42,13 +42,27 @@ type HelmAgent struct {
 	quiet          bool
 }
 
-func NewHelmAgent(profile *helm.Profile, writer io.Writer, quiet bool) *HelmAgent {
-	return &HelmAgent{
+// HelmAgentOption configures a HelmAgent.
+type HelmAgentOption func(*HelmAgent)
+
+// WithHelmBinaryName overrides the Helm executable used by the agent.
+func WithHelmBinaryName(name string) HelmAgentOption {
+	return func(agent *HelmAgent) {
+		agent.helmBinaryName = name
+	}
+}
+
+func NewHelmAgent(profile *helm.Profile, writer io.Writer, quiet bool, opts ...HelmAgentOption) *HelmAgent {
+	agent := &HelmAgent{
 		profile:        profile,
 		writer:         writer,
 		helmBinaryName: "helm",
 		quiet:          quiet,
 	}
+	for _, opt := range opts {
+		opt(agent)
+	}
+	return agent
 }
 
 func (h *HelmAgent) IsHigressInstalled() (bool, error) {
@@ -69,25 +83,21 @@ func (h *HelmAgent) IsHigressInstalled() (bool, error) {
 	cmd.Stderr = &stderr
 
 	if err := cmd.Start(); err != nil {
-		return false, nil
+		return false, fmt.Errorf("start helm ownership check: %w", err)
 	}
 
-	done := make(chan error, 1)
-	go func() {
-		done <- cmd.Wait()
-	}()
-
-	select {
-	case err := <-done:
-		if err == nil {
-			content := out.String()
-			if !h.quiet {
-				fmt.Fprintf(h.writer, "\n%s\n", content)
-			}
-			if strings.Contains(content, "deployed") {
-				return true, nil
-			}
+	if err := cmd.Wait(); err != nil {
+		if message := strings.TrimSpace(stderr.String()); message != "" {
+			return false, fmt.Errorf("helm ownership check failed: %w: %s", err, message)
 		}
+		return false, fmt.Errorf("helm ownership check failed: %w", err)
+	}
+	content := out.String()
+	if !h.quiet {
+		fmt.Fprintf(h.writer, "\n%s\n", content)
+	}
+	if strings.Contains(content, "deployed") {
+		return true, nil
 	}
 	return false, nil
 }

--- a/hgctl/pkg/installer/helm_agent_test.go
+++ b/hgctl/pkg/installer/helm_agent_test.go
@@ -1,3 +1,17 @@
+// Copyright (c) 2022 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package installer
 
 import (

--- a/hgctl/pkg/installer/helm_agent_test.go
+++ b/hgctl/pkg/installer/helm_agent_test.go
@@ -1,0 +1,75 @@
+package installer
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/alibaba/higress/hgctl/pkg/helm"
+)
+
+func TestHelmAgentIsHigressInstalled(t *testing.T) {
+	profile := &helm.Profile{Global: helm.ProfileGlobal{Namespace: "higress-system"}}
+	tests := []struct {
+		name          string
+		mode          string
+		wantInstalled bool
+		wantErr       string
+	}{
+		{name: "missing binary", mode: "missing", wantErr: "start helm ownership check"},
+		{name: "command failure", mode: "failure", wantErr: "helm ownership check failed"},
+		{name: "not installed", mode: "absent"},
+		{name: "deployed release", mode: "deployed", wantInstalled: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			binary := os.Args[0]
+			if tt.mode == "missing" {
+				binary = "helm-not-found-for-test"
+			} else {
+				t.Setenv("HGCTL_HELM_TEST_MODE", tt.mode)
+			}
+			agent := NewHelmAgent(profile, &bytes.Buffer{}, true, WithHelmBinaryName(binary))
+			installed, err := agent.IsHigressInstalled()
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("IsHigressInstalled() error = %v, want substring %q", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("IsHigressInstalled() error = %v", err)
+			}
+			if installed != tt.wantInstalled {
+				t.Fatalf("IsHigressInstalled() = %t, want %t", installed, tt.wantInstalled)
+			}
+		})
+	}
+}
+
+func TestMain(m *testing.M) {
+	mode := os.Getenv("HGCTL_HELM_TEST_MODE")
+	if mode != "" {
+		runHelmHelper(mode)
+		return
+	}
+	os.Exit(m.Run())
+}
+
+func runHelmHelper(mode string) {
+	switch mode {
+	case "failure":
+		fmt.Fprint(os.Stderr, "helm cluster access failed")
+		os.Exit(1)
+	case "absent":
+		fmt.Fprint(os.Stdout, "NAME\tNAMESPACE\tREVISION\tUPDATED\tSTATUS\tCHART\tAPP VERSION\n")
+	case "deployed":
+		fmt.Fprint(os.Stdout, "higress\thigress-system\t1\t2026-01-01\tdeployed\thigress\t2.2.4\n")
+	default:
+		fmt.Fprintf(os.Stderr, "unknown test mode %q", mode)
+		os.Exit(2)
+	}
+}

--- a/hgctl/pkg/installer/installer_k8s.go
+++ b/hgctl/pkg/installer/installer_k8s.go
@@ -35,13 +35,25 @@ type K8sInstaller struct {
 	profile      *helm.Profile
 	writer       io.Writer
 	profileStore ProfileStore
+	helmChecker  helmOwnershipChecker
+}
+
+type helmOwnershipChecker interface {
+	IsHigressInstalled() (bool, error)
 }
 
 func (o *K8sInstaller) Install() error {
 	// check if higress is installed by helm
 	fmt.Fprintf(o.writer, "\n⌛️ Detecting higress installed by helm or not... \n\n")
-	helmAgent := NewHelmAgent(o.profile, o.writer, false)
-	if helmInstalled, _ := helmAgent.IsHigressInstalled(); helmInstalled {
+	helmChecker := o.helmChecker
+	if helmChecker == nil {
+		helmChecker = NewHelmAgent(o.profile, o.writer, false)
+	}
+	helmInstalled, err := helmChecker.IsHigressInstalled()
+	if err != nil {
+		return fmt.Errorf("check Higress Helm ownership: %w", err)
+	}
+	if helmInstalled {
 		fmt.Fprintf(o.writer, "\n🧐 You have already installed higress by helm, please use \"helm upgrade\" to upgrade higress!\n")
 		return nil
 	}

--- a/hgctl/pkg/installer/installer_k8s_test.go
+++ b/hgctl/pkg/installer/installer_k8s_test.go
@@ -1,3 +1,17 @@
+// Copyright (c) 2022 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package installer
 
 import (

--- a/hgctl/pkg/installer/installer_k8s_test.go
+++ b/hgctl/pkg/installer/installer_k8s_test.go
@@ -1,0 +1,59 @@
+package installer
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	"github.com/alibaba/higress/hgctl/pkg/helm"
+)
+
+type failingHelmOwnershipChecker struct{ err error }
+
+func (f failingHelmOwnershipChecker) IsHigressInstalled() (bool, error) { return false, f.err }
+
+type recordingComponent struct{ run bool }
+
+func (c *recordingComponent) ComponentName() ComponentName    { return Higress }
+func (c *recordingComponent) Namespace() string               { return "higress-system" }
+func (c *recordingComponent) Enabled() bool                   { return true }
+func (c *recordingComponent) Run() error                      { c.run = true; return nil }
+func (c *recordingComponent) RenderManifest() (string, error) { return "", nil }
+
+type recordingProfileStore struct{ saved bool }
+
+func (s *recordingProfileStore) Save(*helm.Profile) (string, error)   { s.saved = true; return "", nil }
+func (s *recordingProfileStore) List() ([]*ProfileContext, error)     { return nil, nil }
+func (s *recordingProfileStore) Delete(*helm.Profile) (string, error) { return "", nil }
+
+func TestK8sInstallerOwnershipCheckFailureStopsMutation(t *testing.T) {
+	for _, upgrade := range []bool{false, true} {
+		t.Run(map[bool]string{false: "install", true: "upgrade"}[upgrade], func(t *testing.T) {
+			component := &recordingComponent{}
+			store := &recordingProfileStore{}
+			installer := &K8sInstaller{
+				profile:      &helm.Profile{Global: helm.ProfileGlobal{Install: helm.InstallK8s}},
+				writer:       &bytes.Buffer{},
+				components:   map[ComponentName]Component{Higress: component},
+				profileStore: store,
+				helmChecker:  failingHelmOwnershipChecker{err: errors.New("helm unavailable")},
+			}
+
+			var err error
+			if upgrade {
+				err = installer.Upgrade()
+			} else {
+				err = installer.Install()
+			}
+			if err == nil {
+				t.Fatal("Install() error = nil, want ownership-check failure")
+			}
+			if component.run {
+				t.Fatal("component Run() was called after ownership-check failure")
+			}
+			if store.saved {
+				t.Fatal("ProfileStore.Save() was called after ownership-check failure")
+			}
+		})
+	}
+}


### PR DESCRIPTION
## I. Summary

Make hgctl fail closed when its Helm ownership query cannot execute or exits
unsuccessfully. `K8sInstaller.Install` now returns that error before component
execution, rendering, Kubernetes apply, or Profile persistence; `Upgrade`
remains covered through its existing delegation to `Install`.

The Helm query arguments and deployed-release matching behavior are unchanged.
Uninstall is unchanged.

## II. Related issue

Fixes #4427

## III. Change type

- [x] Bug fix
- [ ] Feature or enhancement
- [ ] Documentation or configuration only
- [x] Refactoring, tests, or maintenance

## IV. Agent participation and issue-spec gate

- [ ] **No agent participation:** This PR is human-only.
- [ ] **Trivial agent-use exception:** Agent use was limited to spelling,
      punctuation, whitespace, or formatting with no substantive choice or
      behavioral effect; the explanation is below.
- [x] **Material agent participation:** An AI or coding agent materially
      participated in analysis, design, implementation, testing, or PR
      preparation.

- [x] **Before implementation began:** A Higress maintainer had approved the
      Proposal and Design Issues, and authorized implementation TASKs linked the
      work to the applicable SPECs.
- [x] **Before verification began:** The Design contained a concrete
      Verification Plan.
- [x] **Before requesting maintainer review or acceptance:** Applicable
      implementation and verification TASKs were `done` with exact commands,
      results, evidence links, and hashes.

- [x] Complete: all three timed obligations above were satisfied.
- [ ] Noncompliant: one or more obligations were not satisfied; explain below.
- [ ] N/A because the PR is human-only or qualifies for the trivial exception.

**Gate-status explanation (or N/A):** Complete. TASK-4533001 and TASK-4533002
record the exact head, commands, results, and pre-existing full-suite failures.

**Trivial-exception explanation (or N/A):** N/A.

**Approved Proposal Issue URL (or N/A with explanation):**
https://github.com/higress-group/higress/issues/4427

**Approved Design Issue URL (or N/A with explanation):**
https://github.com/higress-group/higress/issues/4533

**Applicable SPEC (or N/A with explanation):**
SPEC-4427001: https://github.com/higress-group/higress/issues/4427#issuecomment-5251327762

**Maintainer approval link(s) (or N/A with explanation):**
https://github.com/higress-group/higress/issues/4533#issuecomment-5301471468

**Authorized implementation TASK link(s) (or N/A with explanation):**
https://github.com/higress-group/higress/issues/4533#issuecomment-5306373479

**Verification Plan and verification TASK/evidence link(s) (or N/A with explanation):**
https://github.com/higress-group/higress/issues/4533#issuecomment-5306373672

## V. Testing and verification

**Test and deterministic rerun commands (or N/A with explanation):**

```text
cd hgctl && go test ./pkg/installer -count=1
cd hgctl && go test ./... -count=1
git diff --check 7fd8dd9843284e08e1f85c581e796fc60586e887...10b412ec61335a4e8f04a3eca581fd64ab501936
```

The installer suite passes. It deterministically exercises Helm unavailable,
non-zero Helm exit, confirmed absence, and deployed release; it also proves
both install and upgrade avoid component `Run` and Profile save on lookup error.
The full suite has two pre-existing failures reproduced unchanged on the base:
the `pkg/plugin/types` vet diagnostic and `pkg/util/TestOverlayYAML/blank`.

**Environment and configuration (or N/A with explanation):** macOS local Go toolchain; fake test-process Helm binary, no live cluster.

**Exact tested revision, version, image tag/digest, manifests, and values (or N/A with explanation):**
`10b412ec61335a4e8f04a3eca581fd64ab501936`; no image, manifest, or values change.

**Baseline reproduction evidence for bug fixes (or N/A with explanation):** Before this change, Helm command-start and non-zero-exit failures returned `(false, nil)`, so K8s installation proceeded. The regression tests simulate those two outcomes and assert no mutation boundary is crossed.

**Fixed-version verification evidence for bug fixes (or N/A with explanation):** TASK-4533002 records passing installer tests and the full-suite baseline comparison at the exact head.

**Wasm source revision and SHA-256 (or N/A with explanation):** N/A.

## VI. Special notes for reviewers

Review the intentional availability prerequisite: Kubernetes mutation is now
blocked while Helm ownership is unknown, but confirmed absence still proceeds.

## VII. AI coding disclosure

**Tool(s) used (or N/A):** Codex.

### Prompts or instructions

Implement the maintainer-approved Design for #4533/#4427 with injectable Helm
command testing, mutation-stop regression coverage, DCO, and issue-spec TASK
evidence.

### AI-assisted work summary

The tool mapped the only ownership-check call site, returned contextual command
errors, injected the checker for installer testing, added deterministic fake
Helm outcomes and no-mutation tests, ran validation, and prepared this PR.