### PR TITLE
fix(ai-intent): avoid logging sensitive config

### DIFF
--- a/plugins/wasm-go/extensions/ai-intent/main.go
+++ b/plugins/wasm-go/extensions/ai-intent/main.go
@@ -104,7 +104,6 @@ type KVExtractor struct {
 }
 
 func parseConfig(json gjson.Result, c *PluginConfig, log log.Log) error {
-	log.Infof("config:%s", json.Raw)
 	// init scene
 	c.SceneInfo.Category = json.Get("scene.category").String()
 	log.Infof("SceneInfo.Category:%s", c.SceneInfo.Category)
@@ -119,7 +118,6 @@ func parseConfig(json gjson.Result, c *PluginConfig, log log.Log) error {
 	if c.SceneInfo.Prompt == "" {
 		c.SceneInfo.Prompt = DefaultPrompt
 	}
-	log.Infof("SceneInfo.Prompt:%s", c.SceneInfo.Prompt)
 	// init llmProxy
 	log.Debug("Start to init proxyService's http client.")
 	c.LLMInfo.ProxyServiceName = json.Get("llm.proxyServiceName").String()
@@ -128,7 +126,6 @@ func parseConfig(json gjson.Result, c *PluginConfig, log log.Log) error {
 		return errors.New("llm.proxyServiceName must not by empty")
 	}
 	c.LLMInfo.ProxyUrl = json.Get("llm.proxyUrl").String()
-	log.Infof("c.LLMInfo.ProxyUrl:%s", c.LLMInfo.ProxyUrl)
 	if c.LLMInfo.ProxyUrl == "" {
 		return errors.New("llm.proxyUrl must not by empty")
 	}
@@ -184,7 +181,6 @@ func parseConfig(json gjson.Result, c *PluginConfig, log log.Log) error {
 		c.LLMInfo.ProxyTimeout = defaultTimeout
 	}
 	c.LLMInfo.ProxyApiKey = json.Get("llm.proxyApiKey").String()
-	log.Infof("c.LLMInfo.ProxyApiKey:%s", c.LLMInfo.ProxyApiKey)
 	c.KeyFrom.RequestBody = json.Get("keyFrom.requestBody").String()
 	if c.KeyFrom.RequestBody == "" {
 		c.KeyFrom.RequestBody = "messages.@reverse.0.content"

--- a/plugins/wasm-go/extensions/ai-intent/main_test.go
+++ b/plugins/wasm-go/extensions/ai-intent/main_test.go
@@ -16,12 +16,65 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/higress-group/proxy-wasm-go-sdk/proxywasm/types"
 	"github.com/higress-group/wasm-go/pkg/test"
 	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
 )
+
+type recordingConfigLog struct {
+	entries []string
+}
+
+func (l *recordingConfigLog) append(format string, args ...interface{}) {
+	l.entries = append(l.entries, fmt.Sprintf(format, args...))
+}
+
+func (l *recordingConfigLog) Trace(msg string)                             { l.append("%s", msg) }
+func (l *recordingConfigLog) Tracef(format string, args ...interface{})    { l.append(format, args...) }
+func (l *recordingConfigLog) Debug(msg string)                             { l.append("%s", msg) }
+func (l *recordingConfigLog) Debugf(format string, args ...interface{})    { l.append(format, args...) }
+func (l *recordingConfigLog) Info(msg string)                              { l.append("%s", msg) }
+func (l *recordingConfigLog) Infof(format string, args ...interface{})     { l.append(format, args...) }
+func (l *recordingConfigLog) Warn(msg string)                              { l.append("%s", msg) }
+func (l *recordingConfigLog) Warnf(format string, args ...interface{})     { l.append(format, args...) }
+func (l *recordingConfigLog) Error(msg string)                             { l.append("%s", msg) }
+func (l *recordingConfigLog) Errorf(format string, args ...interface{})    { l.append(format, args...) }
+func (l *recordingConfigLog) Critical(msg string)                          { l.append("%s", msg) }
+func (l *recordingConfigLog) Criticalf(format string, args ...interface{}) { l.append(format, args...) }
+func (l *recordingConfigLog) ResetID(string)                               {}
+
+func TestParseConfigDoesNotLogProxyAPIKey(t *testing.T) {
+	const (
+		apiKey       = "fixture-api-key-must-not-be-logged"
+		secretPrompt = "fixture-private-prompt-must-not-be-logged"
+		secretURL    = "user:password@"
+	)
+	configJSON, err := json.Marshal(map[string]interface{}{
+		"scene": map[string]interface{}{
+			"category": "test",
+			"prompt":   secretPrompt,
+		},
+		"llm": map[string]interface{}{
+			"proxyServiceName": "ai-service",
+			"proxyUrl":         "https://" + secretURL + "ai.example.com/v1/chat/completions",
+			"proxyApiKey":      apiKey,
+		},
+	})
+	require.NoError(t, err)
+
+	logger := &recordingConfigLog{}
+	config := &PluginConfig{}
+	require.NoError(t, parseConfig(gjson.ParseBytes(configJSON), config, logger))
+	logs := strings.Join(logger.entries, "\n")
+	require.NotContains(t, logs, apiKey)
+	require.NotContains(t, logs, secretPrompt)
+	require.NotContains(t, logs, secretURL)
+}
 
 // 测试配置：基本意图识别配置
 var basicIntentConfig = func() json.RawMessage {


### PR DESCRIPTION
## Summary

Remove sensitive `ai-intent` configuration values from logs.

The parser no longer logs the complete configuration, configured Prompt,
`proxyUrl`, or `proxyApiKey`. Non-sensitive configuration diagnostics remain.

## Fixes

Fixes #4564

## Tests

- Added a configuration-log regression that verifies an API key, private Prompt,
  and URL user-info do not appear in captured logs.
- `go test ./... -count=1`
- `GOOS=wasip1 GOARCH=wasm go build -buildmode=c-shared -o /tmp/ai-intent.wasm ./`
- `git diff --check origin/main...HEAD`

## Agent participation

Material agent participation. This small, maintainer-authorized single-file
fix follows the agent-assisted contribution policy and #4564 maintainer guidance.
