### PR TITLE
bugfix: extract model from gemini streaming path with query string

### DIFF
--- a/plugins/wasm-go/extensions/ai-statistics/main.go
+++ b/plugins/wasm-go/extensions/ai-statistics/main.go
@@ -740,9 +740,16 @@ func onHttpRequestBody(ctx wrapper.HttpContext, config AIStatisticsConfig, body 
 	// If model not found in body, try to extract from path (Gemini style)
 	if requestModel == "UNKNOWN" {
 		requestPath := ctx.GetStringContext(RequestPath, "")
-		if strings.Contains(requestPath, "generateContent") || strings.Contains(requestPath, "streamGenerateContent") { // Google Gemini GenerateContent
+		// Strip the query string before matching. Gemini streaming uses
+		// streamGenerateContent?alt=sse, and the trailing-$ anchor would
+		// otherwise fail to match, leaving the reported model as UNKNOWN.
+		pathOnly := requestPath
+		if i := strings.Index(pathOnly, "?"); i >= 0 {
+			pathOnly = pathOnly[:i]
+		}
+		if strings.Contains(pathOnly, "generateContent") || strings.Contains(pathOnly, "streamGenerateContent") { // Google Gemini GenerateContent
 			reg := regexp.MustCompile(`^.*/(?P<api_version>[^/]+)/models/(?P<model>[^:]+):\w+Content$`)
-			matches := reg.FindStringSubmatch(requestPath)
+			matches := reg.FindStringSubmatch(pathOnly)
 			if len(matches) == 3 {
 				requestModel = matches[2]
 			}

--- a/plugins/wasm-go/extensions/ai-statistics/main_test.go
+++ b/plugins/wasm-go/extensions/ai-statistics/main_test.go
@@ -442,6 +442,36 @@ func TestOnHttpRequestBody(t *testing.T) {
 
 			host.CompleteHttp()
 		})
+
+		// 测试 Gemini 流式 path（带 ?alt=sse query）也能从 path 正确提取模型名。
+		// 回归：正则末尾的 $ 锚点曾因 query 后缀失配，导致模型名为 UNKNOWN。
+		t.Run("gemini streaming path with query extracts model", func(t *testing.T) {
+			host, status := test.NewTestHost(requestBodyConfig)
+			defer host.Reset()
+			require.Equal(t, types.OnPluginStartStatusOK, status)
+
+			// path 带 ?alt=sse，且 body 中没有 model 字段（Gemini 原生协议模型名在 path 里）
+			host.CallOnHttpRequestHeaders([][2]string{
+				{":authority", "example.com"},
+				{":path", "/v1beta/models/gemini-3.1-flash-image-preview:streamGenerateContent?alt=sse"},
+				{":method", "POST"},
+			})
+
+			requestBody := []byte(`{
+				"contents": [
+					{"role": "user", "parts": [{"text": "generate an image"}]}
+				]
+			}`)
+			action := host.CallOnHttpRequestBody(requestBody)
+			require.Equal(t, types.ActionContinue, action)
+
+			// span 里的 gen_ai.request.model 应为真实模型名，而不是 UNKNOWN
+			model, ok := getSpanValue(host, ArmsRequestModel)
+			require.True(t, ok, "request model span attribute should be set")
+			require.Equal(t, "gemini-3.1-flash-image-preview", model)
+
+			host.CompleteHttp()
+		})
 	})
 }
 


### PR DESCRIPTION
<!--
Please read the contributing guidelines before submitting this pull request.
Complete every applicable field. For each non-applicable category, write N/A
and explain why; one explanation may cover multiple fields when it is clear.
-->

## I. Summary

Gemini 原生流式接口 `/v1beta/models/<model>:streamGenerateContent?alt=sse`
在 ai-statistics 插件中导致模型名解析为 UNKNOWN。根因:模型提取正则
末尾的 `$` 要求 path 以 `Content` 结尾,而流式 path 带 `?alt=sse` query
导致失配;且取 `:path` 时未剥离 query。修复:匹配前剥离 query 字符串。
不影响请求转发,仅修正统计/span/计数器中的模型名。

## II. Related issue
#4565 

## III. Change type

<!-- Check all that apply. -->

- [x] Bug fix
- [ ] Feature or enhancement
- [ ] Documentation or configuration only
- [ ] Refactoring, tests, or maintenance


## IV. Agent participation and issue-spec gate

