### PR TITLE
fix(ai-json-resp): reject client-spoofed internal recursion marker

### DIFF
--- a/plugins/wasm-go/extensions/ai-json-resp/go.mod
+++ b/plugins/wasm-go/extensions/ai-json-resp/go.mod
@@ -5,6 +5,7 @@ go 1.24.1
 toolchain go1.24.4
 
 require (
+	github.com/google/uuid v1.6.0
 	github.com/higress-group/proxy-wasm-go-sdk v0.0.0-20250822030947-8345453fddd0
 	github.com/higress-group/wasm-go v1.0.2-0.20250821081215-b573359becf8
 	github.com/stretchr/testify v1.9.0
@@ -19,7 +20,6 @@ require (
 )
 
 require (
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/santhosh-tekuri/jsonschema v1.2.4
 	github.com/tidwall/gjson v1.18.0
 	github.com/tidwall/match v1.1.1 // indirect

--- a/plugins/wasm-go/extensions/ai-json-resp/main.go
+++ b/plugins/wasm-go/extensions/ai-json-resp/main.go
@@ -18,9 +18,9 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
-	"strconv"
 	"strings"
 
+	"github.com/google/uuid"
 	"github.com/higress-group/proxy-wasm-go-sdk/proxywasm"
 	"github.com/higress-group/proxy-wasm-go-sdk/proxywasm/types"
 	"github.com/higress-group/wasm-go/pkg/log"
@@ -109,6 +109,10 @@ type PluginConfig struct {
 	rejectStruct               RejectStruct
 	jsonSchemaMaxDepth         int
 	enableJsonSchemaValidation bool
+	// recursionToken is a per-config random token used to identify recursive
+	// sub-requests originated by this plugin. It is never read from the user
+	// config, so external clients cannot spoof it to bypass validation.
+	recursionToken string
 }
 
 func main() {}
@@ -145,6 +149,8 @@ func parseUrl(url string) (string, string) {
 }
 
 func parseConfig(result gjson.Result, config *PluginConfig, log log.Log) error {
+	// generate a per-config random token to identify recursive requests from this plugin
+	config.recursionToken = uuid.New().String()
 	config.serviceName = result.Get("serviceName").String()
 	config.serviceUrl = result.Get("serviceUrl").String()
 	config.serviceDomain = result.Get("serviceDomain").String()
@@ -456,20 +462,19 @@ func onHttpRequestHeaders(ctx wrapper.HttpContext, config PluginConfig, log log.
 	}
 
 	// verify if the request is from this plugin
+	// only a request carrying the per-config random token is treated as
+	// internal; any client-supplied marker is stripped so that it can never
+	// be forwarded upstream or disable validation
 	extendHeaderValue, err := proxywasm.GetHttpRequestHeader(EXTEND_HEADER_KEY)
 	if err == nil {
-		fromThisPlugin, convErr := strconv.ParseBool(extendHeaderValue)
-		if convErr != nil {
-			log.Debugf("failed to parse header value as bool: %v", convErr)
-			ctx.SetContext(FROM_THIS_PLUGIN_KEY, false)
-		}
-		if fromThisPlugin {
+		if extendHeaderValue == config.recursionToken {
 			ctx.SetContext(FROM_THIS_PLUGIN_KEY, true)
 			return types.ActionContinue
 		}
-	} else {
-		ctx.SetContext(FROM_THIS_PLUGIN_KEY, false)
+		proxywasm.RemoveHttpRequestHeader(EXTEND_HEADER_KEY)
+		log.Debugf("stripped client-supplied recursion marker header: %s", EXTEND_HEADER_KEY)
 	}
+	ctx.SetContext(FROM_THIS_PLUGIN_KEY, false)
 
 	path, err := proxywasm.GetHttpRequestHeader(":path")
 	if err != nil {
@@ -519,12 +524,12 @@ func onHttpRequestBody(ctx wrapper.HttpContext, config PluginConfig, body []byte
 
 	var headers [][2]string
 	if h, ok := ctx.GetContext("headers").([][2]string); ok {
-		headers = append(h, [2]string{EXTEND_HEADER_KEY, "true"})
+		headers = append(h, [2]string{EXTEND_HEADER_KEY, config.recursionToken})
 	} else {
 		log.Debugf("cannot get headers from context, use default headers")
 		headers = [][2]string{
 			{"Content-Type", "application/json"},
-			{EXTEND_HEADER_KEY, "true"},
+			{EXTEND_HEADER_KEY, config.recursionToken},
 		}
 	}
 

--- a/plugins/wasm-go/extensions/ai-json-resp/main_test.go
+++ b/plugins/wasm-go/extensions/ai-json-resp/main_test.go
@@ -275,8 +275,30 @@ func TestOnHttpRequestHeaders(t *testing.T) {
 			host, status := test.NewTestHost(basicConfig)
 			defer host.Reset()
 			require.Equal(t, types.OnPluginStartStatusOK, status)
+			config, err := host.GetMatchConfig()
+			require.NoError(t, err)
+			pluginConfig := config.(*PluginConfig)
 
-			// 设置来自插件的请求头
+			// 设置来自插件的请求头（携带内部随机 token）
+			action := host.CallOnHttpRequestHeaders([][2]string{
+				{":authority", "example.com"},
+				{":path", "/v1/chat/completions"},
+				{":method", "POST"},
+				{EXTEND_HEADER_KEY, pluginConfig.recursionToken},
+				{"Content-Type", "application/json"},
+			})
+
+			// 应该返回ActionContinue
+			require.Equal(t, types.ActionContinue, action)
+		})
+
+		// 测试客户端伪造内部标记：应被剥离，且不能绕过校验
+		t.Run("client-supplied marker is stripped", func(t *testing.T) {
+			host, status := test.NewTestHost(basicConfig)
+			defer host.Reset()
+			require.Equal(t, types.OnPluginStartStatusOK, status)
+
+			// 客户端伪造 EXTEND_HEADER_KEY=true
 			action := host.CallOnHttpRequestHeaders([][2]string{
 				{":authority", "example.com"},
 				{":path", "/v1/chat/completions"},
@@ -285,8 +307,12 @@ func TestOnHttpRequestHeaders(t *testing.T) {
 				{"Content-Type", "application/json"},
 			})
 
-			// 应该返回ActionContinue
+			// 正常流程继续，但伪造的标记必须被剥离
 			require.Equal(t, types.ActionContinue, action)
+			headers := host.GetRequestHeaders()
+			for _, h := range headers {
+				require.NotEqual(t, EXTEND_HEADER_KEY, h[0], "client-supplied marker must be stripped")
+			}
 		})
 
 		// 测试没有Authorization头的请求
@@ -335,6 +361,9 @@ func TestOnHttpRequestBody(t *testing.T) {
 			host, status := test.NewTestHost(basicConfig)
 			defer host.Reset()
 			require.Equal(t, types.OnPluginStartStatusOK, status)
+			config, err := host.GetMatchConfig()
+			require.NoError(t, err)
+			pluginConfig := config.(*PluginConfig)
 
 			// 设置请求头，包含EXTEND_HEADER_KEY来标记请求来自插件
 			host.CallOnHttpRequestHeaders([][2]string{
@@ -342,7 +371,7 @@ func TestOnHttpRequestBody(t *testing.T) {
 				{":path", "/v1/chat/completions"},
 				{":method", "POST"},
 				{"Content-Type", "application/json"},
-				{EXTEND_HEADER_KEY, "true"},
+				{EXTEND_HEADER_KEY, pluginConfig.recursionToken},
 			})
 
 			// 设置请求体
@@ -356,6 +385,58 @@ func TestOnHttpRequestBody(t *testing.T) {
 			action := host.CallOnHttpRequestBody([]byte(body))
 			// 应该返回ActionContinue，因为请求来自插件
 			require.Equal(t, types.ActionContinue, action)
+		})
+
+		// 测试客户端伪造内部标记：不能绕过 JSON 提取与 Schema 校验
+		t.Run("client spoofed marker cannot bypass validation", func(t *testing.T) {
+			host, status := test.NewTestHost(basicConfig)
+			defer host.Reset()
+			require.Equal(t, types.OnPluginStartStatusOK, status)
+
+			// 客户端伪造 EXTEND_HEADER_KEY=true
+			host.CallOnHttpRequestHeaders([][2]string{
+				{":authority", "example.com"},
+				{":path", "/v1/chat/completions"},
+				{":method", "POST"},
+				{"Content-Type", "application/json"},
+				{EXTEND_HEADER_KEY, "true"},
+			})
+
+			body := `{
+				"model": "gpt-3.5-turbo",
+				"messages": [
+					{"role": "user", "content": "Hello"}
+				]
+			}`
+
+			// 修复前这里错误地返回 ActionContinue（绕过校验流程）；
+			// 修复后必须进入正常校验流程，即返回 ActionPause 并发起上游调用
+			action := host.CallOnHttpRequestBody([]byte(body))
+			require.Equal(t, types.ActionPause, action)
+
+			// 模拟上游返回符合 Schema 的响应，验证校验与 JSON 提取确实在运行
+			host.CallOnHttpCall([][2]string{
+				{":status", "200"},
+				{"content-type", "application/json"},
+			}, []byte(`{
+				"id": "chatcmpl-123",
+				"choices": [
+					{
+						"index": 0,
+						"message": {
+							"role": "assistant",
+							"content": "{\"definition\": \"AI is artificial intelligence\", \"examples\": [\"machine learning\", \"natural language processing\"]}"
+						}
+					}
+				]
+			}`))
+
+			response := host.GetLocalResponse()
+			require.NotNil(t, response)
+			require.Contains(t, string(response.Data), "definition")
+
+			// 完成HTTP请求
+			host.CompleteHttp()
 		})
 
 		// 测试配置错误的请求体处理


### PR DESCRIPTION
## I. Summary

`ai-json-resp` identified its own recursive sub-requests via the `X-HIGRESS-AI-JSON-RESP: true` header and trusted the value unconditionally. A client could send this header to make `onHttpRequestHeaders` set `fromThisPlugin=true`, causing `onHttpRequestBody` to return `ActionContinue` and skip the entire JSON extraction / schema validation / repair-retry flow, bypassing structured-output enforcement.

Fix: replace the bare boolean with a per-config random token (generated via `uuid.New()` in `parseConfig`, never read from user config). Recursive sub-requests carry the token as the header value; `onHttpRequestHeaders` only treats a request as internal when the header matches the token, and strips any client-supplied marker so it can never disable validation or leak upstream. Backward compatible: no config changes required.

## II. Related issue

Fixes #4563

## III. Change type

- [x] Bug fix
- [ ] Feature or enhancement
- [ ] Documentation or configuration only
- [ ] Refactoring, tests, or maintenance

## IV. Agent participation and issue-spec gate

Choose exactly one participation declaration:

- [ ] **No agent participation:** This PR is human-only.
- [ ] **Trivial agent-use exception:** Agent use was limited to spelling, punctuation, whitespace, or formatting with no substantive choice or behavioral effect; the explanation is below.
- [ ] **Verified maintainer/administrator exception:** Material agent participation occurred, and authenticated `gh` verification confirmed a `role_name` of `maintain` or `admin` on `higress-group/higress`, and the verified login matches this PR's GitHub author; record the required evidence and rationale below.
- [x] **Material agent participation:** An AI or coding agent materially participated in analysis, design, implementation, testing, or PR preparation.

For material participation that does not use the verified maintainer/administrator exception, check each timed obligation:

- [ ] **Before implementation began:** A Higress maintainer had approved the Proposal and Design Issues, and authorized implementation TASKs linked the work to the applicable SPECs. — Not satisfied; #4563 is a plain bug report with no Proposal/Design/issue-spec labels, so no such approval existed.
- [ ] **Before verification began:** The Design contained a concrete Verification Plan. — N/A, no Design Issue exists for this bug fix.
- [ ] **Before requesting maintainer review or acceptance:** Applicable implementation and verification TASKs were `done` with exact commands, results, evidence links, and hashes. — N/A, no issue-spec TASKs exist for this bug fix.

Then choose exactly one overall gate status:

- [ ] Complete: all three timed obligations above were satisfied.
- [x] Noncompliant: one or more obligations were not satisfied; explain below.
- [ ] Verified exception: material agent participation used the verified-maintainer/administrator exception; provide the required evidence and rationale below.
- [ ] N/A because the PR is human-only or qualifies for the trivial exception.

**Gate-status explanation:** This is a straightforward bug fix for a plain bug report (#4563 carries no Proposal/Design/issue-spec labels). Implementation was completed before any maintainer Proposal/Design approval existed, so the mandatory planning gate is not satisfied (Noncompliant). If maintainers require the issue-spec workflow for this change, I will add the required Proposal/Design artifacts or rework accordingly.

**Trivial-exception explanation (or N/A):** N/A

**Verified maintainer/administrator exception evidence (or N/A):** N/A

**Approved Proposal Issue URL (or N/A with explanation):** N/A — no Proposal Issue exists; #4563 is a bug report without proposal/design labels.

**Approved Design Issue URL (or N/A with explanation):** N/A — no Design Issue exists.

**Maintainer approval link(s) (or N/A with explanation):** N/A — no Proposal/Design approval workflow applied to this bug fix.

**Authorized implementation TASK link(s) (or N/A with explanation):** N/A — no issue-spec TASKs were created for this bug fix.

**Verification Plan and verification TASK/evidence link(s) (or N/A with explanation):** N/A — no Design/Verification Plan exists; unit and regression tests are included in this PR, and runtime red/green verification is pending (see below).

## V. Testing and verification

**Test and deterministic rerun commands (or N/A with explanation):**

```text
cd plugins/wasm-go/extensions/ai-json-resp
go test ./...   # passes in both go and wasm modes (test.RunTest runs both)
GOOS=wasip1 GOARCH=wasm go build -buildmode=c-shared -o /tmp/probe.wasm .   # compile check
```

**Environment and configuration (or N/A with explanation):** macOS (Apple Silicon / darwin-arm64), Go 1.24.x, wasm-go plugin framework (higress-group/proxy-wasm-go-sdk + higress-group/wasm-go). No cluster required for unit tests. Module downloads used `GOPROXY=https://goproxy.cn,direct` (proxy.golang.org was unreachable from this network).

**Exact tested revision, version, image tag/digest, manifests, and values (or N/A with explanation):** This branch at commit fd8c85da; no cluster/image involved in unit testing.

**Baseline reproduction evidence for bug fixes (or N/A with explanation):** Runtime red/green evidence through a real proxy-Wasm data path is **pending** and will be provided per the agent-assisted policy (baseline = pre-fix revision reproducing the bypass; fixed = client-supplied marker rejected). The red/green logic is already demonstrated at the unit level: the regression test `client_spoofed_marker_cannot_bypass_validation` was verified to FAIL when the old trust-any-boolean check is restored, and PASSES on this branch.

**Fixed-version verification evidence for bug fixes (or N/A with explanation):** **Pending** — will be completed with the proxy-Wasm runtime harness (docker compose, pinned Higress gateway release image) and linked here.

**Wasm source revision and SHA-256 (or N/A with explanation):** **Pending** — will attach the SHA-256 of the built Wasm module together with the runtime verification evidence.

## VI. Special notes for reviewers

- The header cannot simply be removed: it is how the plugin recognizes its own recursive sub-request when `config.serviceClient.Post` routes back through the same gateway. The token approach keeps recursion detection intact while making the marker unguessable from outside.
- The token is per-plugin-config (generated at parse time), so it is not shared across plugin instances; a recursive sub-request traversing a *different* ai-json-resp instance would be treated as a normal request and validated again (bounded by `maxRetry`, no infinite loop). This is stricter than before and only affects rare multi-instance topologies.
- The old `strconv.ParseBool` logic (and its unhandled fallthrough on parse errors) is removed; any non-matching header value is now uniformly stripped and ignored.
- Regression tests added: `client-supplied marker is stripped` (asserts header removal) and `client_spoofed_marker_cannot_bypass_validation` (asserts `ActionPause` + full validation flow).

## VII. AI coding disclosure

**Tool(s) used (or N/A):** WorkBuddy (AI coding agent) — used for analysis, implementation, testing, and PR preparation.

### Prompts or instructions

The human author instructed the agent to: confirm the issue described in #4563 is reproducible from the code, propose a fix, implement it locally, and ensure unit tests pass with regression coverage. The agent analyzed `main.go`, selected the token-based approach, implemented it, and verified red/green behavior of the new tests. Prompts were conversational; no sensitive data was involved.

### AI-assisted work summary

Key decisions:
- Chose a per-config random token over plain header stripping because the header is load-bearing for recursion detection (stripping it would break the recursive-refine loop).
- Used `github.com/google/uuid` (already in the module graph) instead of adding `crypto/rand` plumbing; uuid is already used by other wasm-go plugins (e.g. ai-cache).
- Kept the header name unchanged for backward compatibility; only the value semantics changed.

Major changes:
- `PluginConfig.recursionToken` field, generated in `parseConfig` (never read from user config).
- `onHttpRequestHeaders` rewritten: token match → internal; otherwise strip header + normal flow.
- `onHttpRequestBody`: recursive sub-request header value now carries the token.
- `go.mod`: `google/uuid` promoted from indirect to direct dependency.
- Tests: 2 existing cases updated to use the real token; 2 regression cases added.

Important limitations:
- Runtime red/green verification through a real proxy-Wasm data path is still pending and will be added per the agent-assisted contribution policy.
- Cross-instance recursion behavior changes (documented in Special notes above).
