### PR TITLE
feat(ext-auth): support header presence match rules

### DIFF
--- a/plugins/wasm-go/extensions/ext-auth/README.md
+++ b/plugins/wasm-go/extensions/ext-auth/README.md
@@ -20,7 +20,7 @@ description: Ext 认证插件实现了调用外部授权服务进行认证鉴权
 | ------------------------------- | ------------------ | ---- | ------ | ------------------------------------------------------------ |
 | `http_service`                  | object             | 是   | -      | 外部授权服务配置                                             |
 | `match_type`                    | string             | 否   |        | 可选 `whitelist` 或 `blacklist`                              |
-| `match_list`                    | array of MatchRule | 否   |        | 一个包含 (`match_rule_domain`, `match_rule_path`, `match_rule_type`) 的列表 |
+| `match_list`                    | array of MatchRule | 否   |        | 请求匹配规则列表，支持按域名、方法、路径和请求头是否存在进行匹配 |
 | `failure_mode_allow`            | bool               | 否   | false  | 当设置为 true 时，即使与授权服务的通信失败，或者授权服务返回了 HTTP 5xx 错误，仍会接受客户端请求 |
 | `failure_mode_allow_header_add` | bool               | 否   | false  | 当 `failure_mode_allow` 和 `failure_mode_allow_header_add` 都设置为 true 时，若与授权服务的通信失败，或授权服务返回了 HTTP 5xx 错误，那么请求头中将会添加 `x-envoy-auth-failure-mode-allowed: true` |
 | `status_on_error`               | int                | 否   | 403    | 当授权服务无法访问或状态码为 5xx 时，设置返回给客户端的 HTTP 状态码。默认状态码是 `403` |
@@ -88,6 +88,14 @@ MatchRule 类型每一项的配置字段说明，在使用 `array of MatchRule` 
 | `match_rule_method` | []string | 否   | -      | 匹配请求方法                                                 |
 | `match_rule_path`   | string   | 否   | -      | 匹配请求路径的规则                                           |
 | `match_rule_type`   | string   | 否   | -      | 匹配请求路径的规则类型，可选 `exact` , `prefix` , `suffix`, `contains`, `regex` |
+| `match_rule_headers` | array of HeaderPresenceCondition | 否 | - | 按请求头是否存在进行匹配；数组不能为空，同一规则中的所有条件必须同时满足 |
+
+`HeaderPresenceCondition` 类型每一项的配置字段说明：
+
+| 名称     | 数据类型 | 必填 | 默认值 | 描述 |
+|----------|----------|------|--------|------|
+| `name`   | string   | 是   | -      | HTTP 请求头名称，忽略大小写；同一规则中不能配置大小写不同的重复名称 |
+| `exists` | bool     | 是   | -      | `true` 表示请求头存在，`false` 表示请求头不存在；请求头值为空字符串时仍视为存在 |
 
 ### 两种 `endpoint_mode` 的区别
 
@@ -104,7 +112,7 @@ MatchRule 类型每一项的配置字段说明，在使用 `array of MatchRule` 
 
 ### 黑白名单模式
 
-支持黑白名单模式配置，默认为白名单模式，白名单为空，即所有请求都需要经过验证，匹配域名支持泛域名例如 `*.bar.com` ，匹配规则支持 `exact` , `prefix` , `suffix`, `contains`, `regex`
+支持黑白名单模式配置，默认为白名单模式，白名单为空时所有请求都需要鉴权。`whitelist` 规则匹配时跳过鉴权、不匹配时执行鉴权；`blacklist` 规则匹配时执行鉴权、不匹配时跳过鉴权。一个规则内的域名、方法、路径和请求头条件之间为 AND，`match_list` 中的规则之间为 OR。匹配域名支持 `*.bar.com` 等泛域名，路径支持 `exact`、`prefix`、`suffix`、`contains`、`regex`。`authorization_request.allowed_headers` 仅控制转发给鉴权服务的请求头，与是否调用鉴权服务无关。
 
 **白名单模式**
 
@@ -142,6 +150,10 @@ match_list:
   # 所有以 legacy.example.com 为域名的 POST 请求需要验证
   - match_rule_domain: 'legacy.example.com'
     match_rule_method: ["POST"]
+  # 所有包含 x-custom-auth 请求头的请求需要验证
+  - match_rule_headers:
+      - name: 'x-custom-auth'
+        exists: true
 ```
 
 ## 配置示例

--- a/plugins/wasm-go/extensions/ext-auth/README_EN.md
+++ b/plugins/wasm-go/extensions/ext-auth/README_EN.md
@@ -20,7 +20,7 @@ Plugin Execution Priority: `360`
 | --- | --- | --- | --- | --- |
 | `http_service` | object | Yes | - | Configuration for the external authorization service |
 | `match_type` | string | No |  | Can be `whitelist` or `blacklist` |
-| `match_list` | array of MatchRule | No |  | A list containing (`match_rule_domain`, `match_rule_path`, `match_rule_type`) |
+| `match_list` | array of MatchRule | No |  | Request matching rules for domains, methods, paths, and request-header presence |
 | `failure_mode_allow` | bool | No | false | When set to true, client requests will be accepted even if the communication with the authorization service fails or the authorization service returns an HTTP 5xx error |
 | `failure_mode_allow_header_add` | bool | No | false | When both `failure_mode_allow` and `failure_mode_allow_header_add` are set to true, if the communication with the authorization service fails or the authorization service returns an HTTP 5xx error, the `x-envoy-auth-failure-mode-allowed: true` header will be added to the request header |
 | `status_on_error` | int | No | 403 | Sets the HTTP status code returned to the client when the authorization service is inaccessible or has a 5xx status code. The default status code is `403` |
@@ -89,6 +89,14 @@ Configuration fields for each item of `MatchRule` type. When using `array of Mat
 | `match_rule_method` | []string | No | - | Matching rule for the request method |
 | `match_rule_path` | string | No | - | The rule for matching the request path |
 | `match_rule_type` | string | No | - | The type of the rule for matching the request path, can be `exact`, `prefix`, `suffix`, `contains`, `regex` |
