### PR TITLE
fix(ai-proxy): retry/health check 未应用 providerDomain || fix(ai-proxy): retry/health check providerDomain is not applied

### DIFF
--- a/plugins/wasm-go/extensions/ai-proxy/provider/failover.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/failover.go
@@ -233,11 +233,6 @@ func (c *ProviderConfig) transformRequestHeadersAndBody(ctx wrapper.HttpContext,
 		handler.TransformRequestHeaders(ctx, ApiNameChatCompletion, modifiedHeaders)
 	}
 
-	// Apply providerBasePath if configured
-	if c.providerBasePath != "" {
-		modifiedHeaders.Set(":path", c.applyProviderBasePath(modifiedHeaders.Get(":path")))
-	}
-
 	var err error
 	if handler, ok := activeProvider.(TransformRequestBodyHandler); ok {
 		body, err = handler.TransformRequestBody(ctx, ApiNameChatCompletion, body)
@@ -248,6 +243,16 @@ func (c *ProviderConfig) transformRequestHeadersAndBody(ctx wrapper.HttpContext,
 	}
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to transform request body: %v", err)
+	}
+
+	// Apply providerBasePath and providerDomain after all provider transforms so
+	// that providers which overwrite path/host in TransformRequestBodyHeaders
+	// (e.g. Gemini for path, Deepl/Triton for host) do not undo the overrides.
+	if c.providerBasePath != "" {
+		modifiedHeaders.Set(":path", c.applyProviderBasePath(modifiedHeaders.Get(":path")))
+	}
+	if c.providerDomain != "" {
+		util.OverwriteRequestHostHeader(modifiedHeaders, c.providerDomain)
 	}
 
 	return modifiedHeaders, body, nil