See the [agent-assisted contribution policy](https://github.com/higress-group/higress/blob/main/docs/developers/agent-assisted-contributions.md).
Materially agent-assisted PRs that miss the gate receive low review priority,
and timely maintainer review is not guaranteed; this author declaration is the
deterministic prioritization signal.
Choose exactly one participation declaration:

- [ ] **No agent participation:** This PR is human-only.
- [ ] **Trivial agent-use exception:** Agent use was limited to spelling,
      punctuation, whitespace, or formatting with no substantive choice or
      behavioral effect; the explanation is below.
- [ ] **Verified maintainer/administrator exception:** Material agent
      participation occurred, and authenticated `gh` verification confirmed
      a `role_name` of `maintain` or `admin` on `higress-group/higress`, and the
      verified login matches this PR's GitHub author; record the required
      evidence and rationale below.
- [x] **Material agent participation:** An AI or coding agent materially
      participated in analysis, design, implementation, testing, or PR
      preparation.

For material participation that does not use the verified maintainer/administrator
exception, check each timed obligation:

- [ ] **Before implementation began:** A Higress maintainer had approved the
      Proposal and Design Issues, and authorized implementation TASKs linked the
      work to the applicable SPECs.
- [ ] **Before verification began:** The Design contained a concrete
      Verification Plan.
- [ ] **Before requesting maintainer review or acceptance:** Applicable
      implementation and verification TASKs were `done` with exact commands,
      results, evidence links, and hashes.

Then choose exactly one overall gate status:

- [ ] Complete: all three timed obligations above were satisfied.
- [x] Noncompliant: one or more obligations were not satisfied; explain below.
- [ ] Verified exception: material agent participation used the
      verified-maintainer/administrator exception; provide the required evidence
      and rationale below.
- [ ] N/A because the PR is human-only or qualifies for the trivial exception.

**Gate-status explanation (or N/A):**
N/A
**Trivial-exception explanation (or N/A):**
N/A

**Verified maintainer/administrator exception evidence (or N/A):**
<!-- Required when the verified exception is checked; otherwise write N/A. Run the policy's commands with GH_TOKEN and GITHUB_TOKEN unset after this PR is created but before requesting review. Record this PR's number or URL, the authenticated login, returned `role_name` of `maintain` or `admin`, and the author returned by `gh pr view`; the two logins must match. Explicitly attest that both token override variables were unset for every verification command. Never paste a token. The accepting or merging maintainer independently validates the current live evidence. -->

- This PR's number or URL:
- Authenticated `gh` login:
- Canonical-repository `role_name`:
- Actual PR author from `gh pr view`:
- Login/author match:
- Token override attestation (`GH_TOKEN` and `GITHUB_TOKEN` were unset for every verification command; required: `yes`):
- Bypass rationale:
- Maintainer live validation (review URL or N/A until performed):
N/A

**Approved Proposal Issue URL (or N/A with explanation):**
N/A

**Approved Design Issue URL (or N/A with explanation):**
N/A

**Maintainer approval link(s) (or N/A with explanation):**
N/A

**Authorized implementation TASK link(s) (or N/A with explanation):**
N/A

**Verification Plan and verification TASK/evidence link(s) (or N/A with explanation):**
N/A

## V. Testing and verification

**Test and deterministic rerun commands (or N/A with explanation):**

```text

```

**Environment and configuration (or N/A with explanation):**
<!-- Include OS/architecture and relevant Kubernetes, kind/k3s, Envoy, Go, Rust, or other tool versions. -->
OS: macOS Darwin 21.4.0 (arm64); Go: go1.26.4; module: plugins/wasm-go/extensions/ai-statistics.

**Exact tested revision, version, image tag/digest, manifests, and values (or N/A with explanation):**
Branch fix/ai-statistics-gemini-stream-model  based on upstream/main at 7fd8dd9843284e08e1f85c581e796fc60586e887

**Baseline reproduction evidence for bug fixes (or N/A with explanation):**
<!-- Link affected/pre-fix results using the same inputs and configuration as the fixed run. -->
Pre-fix, regex ...:\w+Content$ failed to match
/v1beta/models/gemini-3.1-flash-image-preview:streamGenerateContent?alt=sse
(trailing ?alt=sse vs $ anchor), so ai-statistics recorded
gen_ai.request.model = UNKNOWN for Gemini streaming.

**Fixed-version verification evidence for bug fixes (or N/A with explanation):**
<!-- Link expected/actual results, assertions, logs/metrics, and artifact hashes. -->
Added regression subtest gemini streaming path with query extracts model
under TestOnHttpRequestBody. Sends path ...:streamGenerateContent?alt=sse
with a no-model body, asserts span gen_ai.request.model =
gemini-3.1-flash-image-preview (not UNKNOWN).
go runtime: --- PASS: .../go/gemini_streaming_path_with_query_extracts_model
wasm runtime: --- PASS: .../wasm/gemini_streaming_path_with_query_extracts_model
Full suite: ok  ai-statistics  88.511s (no regressions).

**Wasm source revision and SHA-256 (or N/A with explanation):**
N/A

## VI. Special notes for reviewers

<!-- Call out risk, compatibility, limitations, follow-up work, or review focus. -->


## VII. AI coding disclosure

<!--
Required whenever an AI or coding agent was used, including the trivial-use
exception. Human-only PRs should write N/A. Do not include credentials or
sensitive data.
-->

**Tool(s) used (or N/A):**


### Prompts or instructions

<!-- Paste or link the prompts/instructions given to the tool, with secrets removed. -->


### AI-assisted work summary

<!-- Include key decisions, major changes, and important considerations or limitations. -->