+| `match_rule_headers` | array of HeaderPresenceCondition | No | - | Matches request-header presence; the array must not be empty and every condition in the rule must match |
+
+Configuration fields for each item of `HeaderPresenceCondition` type:
+
+| Name | Data Type | Required | Default Value | Description |
+| --- | --- | --- | --- | --- |
+| `name` | string | Yes | - | An HTTP request-header name, matched case-insensitively. Case-insensitive duplicates within one rule are not allowed |
+| `exists` | bool | Yes | - | `true` requires the header to be present and `false` requires it to be absent. A header with an empty value is still present |
 
 ### Differences between the two `endpoint_mode`
 
@@ -105,7 +113,7 @@ When `endpoint_mode` is `forward_auth`, the authentication request will use the 
 
 ### Blacklist and Whitelist Modes
 
-Supports blacklist and whitelist mode configuration. The default is the whitelist mode. If the whitelist is empty, all requests need to be verified. The matching domain supports wildcard domains such as `*.bar.com`, and the matching rule supports `exact`, `prefix`, `suffix`, `contains`, `regex`.
+Supports blacklist and whitelist modes. Whitelist is the default, and an empty whitelist sends every request to external authorization. A matching `whitelist` rule bypasses authorization, while a miss executes it; a matching `blacklist` rule executes authorization, while a miss bypasses it. Domain, method, path, and header conditions within one rule are ANDed, while entries in `match_list` are ORed. Domains support wildcards such as `*.bar.com`, and paths support `exact`, `prefix`, `suffix`, `contains`, and `regex`. `authorization_request.allowed_headers` only controls which headers are forwarded to the authorization service; it does not control whether that service is called.
 
 **Whitelist Mode**
 
@@ -143,6 +151,10 @@ match_list:
   # For the domain legacy.example.com, all POST requests need verification.
   - match_rule_domain: 'legacy.example.com'
     match_rule_method: ["POST"]
