### PR TITLE
fix(mcp): tolerate unknown client capability members per 2026-07-28 schema

### DIFF
--- a/plugins/wasm-go/pkg/mcp/protocol/capabilities.go
+++ b/plugins/wasm-go/pkg/mcp/protocol/capabilities.go
@@ -63,12 +63,14 @@ func (c *ClientCapabilities) UnmarshalJSON(data []byte) error {
 		case "experimental":
 			decoded.Experimental, err = decodeJSONObjectMap(raw, nil)
 		case "roots":
-			var roots JSONObject
-			roots, err = decodeJSONObject(raw)
-			if err == nil && len(roots) != 0 {
-				err = errors.New("roots capability must be an empty object")
-			}
-			if err == nil {
+			// SEP-2577 deprecates roots as of 2026-07-28 but keeps it in the
+			// specification as an open object (no additionalProperties: false)
+			// for at least twelve months. Tolerate and ignore legacy members
+			// such as the 2025-06-18 listChanged flag instead of rejecting them.
+			_, rootsErr := decodeJSONObject(raw)
+			if rootsErr != nil {
+				err = rootsErr
+			} else {
 				decoded.Roots = &RootCapabilities{}
 			}
 		case "sampling":
@@ -129,6 +131,9 @@ func decodeSamplingCapabilities(raw json.RawMessage) (*SamplingCapabilities, err
 	}
 	capability := &SamplingCapabilities{}
 	for name, value := range members {
+		// The 2026-07-28 schema defines context and tools but leaves the
+		// object open (no additionalProperties: false); unknown members are
+		// tolerated and ignored so newer or older clients stay interoperable.
 		object, objectErr := decodeJSONObject(value)
 		if objectErr != nil {
 			return nil, fmt.Errorf("sampling.%s must be an object", name)
@@ -138,8 +143,6 @@ func decodeSamplingCapabilities(raw json.RawMessage) (*SamplingCapabilities, err
 			capability.Context = &object
 		case "tools":
 			capability.Tools = &object
-		default:
-			return nil, fmt.Errorf("unknown sampling capability %q", name)
 		}
 	}
 	return capability, nil
@@ -152,6 +155,9 @@ func decodeElicitationCapabilities(raw json.RawMessage) (*ElicitationCapabilitie
 	}
 	capability := &ElicitationCapabilities{}
 	for name, value := range members {
+		// form and url are defined by the 2026-07-28 schema; the object stays
+		// open (no additionalProperties: false), so unknown members are
+		// tolerated and ignored for forward compatibility.
 		object, objectErr := decodeJSONObject(value)
 		if objectErr != nil {
 			return nil, fmt.Errorf("elicitation.%s must be an object", name)
@@ -161,8 +167,6 @@ func decodeElicitationCapabilities(raw json.RawMessage) (*ElicitationCapabilitie
 			capability.Form = &object
 		case "url":
 			capability.URL = &object
-		default:
-			return nil, fmt.Errorf("unknown elicitation capability %q", name)
 		}
 	}
 	return capability, nil

--- a/plugins/wasm-go/pkg/mcp/protocol/request_test.go
+++ b/plugins/wasm-go/pkg/mcp/protocol/request_test.go
@@ -375,9 +375,9 @@ func TestModernMetadataSchemaAndExtensions(t *testing.T) {
 	body := strings.Replace(modernListRequest,
 		`"io.modelcontextprotocol/clientCapabilities":{}`,
 		`"io.modelcontextprotocol/clientCapabilities":{
-			"roots":{},
-			"sampling":{"context":{},"tools":{}},
-			"elicitation":{"form":{},"url":{}},
+			"roots":{"listChanged":true},
+			"sampling":{"context":{},"tools":{},"futureMode":{}},
+			"elicitation":{"form":{},"url":{},"voice":{}},
 			"experimental":{"vendor.feature":{"level":1}},
 			"extensions":{"com.example/ui":{"mimeTypes":["text/html"]}},
 			"vendorCapability":{"nested":true}
@@ -401,10 +401,8 @@ func TestModernMetadataSchemaAndExtensions(t *testing.T) {
 
 	invalidMembers := []string{
 		`"io.modelcontextprotocol/clientCapabilities":{"roots":true}`,
-		`"io.modelcontextprotocol/clientCapabilities":{"roots":{"listChanged":true}}`,
 		`"io.modelcontextprotocol/clientCapabilities":{"sampling":{"tools":true}}`,
 		`"io.modelcontextprotocol/clientCapabilities":{"sampling":{"tools":null}}`,
-		`"io.modelcontextprotocol/clientCapabilities":{"sampling":{"unknown":{}}}`,
 		`"io.modelcontextprotocol/clientCapabilities":{"elicitation":{"form":null}}`,
 		`"io.modelcontextprotocol/clientCapabilities":{"experimental":{"vendor":null}}`,
 		`"io.modelcontextprotocol/clientCapabilities":{"extensions":{"not-prefixed":{}}}`,


### PR DESCRIPTION
## I. Summary

closes: #4570

The MCP `2026-07-28` modern-profile request validation rejected schema-valid client capabilities, breaking interoperability with the official reference client **mcp-inspector** (and any client that still advertises legacy capability members).

**Reported failure:** a `server/discover` probe pinned to `2026-07-28` returned `400` with `-32602 "modern MCP clientCapabilities metadata is invalid"`, so version negotiation failed client-side (`no fallback in pin mode`).

**Root cause:** the client-capability decoder in `plugins/wasm-go/pkg/mcp/protocol/capabilities.go` treated the 2026-07-28 schema's empty `properties` as "must be empty":

- `roots` with any member (e.g. the 2025-06-18 `listChanged` flag) → rejected;
- `sampling` with an unknown member name → `unknown sampling capability`;
- `elicitation` with an unknown member name → `unknown elicitation capability`.

Per the official schema pinned by `plugins/wasm-go/extensions/mcp-server/testdata/conformance/official/PROVENANCE.json` (modelcontextprotocol @ `f817239`, release `2026-07-28`), these capability objects are **open objects**: `roots`/`sampling`/`elicitation` define documented members but carry **no `additionalProperties: false`**, and `ClientCapabilities` itself states "this is not a closed set". SEP-2577 deprecates `roots` but the schema comment says it "Remains in the specification for at least twelve months". Deprecation means tolerate-and-ignore, not reject.

**Verification against the official schema** (standard JSON Schema 2020-12 validator `ajv` over `schema/draft/schema.json` @ `f817239`):

| payload | official schema | Higress before | Higress after |
| --- | --- | --- | --- |
| `roots: {"listChanged": true}` (inspector) | VALID | rejected -32602 | accepted |
| `sampling: {"context":{},"tools":{},"futureMode":{}}` | VALID | rejected | accepted |
| `elicitation: {"form":{},"url":{},"voice":{}}` | VALID | rejected | accepted |
| `roots: true` (control) | INVALID | rejected | rejected |
| `sampling.context: 42` (control) | INVALID | rejected | rejected |

**Change:**

- `roots`: still required to be a JSON object; members are ignored (deprecated capability, presence is all that matters).
- `sampling`/`elicitation`: known members (`context`/`tools`, `form`/`url`) keep the object-value requirement; unknown member names are tolerated and ignored.
- Tests: moved the affected shapes from the invalid-metadata table into the complete-metadata acceptance case; control cases (non-object shapes, `null` values, extension-name rules) unchanged and still rejected.

Compatibility/migration: none — strictly widens acceptance to schema-valid payloads.

## II. Related issue

N/A — searched `higress-group/higress` issues (`roots listChanged`, `2026-07-28 clientCapabilities`, `MCP 2026-07-28 discover 400`); no existing report. A Proposal Issue under the issue-spec workflow can be filed on maintainer request.

## III. Change type

- [x] Bug fix
- [ ] Feature or enhancement
- [ ] Documentation or configuration only
- [ ] Refactoring, tests, or maintenance

## IV. Agent participation and issue-spec gate

- [x] **Material agent participation:** An AI or coding agent materially participated in analysis, design, implementation, testing, or PR preparation.

Timed obligations:

- [ ] **Before implementation began:** A Higress maintainer had approved the Proposal and Design Issues, and authorized implementation TASKs linked the work to the applicable SPECs.
- [ ] **Before verification began:** The Design contained a concrete Verification Plan.
- [ ] **Before requesting maintainer review or acceptance:** Applicable implementation and verification TASKs were `done` with exact commands, results, evidence links, and hashes.

Overall gate status:

- [x] **Noncompliant:** one or more obligations were not satisfied; explain below.

**Gate-status explanation:** this is an agent-assisted bug fix authored directly on a fork branch at the contributor's direction; no Proposal/Design Issues were filed or approved yet. Declared honestly for review prioritization. The contributor is willing to file the Proposal Issue with the collected diagnostic evidence (schema pinning, ajv validation, payload reproduction) and follow the issue-spec workflow if maintainers require it before review/merge.

**Trivial-exception explanation (or N/A):** N/A

**Verified maintainer/administrator exception evidence (or N/A):** N/A — author is not a canonical-repository maintainer/administrator (`role_name` check returns 403).

**Approved Proposal Issue URL (or N/A with explanation):** N/A — not yet filed; see gate-status explanation.

**Approved Design Issue URL (or N/A with explanation):** N/A — not yet filed; see gate-status explanation.

**Maintainer approval link(s) (or N/A with explanation):** N/A — pending.

**Authorized implementation TASK link(s) (or N/A with explanation):** N/A — pending.

**Verification Plan and verification TASK/evidence link(s) (or N/A with explanation):** N/A at issue-spec level. Unit/integration verification performed as below; proxy-Wasm runtime red/green evidence via the compose harness can be provided on request before merge.

## V. Testing and verification

**Test and deterministic rerun commands (or N/A with explanation):**

```text
# unit + integration tests for the affected module
cd plugins/wasm-go/pkg/mcp && go build ./... && go test ./... -count=1
#   ok  protocol / server / utils / validator

# plugin module (uses pkg/mcp via replace directive; includes the pinned
# official-fixture conformance tests)
cd plugins/wasm-go/extensions/mcp-server && go test -count=1 -timeout 600s .
#   ok  mcp-server

# red/green reproduction with the exact field payload (temporary test file,
# not committed): before the fix -> -32602 "modern MCP clientCapabilities
# metadata is invalid"; after the fix -> request accepted
```

**Environment and configuration (or N/A with explanation):** macOS (darwin/arm64), Go 1.24.x, module `github.com/alibaba/higress/plugins/wasm-go`; schema validator `ajv` (draft 2020-12) over the official `schema/draft/schema.json` at commit `f817239`.

**Exact tested revision, version, image tag/digest, manifests, and values (or N/A with explanation):** fix commit on branch `fix/mcp-open-client-capabilities` (fork `vvlisn/higress`), based on `upstream/main` @ `aae6fbce`. Field report was against v2.2.4 (`58666ac9`) at `http://10.93.112.109:30080/mcp-servers/user`.

**Baseline reproduction evidence for bug fixes (or N/A with explanation):**

- Field capture (client-side): `server/discover` POST with `Mcp-Protocol-Version: 2026-07-28` → HTTP 400, body `{"jsonrpc":"2.0","id":"server-discover-probe-1","error":{"code":-32602,"message":"modern MCP clientCapabilities metadata is invalid"}}`; client then failed negotiation: "Version negotiation failed: the server did not offer pinned protocol version 2026-07-28 via server/discover (no fallback in pin mode)".
- Unit-level reproduction on the pre-fix revision: the exact mcp-inspector `server/discover` JSON body through `PrepareRequest` returns the same `-32602`; the same body with `roots` changed to `{}` was accepted — isolating `roots.listChanged` as the rejected member.

**Fixed-version verification evidence for bug fixes (or N/A with explanation):** the exact mcp-inspector payload now passes `PrepareRequest` (modern transport, pinned version) with no protocol error; expanded acceptance test in `TestModernMetadataSchemaAndExtensions` covers `roots.listChanged`, unknown `sampling`/`elicitation` members; control cases remain rejected. Full test suites pass as listed above.

**Wasm source revision and SHA-256 (or N/A with explanation):** N/A for this unit-level submission — no Wasm binary was built/published; the compose-harness proxy-Wasm red/green run (baseline v2.2.4 vs fixed, with module SHA-256 and Envoy logs) can be executed and linked on request before merge.

## VI. Special notes for reviewers

- Scope is deliberately narrow: only unknown-member *tolerance* changed. Object-shape requirements (`roots` must be an object; `context`/`tools`, `form`/`url` values must be objects), `experimental`/`extensions`/extension-name validation, and all transport-level strictness are untouched.
- Known boundary (unchanged, pre-existing): unknown capability members must still be JSON *objects* to be tolerated at the `sampling`/`elicitation`/top-level layers, which mirrors the file's existing `JSONObject` type discipline. A pure-schema reading would allow non-object values for unknown members; no known client sends those.
- `RootCapabilities` intentionally stays an empty struct: `roots` is deprecated (SEP-2577) and nothing consumes its members; only presence is meaningful, so members are dropped on decode (round-trip normalizes `roots` to `{}`).