--- a/plugins/wasm-go/extensions/ai-proxy/provider/provider.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/provider.go
@@ -1296,6 +1296,10 @@ func (c *ProviderConfig) handleRequestBody(
 		if c.providerBasePath != "" {
 			headers.Set(":path", c.applyProviderBasePath(headers.Get(":path")))
 		}
+		// Apply providerDomain if configured (overrides any domain set by the provider in TransformRequestBodyHeaders)
+		if c.providerDomain != "" {
+			util.OverwriteRequestHostHeader(headers, c.providerDomain)
+		}
 		util.ReplaceRequestHeaders(headers)
 	} else {
 		body, err = c.defaultTransformRequestBody(ctx, apiName, body)

--- a/plugins/wasm-go/extensions/ai-proxy/provider/provider_test.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/provider_test.go
@@ -1,9 +1,12 @@
 package provider
 
 import (
+	"net/http"
 	"strings"
 	"testing"
 
+	"github.com/alibaba/higress/plugins/wasm-go/extensions/ai-proxy/util"
+	"github.com/higress-group/wasm-go/pkg/wrapper"
 	"github.com/stretchr/testify/assert"
 	"github.com/tidwall/gjson"
 )
@@ -820,4 +823,108 @@ func TestStripClaudeInternalMessageFields(t *testing.T) {
 	assert.Equal(t, "reasoning", gjson.GetBytes(preserved, "messages.0.reasoning_content").String())
 	assert.False(t, gjson.GetBytes(preserved, "messages.0.reasoning_signature").Exists())
 	assert.False(t, gjson.GetBytes(preserved, "messages.0.claude_content_blocks").Exists())
+}
+
+// mockProviderForTransform simulates a provider that sets :authority and :path
+// in both TransformRequestHeaders and TransformRequestBodyHeaders, like Deepl
+// or Triton which overwrite the host in the body stage.
+type mockProviderForTransform struct {
+	host       string
+	path       string
+	bodyHost   string // host set in TransformRequestBodyHeaders (empty = no overwrite)
+	bodyPath   string // path set in TransformRequestBodyHeaders (empty = no overwrite)
+}
+
+func (m *mockProviderForTransform) GetProviderType() string { return "mock" }
+
+func (m *mockProviderForTransform) TransformRequestHeaders(_ wrapper.HttpContext, _ ApiName, headers http.Header) {
+	util.OverwriteRequestHostHeader(headers, m.host)
+	if m.path != "" {
+		util.OverwriteRequestPathHeader(headers, m.path)
+	}
+}
+
+func (m *mockProviderForTransform) TransformRequestBodyHeaders(_ wrapper.HttpContext, _ ApiName, body []byte, headers http.Header) ([]byte, error) {
+	if m.bodyHost != "" {
+		util.OverwriteRequestHostHeader(headers, m.bodyHost)
+	}
+	if m.bodyPath != "" {
+		util.OverwriteRequestPathHeader(headers, m.bodyPath)
+	}
+	return body, nil
+}
+
+func TestTransformRequestHeadersAndBody_ProviderDomain(t *testing.T) {
+	t.Run("providerDomain_overrides_host_set_in_TransformRequestHeaders", func(t *testing.T) {
+		config := &ProviderConfig{
+			providerDomain: "proxy.example.com",
+		}
+		provider := &mockProviderForTransform{
+			host: "api.default.com",
+			path: "/v1/chat/completions",
+		}
+		headers := [][2]string{
+			{":authority", "gateway.local"},
+			{":path", "/v1/chat/completions"},
+		}
+		modifiedHeaders, _, err := config.transformRequestHeadersAndBody(nil, provider, headers, []byte("{}"))
+		assert.NoError(t, err)
+		assert.Equal(t, "proxy.example.com", modifiedHeaders.Get(":authority"))
+	})
+
+	t.Run("providerDomain_overrides_host_overwritten_in_TransformRequestBodyHeaders", func(t *testing.T) {
+		// Simulates Deepl/Triton which set :authority in TransformRequestBodyHeaders
+		config := &ProviderConfig{
+			providerDomain: "proxy.example.com",
+		}
+		provider := &mockProviderForTransform{
+			host:     "api.default.com",
+			bodyHost: "api.body-stage.com",
+		}
+		headers := [][2]string{
+			{":authority", "gateway.local"},
+			{":path", "/v1/chat/completions"},
+		}
+		modifiedHeaders, _, err := config.transformRequestHeadersAndBody(nil, provider, headers, []byte("{}"))
+		assert.NoError(t, err)
+		assert.Equal(t, "proxy.example.com", modifiedHeaders.Get(":authority"),
+			"providerDomain must override host set by TransformRequestBodyHeaders")
+	})
+
+	t.Run("providerDomain_and_providerBasePath_both_applied", func(t *testing.T) {
+		config := &ProviderConfig{
+			providerDomain:   "proxy.example.com",
+			providerBasePath: "/api/ai",
+		}
+		provider := &mockProviderForTransform{
+			host:     "api.default.com",
+			path:     "/v1/chat/completions",
+			bodyHost: "api.body-stage.com",
+			bodyPath: "/v1/chat/completions",
+		}
+		headers := [][2]string{
+			{":authority", "gateway.local"},
+			{":path", "/v1/chat/completions"},
+		}
+		modifiedHeaders, _, err := config.transformRequestHeadersAndBody(nil, provider, headers, []byte("{}"))
+		assert.NoError(t, err)
+		assert.Equal(t, "proxy.example.com", modifiedHeaders.Get(":authority"))
+		assert.Equal(t, "/api/ai/v1/chat/completions", modifiedHeaders.Get(":path"))
+	})
+
+	t.Run("no_providerDomain_preserves_provider_host", func(t *testing.T) {
+		config := &ProviderConfig{}
+		provider := &mockProviderForTransform{
+			host:     "api.default.com",
+			bodyHost: "api.body-stage.com",
+		}
+		headers := [][2]string{
+			{":authority", "gateway.local"},
+			{":path", "/v1/chat/completions"},
+		}
+		modifiedHeaders, _, err := config.transformRequestHeadersAndBody(nil, provider, headers, []byte("{}"))
+		assert.NoError(t, err)
+		assert.Equal(t, "api.body-stage.com", modifiedHeaders.Get(":authority"),
+			"without providerDomain, the last provider-set host should win")
+	})
 }


### PR DESCRIPTION
## I. Summary

修复 commit `228eb27e`（PR #3686）引入的 `providerDomain` 覆盖缺失：该 commit 将 `providerDomain` 处理集中到 `handleRequestHeaders`，但 ai-proxy 另外两条构建出向请求 header 的路径——`transformRequestHeadersAndBody`（retry 与 health check 共用）和 `handleRequestBody` 的 `TransformRequestBodyHeadersHandler` 分支——未同步应用 `providerDomain`，导致：

- retry（失败重试）请求绕过 `providerDomain`，直连 provider 硬编码域名；
- health check 请求同样绕过 `providerDomain`；
- Deepl/Triton 等在 body 阶段覆盖 `:authority` 的 provider，正常请求的 `providerDomain` 也会被冲掉。

改动：将 `providerDomain`/`providerBasePath` 的应用统一移到所有 provider transform（含 body 阶段）之后，并在 `handleRequestBody` body 分支补上 `providerDomain` 覆盖。无破坏性变更：`providerDomain`/`providerBasePath` 为空时行为不变。

## II. Related issue

Proposal Issue: #4544

## III. Change type

- [x] Bug fix

## IV. Agent participation and issue-spec gate

- [x] **Material agent participation:** An AI or coding agent materially participated in analysis, design, implementation, testing, or PR preparation.

- [x] **Before implementation began:** 未满足——实现先于 Proposal/Design 批准（Proposal Issue #4544 已创建，待 maintainer 批准）。
- [ ] **Before verification began:** N/A（Design 尚未批准）。
- [ ] **Before requesting maintainer review or acceptance:** N/A。

Gate status: **Noncompliant** — 实现在 Proposal/Design 批准前已完成。本 PR 提前提交以供 maintainer 并行预览修复代码，接受低 review 优先级。待 Proposal #4544 与后续 Design Issue 获批后，将补齐运行时验证 TASK 与证据。

**Approved Proposal Issue URL:** #4544（待批准）

**Approved Design Issue URL:** N/A（待 Proposal 批准后创建）

**Maintainer approval link(s):** N/A（待批准）

**Authorized implementation TASK link(s):** N/A

**Verification Plan and verification TASK/evidence link(s):** N/A（验证计划见 Design 草稿，待 Design 批准后执行）

## V. Testing and verification

**Test and deterministic rerun commands:**

```text
cd plugins/wasm-go/extensions/ai-proxy
go test -count=1 ./provider/
```

结果：全部通过，含新增 4 个回归子测试 `TestTransformRequestHeadersAndBody_ProviderDomain`。

**Environment and configuration:**

- OS: Windows (amd64)
- Go: go1.26.0
- ai-proxy 为独立 Go module（`plugins/wasm-go/extensions/ai-proxy/go.mod`，go 1.24.1）
- wasm 构建：`GOOS=wasip1 GOARCH=wasm go build -buildmode=c-shared`，成功，SHA-256 `29FA39264F27D4CD3A8AA8E77E7B2130B39A29071F2930E2E97D268528222E13`

**Exact tested revision, version, image tag/digest, manifests, and values:**

- 源码：当前工作区（fix 未提交，待本 PR 提交）

**Baseline reproduction evidence for bug fixes:**

Pending — baseline vs fixed 运行时验证（proxy-Wasm 数据通路）将在 Design Issue 批准后执行。验证计划：用 Deepl provider（body 阶段覆盖 `:authority`）配置 `providerDomain`，baseline 期望 access log `:authority=api-free.deepl.com`，fixed 期望 `=providerDomain`。

**Fixed-version verification evidence for bug fixes:**

Pending — 同上，运行时验证待执行。当前仅单元测试通过。

**Wasm source revision and SHA-256:**

- fixed wasm SHA-256: `29FA39264F27D4CD3A8AA8E77E7B2130B39A29071F2930E2E97D268528222E13`
- baseline wasm SHA-256: 待构建（验证阶段）

## VI. Special notes for reviewers

- 本 PR 为并行预览：Proposal Issue #4544 待批准，Design Issue 待创建。maintainer 可在审 issue-spec 闸门的同时直接审本 PR 代码。
- 修复逻辑：`providerDomain`/`providerBasePath` 必须在所有 provider transform（含 `TransformRequestBodyHeaders`）之后应用，否则被 Deepl/Triton（覆盖 host）、Gemini/Triton/Vertex（覆盖 path）冲掉。
- 运行时验证尚未执行，PR 暂不可合并；待 gate 解锁后补证据。

## VII. AI coding disclosure

**Tool(s) used:** Codex (GPT-5 based coding agent)

### Prompts or instructions

用户要求分析 commit `228eb27e` 的 `providerDomain` 在 retry/health check 场景的处理，端到端评估是否存在 bug，修复并准备 PR。随后选择走 issue-spec 路线 A（Proposal → Design → TASK → PR），并要求并行提 PR 关联 issue。

### AI-assisted work summary

- 分析 commit `228eb27e`，确认三条 header 构建路径中 retry/health check/body 阶段缺失 `providerDomain` 覆盖。
- 实现修复：`failover.go`（移动 override 时机至 body transform 后）、`provider.go`（body 分支补 `providerDomain`）、`provider_test.go`（4 个回归子测试）。
- 起草 Proposal Issue body 与 Design Issue body（含验证计划）。
- 本 PR 描述由 agent 撰写。
- 关键决策：override 须在 provider transform 之后应用，因部分 provider 在 body 阶段覆盖 host/path。
- 局限：运行时验证未执行；retry 路径的端到端复现依赖内部 HTTP call，本地 harness 可能难以稳定触发，以单测 + Deepl body 阶段场景为主。

<!--This is a translation content dividing line, the content below is generated by machine, please do not modify the content below-->
---
## I. Summary

Fix missing `providerDomain` coverage introduced by commit `228eb27e` (PR #3686): This commit centralizes `providerDomain` processing to `handleRequestHeaders`, but ai-proxy has two other paths to build outbound request headers - `transformRequestHeadersAndBody` (retry shared with health check) and `handleRequestBody` `TransformRequestBodyHeadersHandler` branch - `providerDomain` is not applied in sync, resulting in:

- retry (failure retry) request bypasses `providerDomain` and directly connects to the provider hard-coded domain name;
- health check requests also bypass `providerDomain`;
- Providers such as Deepl/Triton that overwrite `:authority` in the body stage will also flush out the `providerDomain` of normal requests.

Change: Move the application of `providerDomain`/`providerBasePath` to the end of all provider transforms (including the body stage), and add `providerDomain` coverage in the `handleRequestBody` body branch. No breaking changes: No change in behavior when `providerDomain`/`providerBasePath` is empty.

## II. Related issue

Proposal Issue: #4544

## III. Change type

- [x] Bug fix

## IV. Agent participation and issue-spec gate

- [x] **Material agent participation:** An AI or coding agent materially participated in analysis, design, implementation, testing, or PR preparation.

- [x] **Before implementation began:** Not met - implementation precedes Proposal/Design approval (Proposal Issue #4544 created, pending maintainer approval).
- [ ] **Before verification began:** N/A (Design has not been approved yet).
- [ ] **Before requesting maintainer review or acceptance:** N/A.

Gate status: **Noncompliant** — Implementation is complete prior to Proposal/Design approval. This PR is submitted in advance for maintainers to preview the repair code in parallel and accepts low review priority. After Proposal #4544 and subsequent Design Issues are approved, the runtime verification TASK and evidence will be completed.

**Approved Proposal Issue URL:** #4544 (pending approval)

**Approved Design Issue URL:** N/A (to be created after Proposal approval)

**Maintainer approval link(s):** N/A (pending)

**Authorized implementation TASK link(s):** N/A

**Verification Plan and verification TASK/evidence link(s):** N/A (the verification plan is in the Design draft and will be executed after Design approval)

## V. Testing and verification

**Test and deterministic rerun commands:**

```text
cd plugins/wasm-go/extensions/ai-proxy
go test -count=1 ./provider/
```

Result: All passed, including 4 new regression subtests `TestTransformRequestHeadersAndBody_ProviderDomain`.

**Environment and configuration:**

- OS: Windows (amd64)
- Go: go1.26.0
- ai-proxy is an independent Go module (`plugins/wasm-go/extensions/ai-proxy/go.mod`, go 1.24.1)
- wasm build: `GOOS=wasip1 GOARCH=wasm go build -buildmode=c-shared`, successful, SHA-256 `29FA39264F27D4CD3A8AA8E77E7B2130B39A29071F2930E2E97D268528222E13`

**Exact tested revision, version, image tag/digest, manifests, and values:**

- Source code: current workspace (fix has not been submitted, waiting for submission of this PR)

**Baseline reproduction evidence for bug fixes:**

Pending — baseline vs fixed Runtime verification (proxy-Wasm datapath) will be performed after Design Issue approval. Verification plan: Configure `providerDomain` with Deepl provider (body phase overrides `:authority`), baseline expects access log `:authority=api-free.deepl.com`, fixed expects `=providerDomain`.

**Fixed-version verification evidence for bug fixes:**

Pending — Same as above, runtime verification is pending. Currently only unit tests pass.

**Wasm source revision and SHA-256:**

- fixed wasm SHA-256: `29FA39264F27D4CD3A8AA8E77E7B2130B39A29071F2930E2E97D268528222E13`
- baseline wasm SHA-256: To be built (verification phase)

## VI. Special notes for reviewers

- This PR is a side-by-side preview: Proposal Issue #4544 is pending approval and a Design Issue is pending creation. Maintainers can review the PR code directly while reviewing the issue-spec gate.
- Fix logic: `providerDomain`/`providerBasePath` must be applied after all provider transforms (including `TransformRequestBodyHeaders`), otherwise they will be washed away by Deepl/Triton (overwriting host) and Gemini/Triton/Vertex (overwriting path).
- The runtime verification has not yet been executed, and the PR cannot be merged yet; evidence will be provided after the gate is unlocked.

## VII. AI coding disclosure

**Tool(s) used:** Codex (GPT-5 based coding agent)

### Prompts or instructions

The user requested to analyze the processing of `providerDomain` of commit `228eb27e` in the retry/health check scenario, evaluate whether there are bugs end-to-end, fix it and prepare PR. Then choose issue-spec route A (Proposal → Design → TASK → PR), and ask for a PR associated issue in parallel.

### AI-assisted work summary

- Analyze commit `228eb27e` and confirm that the `providerDomain` coverage is missing in the retry/health check/body stage in the three header build paths.
- Implementation fixes: `failover.go` (move override timing to after body transform), `provider.go` (body branch adds `providerDomain`), `provider_test.go` (4 regression subtests).
- Draft Proposal Issue body and Design Issue body (including verification plan).
- This PR description was written by agent.
- Key decision: override must be applied after provider transform because some providers override host/path in the body stage.
- Limitations: Runtime verification is not performed; the end-to-end reproduction of the retry path relies on internal HTTP calls, and the local harness may be difficult to trigger stably, mainly in the single test + Deepl body stage scenario.