+  # Requests containing the x-custom-auth header need verification.
+  - match_rule_headers:
+      - name: 'x-custom-auth'
+        exists: true
 ```
 
 

--- a/plugins/wasm-go/extensions/ext-auth/config/config.go
+++ b/plugins/wasm-go/extensions/ext-auth/config/config.go
@@ -294,10 +294,17 @@ func parseMatchRules(json gjson.Result, config *ExtAuthConfig) error {
 			}
 		}
 
+		headerConditions, parseErr := parseHeaderConditions(value.Get("match_rule_headers"), int(key.Int()))
+		if parseErr != nil {
+			err = parseErr
+			return false // stop iterating
+		}
+
 		ruleList = append(ruleList, expr.Rule{
-			Domain: domain,
-			Method: convertToStringList(methodArray),
-			Path:   pathMatcher,
+			Domain:  domain,
+			Method:  convertToStringList(methodArray),
+			Path:    pathMatcher,
+			Headers: headerConditions,
 		})
 		return true // keep iterating
 	})
@@ -311,6 +318,68 @@ func parseMatchRules(json gjson.Result, config *ExtAuthConfig) error {
 		RuleList: ruleList,
 	}
 	return nil
+}
+
+func parseHeaderConditions(result gjson.Result, ruleIndex int) ([]expr.HeaderCondition, error) {
+	if !result.Exists() {
+		return nil, nil
+	}
+
+	fieldPath := fmt.Sprintf("match_list[%d].match_rule_headers", ruleIndex)
+	if !result.IsArray() {
+		return nil, fmt.Errorf("%s must be a non-empty array", fieldPath)
+	}
+	items := result.Array()
+	if len(items) == 0 {
+		return nil, fmt.Errorf("%s must be a non-empty array", fieldPath)
+	}
+
+	conditions := make([]expr.HeaderCondition, 0, len(items))
+	seenNames := make(map[string]struct{}, len(items))
+	for index, item := range items {
+		itemPath := fmt.Sprintf("%s[%d]", fieldPath, index)
+		nameResult := item.Get("name")
+		if !nameResult.Exists() {
+			return nil, fmt.Errorf("%s: missing required field 'name'", itemPath)
+		}
+		name := nameResult.String()
+		if nameResult.Type != gjson.String || !isValidHTTPHeaderName(name) {
+			return nil, fmt.Errorf("%s.name must be a valid non-pseudo HTTP header name", itemPath)
+		}
+		name = strings.ToLower(name)
+		if _, duplicate := seenNames[name]; duplicate {
+			return nil, fmt.Errorf("%s contains duplicate header name %q", fieldPath, name)
+		}
+
+		existsResult := item.Get("exists")
+		if !existsResult.Exists() {
+			return nil, fmt.Errorf("%s: missing required field 'exists'", itemPath)
+		}
+		if existsResult.Type != gjson.True && existsResult.Type != gjson.False {
+			return nil, fmt.Errorf("%s.exists must be a boolean", itemPath)
+		}
+
+		seenNames[name] = struct{}{}
+		conditions = append(conditions, expr.HeaderCondition{Name: name, Exists: existsResult.Bool()})
+	}
+	return conditions, nil
+}
+
+func isValidHTTPHeaderName(name string) bool {
+	if name == "" {
+		return false
+	}
+	for _, char := range []byte(name) {
+		if char >= 'a' && char <= 'z' || char >= 'A' && char <= 'Z' || char >= '0' && char <= '9' {
+			continue
+		}
+		switch char {
+		case '!', '#', '$', '%', '&', '\'', '*', '+', '-', '.', '^', '_', '`', '|', '~':
+			continue
+		}
+		return false
+	}
+	return true
 }
 
 func convertToStringMap(result gjson.Result) map[string]string {

--- a/plugins/wasm-go/extensions/ext-auth/config/match_rule_headers_test.go
+++ b/plugins/wasm-go/extensions/ext-auth/config/match_rule_headers_test.go
@@ -1,0 +1,71 @@
+package config
+
+import (
+	"fmt"
+	"testing"
+
+	"ext-auth/expr"
+
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+func parseMatchRuleConfig(ruleJSON string) (ExtAuthConfig, error) {
+	var cfg ExtAuthConfig
+	configJSON := fmt.Sprintf(`{
+		"match_type": "blacklist",
+		"match_list": [{%s}]
+	}`, ruleJSON)
+	err := parseMatchRules(gjson.Parse(configJSON), &cfg)
+	return cfg, err
+}
+
+func TestParseMatchRuleHeaders(t *testing.T) {
+	cfg, err := parseMatchRuleConfig(`"match_rule_headers": [
+		{"name": "X-Custom-Auth", "exists": true},
+		{"name": "x-skip-auth", "exists": false}
+	]`)
+
+	require.NoError(t, err)
+	require.Equal(t, []expr.HeaderCondition{
+		{Name: "x-custom-auth", Exists: true},
+		{Name: "x-skip-auth", Exists: false},
+	}, cfg.MatchRules.RuleList[0].Headers)
+}
+
+func TestParseMatchRuleHeadersOmitted(t *testing.T) {
+	cfg, err := parseMatchRuleConfig(`"match_rule_method": ["GET"]`)
+
+	require.NoError(t, err)
+	require.Nil(t, cfg.MatchRules.RuleList[0].Headers)
+}
+
+func TestParseMatchRuleHeadersRejectsInvalidConfiguration(t *testing.T) {
+	tests := []struct {
+		name      string
+		ruleJSON  string
+		errorText string
+	}{
+		{name: "empty list", ruleJSON: `"match_rule_headers": []`, errorText: "must be a non-empty array"},
+		{name: "not a list", ruleJSON: `"match_rule_headers": {}`, errorText: "must be a non-empty array"},
+		{name: "missing name", ruleJSON: `"match_rule_headers": [{"exists": true}]`, errorText: "missing required field 'name'"},
+		{name: "missing exists", ruleJSON: `"match_rule_headers": [{"name": "x-auth"}]`, errorText: "missing required field 'exists'"},
+		{name: "non-string name", ruleJSON: `"match_rule_headers": [{"name": 1, "exists": true}]`, errorText: "valid non-pseudo HTTP header name"},
+		{name: "empty name", ruleJSON: `"match_rule_headers": [{"name": "", "exists": true}]`, errorText: "valid non-pseudo HTTP header name"},
+		{name: "invalid name", ruleJSON: `"match_rule_headers": [{"name": "bad header", "exists": true}]`, errorText: "valid non-pseudo HTTP header name"},
+		{name: "pseudo header", ruleJSON: `"match_rule_headers": [{"name": ":authority", "exists": true}]`, errorText: "valid non-pseudo HTTP header name"},
+		{name: "non-boolean exists", ruleJSON: `"match_rule_headers": [{"name": "x-auth", "exists": "true"}]`, errorText: "exists must be a boolean"},
+		{
+			name:      "duplicate name ignoring case",
+			ruleJSON:  `"match_rule_headers": [{"name": "X-Auth", "exists": true}, {"name": "x-auth", "exists": false}]`,
+			errorText: `duplicate header name "x-auth"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := parseMatchRuleConfig(tt.ruleJSON)
+			require.ErrorContains(t, err, tt.errorText)
+		})
+	}
+}

--- a/plugins/wasm-go/extensions/ext-auth/expr/expr_extra_test.go
+++ b/plugins/wasm-go/extensions/ext-auth/expr/expr_extra_test.go
@@ -46,20 +46,21 @@ func TestMatchRulesDefaults_EmptyButNonNilRuleList(t *testing.T) {
 // the empty-list defaults case is an important degenerate edge.
 func TestMatchRulesDefaults_EmptyWhitelistDenies(t *testing.T) {
 	d := MatchRulesDefaults()
-	require.False(t, d.IsAllowedByMode("example.com", "GET", "/x"))
+	request := RequestAttributes{Domain: "example.com", Method: "GET", Path: "/x"}
+	require.True(t, d.Matches(request))
 }
 
-// === Module B — IsAllowedByMode default branch ==========================
+// === Module B — Matches default branch ==================================
 //
-// `default: return false` at match_rules.go:51 is unreachable through
+// `default: return true` is unreachable through
 // MatchRulesDefaults because Mode is whitelist there. A misconfigured /
-// hand-built MatchRules with an unknown mode must safely fall back to
-// "not allowed" so the request still goes through the auth server rather
-// than silently bypassing it.
+// hand-built MatchRules with an unknown mode must remain in the external
+// authorization scope rather than silently bypassing it.
 
-func TestIsAllowedByMode_UnknownModeFallsToFalse(t *testing.T) {
+func TestMatches_UnknownModeFailsClosed(t *testing.T) {
 	mr := MatchRules{Mode: "not-a-mode", RuleList: []Rule{}}
-	require.False(t, mr.IsAllowedByMode("example.com", "GET", "/x"))
+	request := RequestAttributes{Domain: "example.com", Method: "GET", Path: "/x"}
+	require.True(t, mr.Matches(request))
 }
 
 // === Module C — BuildStringMatcher edges ================================

--- a/plugins/wasm-go/extensions/ext-auth/expr/match_rule_headers_test.go
+++ b/plugins/wasm-go/extensions/ext-auth/expr/match_rule_headers_test.go
@@ -1,0 +1,105 @@
+package expr
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestHeaderPresenceConditions(t *testing.T) {
+	tests := []struct {
+		name      string
+		condition HeaderCondition
+		headers   [][2]string
+		matches   bool
+	}{
+		{
+			name:      "exists true counts mixed-case empty-value header",
+			condition: HeaderCondition{Name: "x-custom-auth", Exists: true},
+			headers:   [][2]string{{"X-Custom-Auth", ""}},
+			matches:   true,
+		},
+		{name: "exists true rejects missing header", condition: HeaderCondition{Name: "x-auth", Exists: true}},
+		{name: "exists false matches missing header", condition: HeaderCondition{Name: "x-auth", Exists: false}, matches: true},
+		{
+			name:      "exists false rejects present header",
+			condition: HeaderCondition{Name: "x-auth", Exists: false},
+			headers:   [][2]string{{"x-auth", "value"}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rule := Rule{Headers: []HeaderCondition{tt.condition}}
+			request := RequestAttributes{HeaderNames: NewHeaderNameSet(tt.headers)}
+			require.Equal(t, tt.matches, rule.matchesAllConditions(request))
+		})
+	}
+}
+
+func TestHeaderConditionsComposeWithRuleAndRulesOR(t *testing.T) {
+	rule := Rule{
+		Domain: "api.example.com",
+		Method: []string{"GET"},
+		Path:   createMatcher("/public", true),
+		Headers: []HeaderCondition{
+			{Name: "x-custom-auth", Exists: true},
+			{Name: "x-skip-auth", Exists: false},
+		},
+	}
+	request := RequestAttributes{
+		Domain:      "api.example.com",
+		Method:      "GET",
+		Path:        "/public",
+		HeaderNames: NewHeaderNameSet([][2]string{{"x-custom-auth", ""}}),
+	}
+
+	require.True(t, rule.matchesAllConditions(request))
+	request.HeaderNames["x-skip-auth"] = struct{}{}
+	require.False(t, rule.matchesAllConditions(request))
+	delete(request.HeaderNames, "x-skip-auth")
+
+	request.Method = "POST"
+	require.False(t, rule.matchesAllConditions(request))
+
+	request.Method = "GET"
+	rules := MatchRules{RuleList: []Rule{
+		{Headers: []HeaderCondition{{Name: "x-other", Exists: true}}},
+		rule,
+	}}
+	require.True(t, rules.matchesAnyRule(request))
+}
+
+func TestHeaderPresenceAuthorizationScope(t *testing.T) {
+	rule := Rule{Headers: []HeaderCondition{{Name: "x-custom-auth", Exists: true}}}
+	matchingRequest := RequestAttributes{HeaderNames: NewHeaderNameSet([][2]string{{"x-custom-auth", ""}})}
+	missingRequest := RequestAttributes{HeaderNames: NewHeaderNameSet(nil)}
+
+	tests := []struct {
+		name    string
+		mode    string
+		request RequestAttributes
+		inScope bool
+	}{
+		{name: "whitelist match", mode: ModeWhitelist, request: matchingRequest},
+		{name: "whitelist miss", mode: ModeWhitelist, request: missingRequest, inScope: true},
+		{name: "blacklist match", mode: ModeBlacklist, request: matchingRequest, inScope: true},
+		{name: "blacklist miss", mode: ModeBlacklist, request: missingRequest},
+		{name: "unknown mode fails closed", mode: "unknown", request: missingRequest, inScope: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rules := MatchRules{Mode: tt.mode, RuleList: []Rule{rule}}
+			require.Equal(t, tt.inScope, rules.Matches(tt.request))
+		})
+	}
+}
+
+func TestRequiresRequestHeaders(t *testing.T) {
+	methodOnlyRules := MatchRules{RuleList: []Rule{{Method: []string{"GET"}}}}
+	headerRules := MatchRules{RuleList: []Rule{{Headers: []HeaderCondition{{Name: "x-auth", Exists: true}}}}}
+
+	require.False(t, methodOnlyRules.RequiresRequestHeaders())
+	require.True(t, headerRules.RequiresRequestHeaders())
+}

--- a/plugins/wasm-go/extensions/ext-auth/expr/match_rules.go
+++ b/plugins/wasm-go/extensions/ext-auth/expr/match_rules.go
@@ -1,10 +1,10 @@
 package expr
 
 import (
+	"regexp"
 	"strings"
 
 	"ext-auth/util"
-	"regexp"
 )
 
 const (
@@ -18,9 +18,32 @@ type MatchRules struct {
 }
 
 type Rule struct {
-	Domain string
-	Method []string
-	Path   Matcher
+	Domain  string
+	Method  []string
+	Path    Matcher
+	Headers []HeaderCondition
+}
+
+type HeaderCondition struct {
+	Name   string
+	Exists bool
+}
+
+type HeaderNameSet map[string]struct{}
+
+type RequestAttributes struct {
+	Domain      string
+	Method      string
+	Path        string
+	HeaderNames HeaderNameSet
+}
+
+func NewHeaderNameSet(headers [][2]string) HeaderNameSet {
+	headerNames := make(HeaderNameSet, len(headers))
+	for _, header := range headers {
+		headerNames[strings.ToLower(header[0])] = struct{}{}
+	}
+	return headerNames
 }
 
 func MatchRulesDefaults() MatchRules {
@@ -30,43 +53,60 @@ func MatchRulesDefaults() MatchRules {
 	}
 }
 
-// IsAllowedByMode checks if the given domain, method and path are allowed based on the configuration mode.
-func (config *MatchRules) IsAllowedByMode(domain, method, path string) bool {
+func (config *MatchRules) RequiresRequestHeaders() bool {
+	for _, rule := range config.RuleList {
+		if len(rule.Headers) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+// Matches reports whether the request is within the external authorization scope.
+func (config *MatchRules) Matches(request RequestAttributes) bool {
 	switch config.Mode {
 	case ModeWhitelist:
-		for _, rule := range config.RuleList {
-			if rule.matchesAllConditions(domain, method, path) {
-				return true
-			}
-		}
-		return false
+		return !config.matchesAnyRule(request)
 	case ModeBlacklist:
-		for _, rule := range config.RuleList {
-			if rule.matchesAllConditions(domain, method, path) {
-				return false
-			}
-		}
-		return true
+		return config.matchesAnyRule(request)
 	default:
-		return false
+		return true
 	}
 }
 
-// matchesAllConditions checks if the given domain, method and path match all conditions of the rule.
-func (rule *Rule) matchesAllConditions(domain, method, path string) bool {
+func (config *MatchRules) matchesAnyRule(request RequestAttributes) bool {
+	for _, rule := range config.RuleList {
+		if rule.matchesAllConditions(request) {
+			return true
+		}
+	}
+	return false
+}
+
+// matchesAllConditions checks if the given domain, method, path and headers match all conditions of the rule.
+func (rule *Rule) matchesAllConditions(request RequestAttributes) bool {
 	// If all conditions are empty, return false
-	if rule.Domain == "" && rule.Path == nil && len(rule.Method) == 0 {
+	if rule.Domain == "" && rule.Path == nil && len(rule.Method) == 0 && len(rule.Headers) == 0 {
 		return false
 	}
 
 	// Check domain and path matching
-	domainMatch := rule.Domain == "" || matchDomain(domain, rule.Domain)
-	pathMatch := rule.Path == nil || rule.Path.Match(path)
+	domainMatch := rule.Domain == "" || matchDomain(request.Domain, rule.Domain)
+	pathMatch := rule.Path == nil || rule.Path.Match(request.Path)
 
 	// Check HTTP method matching: if no methods are specified, any method is allowed
-	methodMatch := len(rule.Method) == 0 || util.ContainsString(rule.Method, method)
+	methodMatch := len(rule.Method) == 0 || util.ContainsString(rule.Method, request.Method)
 
-	return domainMatch && pathMatch && methodMatch
+	headerMatch := true
+	for _, condition := range rule.Headers {
+		_, present := request.HeaderNames[condition.Name]
+		if present != condition.Exists {
+			headerMatch = false
+			break
+		}
+	}
+
+	return domainMatch && pathMatch && methodMatch && headerMatch
 }
 
 // matchDomain checks if the given domain matches the pattern.

--- a/plugins/wasm-go/extensions/ext-auth/expr/match_rules_test.go
+++ b/plugins/wasm-go/extensions/ext-auth/expr/match_rules_test.go
@@ -14,7 +14,7 @@ func createMatcher(pattern string, caseSensitive bool) Matcher {
 	return pathMatcher
 }
 
-func TestIsAllowedByMode(t *testing.T) {
+func TestMatchesPreservesBypassSemantics(t *testing.T) {
 	tests := []struct {
 		name     string
 		config   MatchRules
@@ -322,8 +322,12 @@ func TestIsAllowedByMode(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := tt.config.IsAllowedByMode(tt.domain, tt.method, tt.path)
-			assert.Equal(t, tt.expected, result)
+			bypassed := !tt.config.Matches(RequestAttributes{
+				Domain: tt.domain,
+				Method: tt.method,
+				Path:   tt.path,
+			})
+			assert.Equal(t, tt.expected, bypassed)
 		})
 	}
 }

--- a/plugins/wasm-go/extensions/ext-auth/header_match_test.go
+++ b/plugins/wasm-go/extensions/ext-auth/header_match_test.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/higress-group/proxy-wasm-go-sdk/proxywasm/types"
+	"github.com/higress-group/wasm-go/pkg/test"
+	"github.com/stretchr/testify/require"
+)
+
+var headerMatchConfig = json.RawMessage(`{
+	"http_service": {
+		"endpoint_mode": "envoy",
+		"endpoint": {
+			"service_name": "ext-auth.backend.svc.cluster.local",
+			"service_port": 8090,
+			"path_prefix": "/auth"
+		},
+		"authorization_request": {"with_request_body": true}
+	},
+	"match_type": "blacklist",
+	"match_list": [{
+		"match_rule_headers": [{"name": "X-Custom-Auth", "exists": true}]
+	}]
+}`)
+
+func newHeaderMatchTestHost(t *testing.T) test.TestHost {
+	t.Helper()
+	host, status := test.NewTestHost(headerMatchConfig)
+	require.Equal(t, types.OnPluginStartStatusOK, status)
+	t.Cleanup(host.Reset)
+	return host
+}
+
+func TestHeaderPresenceMatchRequestFlow(t *testing.T) {
+	test.RunTest(t, func(t *testing.T) {
+		t.Run("missing header bypasses before body buffering and callout", func(t *testing.T) {
+			host := newHeaderMatchTestHost(t)
+			action := host.CallOnHttpRequestHeaders([][2]string{
+				{":authority", "example.com"}, {":path", "/users"}, {":method", "POST"}, {"content-length", "7"},
+			})
+
+			require.Equal(t, types.ActionContinue, action)
+			require.Empty(t, host.GetHttpCalloutAttributes())
+			host.CompleteHttp()
+		})
+
+		t.Run("present empty header executes authorization", func(t *testing.T) {
+			host := newHeaderMatchTestHost(t)
+			action := host.CallOnHttpRequestHeaders([][2]string{
+				{":authority", "example.com"}, {":path", "/users"}, {":method", "POST"}, {"x-custom-auth", ""},
+			})
+
+			require.Equal(t, types.HeaderStopAllIterationAndWatermark, action)
+			require.Len(t, host.GetHttpCalloutAttributes(), 1)
+			host.CompleteHttp()
+		})
+	})
+}

--- a/plugins/wasm-go/extensions/ext-auth/main.go
+++ b/plugins/wasm-go/extensions/ext-auth/main.go
@@ -19,6 +19,7 @@ import (
 	"path"
 
 	"ext-auth/config"
+	"ext-auth/expr"
 	"ext-auth/util"
 
 	"github.com/higress-group/wasm-go/pkg/log"
@@ -55,8 +56,10 @@ const (
 )
 
 func onHttpRequestHeaders(ctx wrapper.HttpContext, config config.ExtAuthConfig) types.Action {
-	// If the request's domain and path match the MatchRules, skip authentication
-	if config.MatchRules.IsAllowedByMode(ctx.Host(), ctx.Method(), wrapper.GetRequestPathWithoutQuery()) {
+	matchRequest, err := buildMatchRequest(ctx, config.MatchRules)
+	if err != nil {
+		log.Errorf("failed to read request headers for match rules: %v; continuing external authorization", err)
+	} else if !config.MatchRules.Matches(matchRequest) {
 		ctx.DontReadRequestBody()
 		return types.ActionContinue
 	}
@@ -75,6 +78,24 @@ func onHttpRequestHeaders(ctx wrapper.HttpContext, config config.ExtAuthConfig) 
 
 	ctx.DontReadRequestBody()
 	return checkExtAuth(ctx, config, nil, types.HeaderStopAllIterationAndWatermark)
+}
+
+func buildMatchRequest(ctx wrapper.HttpContext, matchRules expr.MatchRules) (expr.RequestAttributes, error) {
+	request := expr.RequestAttributes{
+		Domain: ctx.Host(),
+		Method: ctx.Method(),
+		Path:   wrapper.GetRequestPathWithoutQuery(),
+	}
+	if !matchRules.RequiresRequestHeaders() {
+		return request, nil
+	}
+
+	requestHeaders, err := proxywasm.GetHttpRequestHeaders()
+	if err != nil {
+		return expr.RequestAttributes{}, err
+	}
+	request.HeaderNames = expr.NewHeaderNameSet(requestHeaders)
+	return request, nil
 }
 
 func onHttpRequestBody(ctx wrapper.HttpContext, config config.ExtAuthConfig, body []byte) types.Action {


### PR DESCRIPTION
## I. Summary

为 ext-auth 现有 `match_list` 规则增加可选的 `match_rule_headers` 请求头存在性条件：

- 每个条件显式配置 `name` 和必填布尔值 `exists`；
- 请求头名称忽略大小写，空值仍视为存在；
- Header 条件与同一规则中的域名、方法、路径保持 AND，规则之间保持 OR；
- 保留现有 `whitelist`/`blacklist` 真值表和旧配置行为；
- 仅在至少一条规则需要 Header 条件时读取完整请求头，读取失败时继续外部鉴权（fail-closed）；
- 更新中英文用户文档和解析、匹配、插件流程测试，不修改插件 `VERSION`。

## II. Related issue

Closes #4484
Closes #4485

- Aone requirement: https://project.aone.alibaba-inc.com/v2/project/2074522/req/84396086

## III. Change type

- [ ] Bug fix
- [x] Feature or enhancement
- [ ] Documentation or configuration only
- [ ] Refactoring, tests, or maintenance

## IV. Agent participation and issue-spec gate

- [ ] **No agent participation:** This PR is human-only.
- [ ] **Trivial agent-use exception:** Agent use was limited to spelling,
      punctuation, whitespace, or formatting with no substantive choice or
      behavioral effect; the explanation is below.
- [ ] **Verified maintainer/administrator exception:** Material agent
      participation occurred, and authenticated `gh` verification confirmed
      a `role_name` of `maintain` or `admin` on `higress-group/higress`, and the
      verified login matches this PR's GitHub author; record the required
      evidence and rationale below.
- [x] **Material agent participation:** An AI or coding agent materially
      participated in analysis, design, implementation, testing, or PR
      preparation.

For material participation that does not use the verified maintainer/administrator
exception, check each timed obligation:

- [x] **Before implementation began:** A Higress maintainer had approved the
      Proposal and Design Issues, and authorized implementation TASKs linked the
      work to the applicable SPECs.
- [x] **Before verification began:** The Design contained a concrete
      Verification Plan.
- [ ] **Before requesting maintainer review or acceptance:** Applicable
      implementation and verification TASKs were `done` with exact commands,
      results, evidence links, and hashes.

Then choose exactly one overall gate status:

- [ ] Complete: all three timed obligations above were satisfied.
- [x] Noncompliant: one or more obligations were not satisfied; explain below.
- [ ] Verified exception: material agent participation used the
      verified-maintainer/administrator exception; provide the required evidence
      and rationale below.
- [ ] N/A because the PR is human-only or qualifies for the trivial exception.

**Gate-status explanation (or N/A):** 当前 PR 仅作为 Draft 提交，不请求 Maintainer Review。实现和正常路径验证已完成；Verification TASK 尚待 Maintainer 确认当前 SDK 无法注入 `GetHttpRequestHeaders` 失败时可采用静态 fail-closed 分支审查。确认并同步 TASK 后，会在请求 Review 前将本项更新为 Complete。

**Trivial-exception explanation (or N/A):** N/A；本 PR 属于实质性 Agent 参与。

**Verified maintainer/administrator exception evidence (or N/A):** N/A；未使用该例外。

**Approved Proposal Issue URL (or N/A with explanation):** https://github.com/higress-group/higress/issues/4484

**Approved Design Issue URL (or N/A with explanation):** https://github.com/higress-group/higress/issues/4485

**Maintainer approval link(s) (or N/A with explanation):**

- Proposal: https://github.com/higress-group/higress/issues/4484#issuecomment-5294824746
- Design: https://github.com/higress-group/higress/issues/4485#issuecomment-5294824913

**Authorized implementation TASK link(s) (or N/A with explanation):** https://github.com/higress-group/higress/issues/4485#issuecomment-5282919621

**Verification Plan and verification TASK/evidence link(s) (or N/A with explanation):**

- Verification Plan: https://github.com/higress-group/higress/issues/4485#verification-plan
- Verification TASK: https://github.com/higress-group/higress/issues/4485#issuecomment-5282922752
- Header-read failure verification clarification: https://github.com/higress-group/higress/issues/4485#issuecomment-5312573216
- DCO-only exact-head revalidation: https://github.com/higress-group/higress/issues/4485#issuecomment-5312729728

## V. Testing and verification

**Test and deterministic rerun commands (or N/A with explanation):**

```text
GOWORK=off GOTOOLCHAIN=local GOPROXY=https://proxy.golang.org,direct go test -count=1 ./...
GOWORK=off GOTOOLCHAIN=local GOPROXY=https://proxy.golang.org,direct go vet ./...
GOWORK=off GOTOOLCHAIN=local GOPROXY=https://proxy.golang.org,direct go test -race -count=1 ./...
GOWORK=off GOTOOLCHAIN=local GOPROXY=https://proxy.golang.org,direct GOOS=wasip1 GOARCH=wasm go build -buildmode=c-shared -o /tmp/ext-auth-header-presence.wasm ./
GOWORK=off GOTOOLCHAIN=local GOPROXY=https://proxy.golang.org,direct WASM_FILE_PATH=/tmp/ext-auth-header-presence.wasm go test -count=1 ./...
```

真实 proxy-Wasm 路径使用仓库 Compose harness 的固定镜像摘要配置；完整配置、请求、响应、callout 计数、日志、清理记录和 SHA-256 已记录在 Verification TASK。

**Environment and configuration (or N/A with explanation):**

- Host: macOS Darwin 23.4.0, arm64
- Go: `go1.24.4 darwin/arm64`
- Docker Engine: `29.6.1`, linux/arm64 (Lima)
- Docker Compose: `v5.2.0`
- Gateway: `higress-registry.cn-hangzhou.cr.aliyuncs.com/higress/gateway@sha256:3dbd609df5db3fca61653eafe0e2310705e485190c4f8cd02d9aab8f07dcf329`
- HTTP mock: `ghcr.io/mccutchen/go-httpbin@sha256:402d89c482f99ddd053f0fdc8c6a2caa4fa20c4a804f37de640189518c636bf6`

**Exact tested revision, version, image tag/digest, manifests, and values (or N/A with explanation):**

- Base SHA: `7fd8dd9843284e08e1f85c581e796fc60586e887`
- Tested source SHA: `abefd2c88746c9bcc9d216e1b000ca3e8ed802f0`
- Plugin `VERSION`: unchanged
- Rendered Compose/configuration hash and image digests: see Verification TASK

**Baseline reproduction evidence for bug fixes (or N/A with explanation):** N/A；这是兼容性新增功能，不是 Bug 修复。

**Fixed-version verification evidence for bug fixes (or N/A with explanation):** N/A；这是兼容性新增功能，不是 Bug 修复。

**Wasm source revision and SHA-256 (or N/A with explanation):**

- Source SHA: `abefd2c88746c9bcc9d216e1b000ca3e8ed802f0`
- Wasm SHA-256: `9598e8654a77f503971ebe4fbae8a489765d9a8aee77d0dfaba838c5f46c72f4`
- 两次独立构建字节一致；同一产物已通过编译后 Wasm 测试和真实 Envoy 验证。

## VI. Special notes for reviewers

- 请重点审查现有 mode 真值表是否完整保持，以及 Header 读取失败时是否确实不会触发 bypass。
- 当前 head 是仅补充 `Signed-off-by` 的 DCO amend；其 tree 与原验证提交一致，且全部测试、Wasm 和真实 Envoy 验证已在新 head 上重跑。
- 当前 SDK 测试宿主没有 Header map hostcall 故障注入入口。为避免向生产代码增加测试专用 seam，该异常分支暂以代码审查证据覆盖；PR 在 Maintainer 确认前保持 Draft。
- `authorization_request.allowed_headers` 仍只控制向鉴权服务转发哪些 Header，与是否调用鉴权服务无关。
- 稳定版本分配和下游发布元数据同步不在本功能 PR 范围内。

## VII. AI coding disclosure

**Tool(s) used (or N/A):** OpenAI Codex；issue-spec CLI；独立只读代码审查/测试调查子任务。

### Prompts or instructions

用户的主要指令包括：

- 先分析当前用户问题、现有插件为什么不能满足，并列出现有配置规则与新规则变化；
- 采用语义专业的 bypass/匹配方案，并尽量减少原配置和实现改动；
- 在现有 `match_list` 规则中增加请求头存在性条件，保持规则内 AND、规则间 OR 和现有黑白名单行为；
- `exists` 最终保持必填，Header 名称校验保留，但用户文档不强调伪 Header；
- 不引入 `shouldBypassExtAuth` 一类专用逻辑，按正向规则匹配，不匹配时直接放行；
- 不保留可变的包级 `getRequestHeadersForMatching` 测试注入点；
- 代码要求逻辑清晰、优雅、简洁、可读，并在提交前由用户审核；
- 按 Higress 开发规范和 issue-spec Proposal/Design/TASK 流程推进，验证完成后再准备 PR。

仓库 `AGENTS.md`、Higress 贡献规范、已批准 Proposal #4484、Design #4485 及其 Verification Plan 同时作为约束。

### AI-assisted work summary

- 基于现有 `match_list` 扩展 `match_rule_headers`，没有新增顶层授权策略，也没有复用语义不同的 `allowed_headers`；
- 解析阶段要求显式布尔 `exists`，验证并一次性小写化 Header 名称，拒绝非法、伪 Header 和大小写无关重复项；
- 匹配阶段使用请求 Header 名称集合组合现有 domain/method/path 条件，保留旧 mode 真值表和空规则行为；
- 仅在配置需要时读取完整 Header；读取失败记录日志并继续外部鉴权；
- 增加解析、匹配、旧行为、Go/Wasm 插件流程测试和中英文文档，并在精确提交上完成原生、Race、Wasm 和真实 Envoy 验证；
- 重要限制：当前 SDK 测试宿主无法注入 Header 读取错误。未为此增加生产测试 seam，已在 Design 下请求 Maintainer 确认静态 fail-closed 分支审查方案，确认前 PR 保持 Draft。

<!--This is a translation content dividing line, the content below is generated by machine, please do not modify the content below-->
---
## I. Summary

Add optional `match_rule_headers` request header presence condition to existing `match_list` rules of ext-auth:

- Explicit configuration of `name` and required boolean `exists` for each condition;
- Request header names ignore case, and empty values are still considered to exist;
- The Header condition maintains AND with the domain name, method, and path in the same rule, and the rules maintain OR;
- Preserve existing `whitelist`/`blacklist` truth tables and old configuration behavior;
- Only read the complete request header when at least one rule requires a Header condition, and continue external authentication if the reading fails (fail-closed);
- Updated Chinese and English user documentation and parsing, matching, and plug-in process tests without modifying the plug-in `VERSION`.

## II. Related issue

Closes #4484
Closes #4485

- Aone requirement: https://project.aone.alibaba-inc.com/v2/project/2074522/req/84396086

## III. Change type

- [ ] Bug fix
- [x] Feature or enhancement
- [ ] Documentation or configuration only
- [ ] Refactoring, tests, or maintenance

## IV. Agent participation and issue-spec gate

- [ ] **No agent participation:** This PR is human-only.
- [ ] **Trivial agent-use exception:** Agent use was limited to spelling,
      punctuation, whitespace, or formatting with no substantive choice or
      behavioral effect; the explanation is below.
- [ ] **Verified maintainer/administrator exception:** Material agent
      participation occurred, and authenticated `gh` verification confirmed
      a `role_name` of `maintain` or `admin` on `higress-group/higress`, and the
      verified login matches this PR's GitHub author; record the required
      evidence and rationale below.
- [x] **Material agent participation:** An AI or coding agent materially
      participated in analysis, design, implementation, testing, or PR
      preparation.

For material participation that does not use the verified maintainer/administrator
exception, check each timed obligation:

- [x] **Before implementation began:** A Higress maintainer had approved the
      Proposal and Design Issues, and authorized implementation TASKs linked to the
      work to the applicable SPECs.
- [x] **Before verification began:** The Design contained a concrete
      Verification Plan.
- [ ] **Before requesting maintainer review or acceptance:** Applicable
      implementation and verification TASKs were `done` with exact commands,
      results, evidence links, and hashes.

Then choose exactly one overall gate status:

- [ ] Complete: all three timed obligations above were satisfied.
- [x] Noncompliant: one or more obligations were not satisfied; explain below.
- [ ] Verified exception: material agent participation used the
      verified-maintainer/administrator exception; provide the required evidence
      and rationale below.
- [ ] N/A because the PR is human-only or qualifies for the trivial exception.

**Gate-status explanation (or N/A):** The current PR is submitted as Draft only and does not request Maintainer Review. Implementation and normal path verification completed; Verification TASK pending Maintainer confirmation that the current SDK cannot inject `GetHttpRequestHeaders` and can be reviewed using a static fail-closed branch when it fails. After confirming and synchronizing the TASK, this item will be updated to Complete before requesting Review.

**Trivial-exception explanation (or N/A):** N/A; this PR involves substantial Agent participation.

**Verified maintainer/administrator exception evidence (or N/A):** N/A; the exception is not used.

**Approved Proposal Issue URL (or N/A with explanation):** https://github.com/higress-group/higress/issues/4484

**Approved Design Issue URL (or N/A with explanation):** https://github.com/higress-group/higress/issues/4485

**Maintainer approval link(s) (or N/A with explanation):**

- Proposal: https://github.com/higress-group/higress/issues/4484#issuecomment-5294824746
- Design: https://github.com/higress-group/higress/issues/4485#issuecomment-5294824913

**Authorized implementation TASK link(s) (or N/A with explanation):** https://github.com/higress-group/higress/issues/4485#issuecomment-5282919621

**Verification Plan and verification TASK/evidence link(s) (or N/A with explanation):**

- Verification Plan: https://github.com/higress-group/higress/issues/4485#verification-plan
- Verification TASK: https://github.com/higress-group/higress/issues/4485#issuecomment-5282922752
- Header-read failure verification clarification: https://github.com/higress-group/higress/issues/4485#issuecomment-5312573216
- DCO-only exact-head revalidation: https://github.com/higress-group/higress/issues/4485#issuecomment-5312729728

## V. Testing and verification

**Test and deterministic rerun commands (or N/A with explanation):**

```text
GOWORK=off GOTOOLCHAIN=local GOPROXY=https://proxy.golang.org,direct go test -count=1 ./...
GOWORK=off GOTOOLCHAIN=local GOPROXY=https://proxy.golang.org,direct go vet ./...
GOWORK=off GOTOOLCHAIN=local GOPROXY=https://proxy.golang.org,direct go test -race -count=1 ./...
GOWORK=off GOTOOLCHAIN=local GOPROXY=https://proxy.golang.org,direct GOOS=wasip1 GOARCH=wasm go build -buildmode=c-shared -o /tmp/ext-auth-header-presence.wasm ./
GOWORK=off GOTOOLCHAIN=local GOPROXY=https://proxy.golang.org,direct WASM_FILE_PATH=/tmp/ext-auth-header-presence.wasm go test -count=1 ./...
```

The real proxy-Wasm path is configured using the fixed image summary of the repository's Compose harness; the full configuration, requests, responses, callout counts, logs, cleanup records, and SHA-256 are logged in the Verification TASK.

**Environment and configuration (or N/A with explanation):**

- Host: macOS Darwin 23.4.0, arm64
- Go: `go1.24.4 darwin/arm64`
- Docker Engine: `29.6.1`, linux/arm64 (Lima)
- Docker Compose: `v5.2.0`
- Gateway: `higress-registry.cn-hangzhou.cr.aliyuncs.com/higress/gateway@sha256:3dbd609df5db3fca61653eafe0e2310705e485190c4f8cd02d9aab8f07dcf329`
- HTTP mock: `ghcr.io/mccutchen/go-httpbin@sha256:402d89c482f99ddd053f0fdc8c6a2caa4fa20c4a804f37de640189518c636bf6`

**Exact tested revision, version, image tag/digest, manifests, and values (or N/A with explanation):**

- Base SHA: `7fd8dd9843284e08e1f85c581e796fc60586e887`
- Tested source SHA: `abefd2c88746c9bcc9d216e1b000ca3e8ed802f0`
- Plugin `VERSION`: unchanged
- Rendered Compose/configuration hash and image digests: see Verification TASK

**Baseline reproduction evidence for bug fixes (or N/A with explanation):** N/A; this is a compatibility addition, not a bug fix.

**Fixed-version verification evidence for bug fixes (or N/A with explanation):** N/A; this is a compatibility addition, not a bug fix.

**Wasm source revision and SHA-256 (or N/A with explanation):**

- Source SHA: `abefd2c88746c9bcc9d216e1b000ca3e8ed802f0`
- Wasm SHA-256: `9598e8654a77f503971ebe4fbae8a489765d9a8aee77d0dfaba838c5f46c72f4`
- The two independent builds are byte consistent; the same product has passed post-compilation Wasm testing and real Envoy verification.

## VI. Special notes for reviewers

- Please focus on reviewing whether the existing mode truth table is kept intact, and whether the bypass will not be triggered when the Header reading fails.
- The current head is a DCO amend that only adds `Signed-off-by`; its tree is consistent with the original verification commit, and all tests, Wasm and real Envoy verification have been rerun on the new head.
- The current SDK test host does not have a Header map hostcall fault injection entry. In order to avoid adding a test-specific seam to the production code, the abnormal branch is temporarily covered with code review evidence; the PR remains Draft until confirmed by the Maintainer.
- `authorization_request.allowed_headers` still only controls which headers are forwarded to the authentication service, regardless of whether the authentication service is called.
- Stable version distribution and downstream release metadata synchronization are not within the scope of this feature PR.

## VII. AI coding disclosure

**Tool(s) used (or N/A):** OpenAI Codex; issue-spec CLI; independent read-only code review/test investigation subtask.

### Prompts or instructions

The main instructions for users include:

- First analyze the current user problems, why existing plug-ins cannot meet the needs, and list the existing configuration rules and new rule changes;
- Adopt semantically professional bypass/matching solutions and minimize original configuration and implementation changes;
- Add request header existence conditions to existing `match_list` rules, maintaining intra-rule AND, inter-rule OR and existing black and white list behavior;
- `exists` finally remains required, Header name verification is retained, but user documentation does not emphasize pseudo-Headers;
- Do not introduce `shouldBypassExtAuth`, a type of special logic, match according to forward rules, and directly let it go if it does not match;
- Do not preserve mutable package-level `getRequestHeadersForMatching` test injection points;
- The code must be logically clear, elegant, concise and readable, and must be reviewed by users before submission;
- Promote according to Higress development specifications and issue-spec Proposal/Design/TASK process, and prepare PR after verification is completed.

The repository `AGENTS.md`, Higress contribution specification, approved Proposal #4484, Design #4485 and its Verification Plan also serve as constraints.

### AI-assisted work summary

- Extended `match_rule_headers` based on the existing `match_list`, without adding a new top-level authorization policy, and without reusing `allowed_headers` with different semantics;
- The parsing phase requires explicit Boolean `exists`, validates and lowercases the Header name once, and rejects illegal, spurious Headers and case-independent duplicates;
- The matching phase uses the request header name set to combine existing domain/method/path conditions, retaining the old mode truth table and empty rule behavior;
- Only read the complete header when required by the configuration; record failure logs and continue external authentication;
- Add parsing, matching, old behavior, Go/Wasm plug-in process testing and Chinese and English documentation, and complete native, Race, Wasm and real Envoy verification on accurate submissions;
- Important limitation: The current SDK test host cannot inject Header read errors. No production test seam has been added for this. The Maintainer has been requested under Design to confirm the static fail-closed branch review plan, and the PR remains Draft before confirmation.
