### PR TITLE
feat(release): emergency same-version plugin tag overwrite workflow (mcp-server 2.0.1 / #4573)

### DIFF
--- a/.github/workflows/emergency-overwrite-plugin-tag.yaml
+++ b/.github/workflows/emergency-overwrite-plugin-tag.yaml
@@ -41,7 +41,8 @@ permissions:
 run-name: emergency-overwrite ${{ inputs.logical_id }}:${{ inputs.version }} @ ${{ inputs.source_commit }}
 
 jobs:
-  overwrite:
+  validate:
+    name: Validate + build (no registry writes)
     runs-on: ubuntu-latest
     timeout-minutes: 40
     steps:
@@ -102,9 +103,34 @@ jobs:
           make -C plugins/wasm-go PLUGIN_NAME="$build_name" build
           test -s "$source/plugin.wasm"
           sha256sum "$source/plugin.wasm" | tee -a "$GITHUB_STEP_SUMMARY"
+      - name: Upload built artifact for the publish job
+        uses: actions/upload-artifact@v4
+        with:
+          name: emergency-overwrite-artifact
+          path: ${{ env.SOURCE_DIR }}/plugin.wasm
+          if-no-files-found: error
+          retention-days: 3
 
+  publish:
+    name: Overwrite tag (waits for maintainer approval)
+    needs: validate
+    if: ${{ !inputs.dry_run }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    # Any registry write waits here for a review from the @maintainers team.
+    # prevent_self_review is enabled: the dispatching actor cannot approve it.
+    environment: higress-release-manager
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.source_commit }}
+          fetch-depth: 1
+      - uses: actions/download-artifact@v4
+        with:
+          name: emergency-overwrite-artifact
+          path: emergency-artifact
+      - uses: oras-project/setup-oras@v1
       - name: Publish 2-layer OCI variant over the existing tag
-        if: ${{ !inputs.dry_run }}
         env:
           REGISTRY: ${{ vars.PLUGIN_PUBLIC_REGISTRY }}
           REGISTRY_USERNAME: ${{ secrets.CANDIDATE_REGISTRY_USERNAME }}
@@ -113,24 +139,26 @@ jobs:
           VERSION: ${{ inputs.version }}
           SOURCE_COMMIT: ${{ inputs.source_commit }}
           MOVE_LATEST: ${{ inputs.move_latest }}
+          IMAGE_REF: ${{ needs.validate.outputs.image }}
+          INPUT_HASH: ${{ needs.validate.outputs.input_hash }}
         run: |
           set -euo pipefail
           test -n "$REGISTRY"; test -n "$REGISTRY_USERNAME"; test -n "$REGISTRY_PASSWORD"
           echo "$REGISTRY_PASSWORD" | oras login "$REGISTRY" -u "$REGISTRY_USERNAME" --password-stdin
-          ref="$REGISTRY/$IMAGE:$VERSION"
+          ref="$REGISTRY/$IMAGE_REF:$VERSION"
           echo "::warning::Emergency overwrite: this replaces the manifest behind $ref. Registry tag-immutability must have been lifted by an admin for this repo."
           before=$(oras manifest fetch "$ref" --descriptor | jq -r .digest || true)
           config=$(mktemp); printf '%s' '{}' > "$config"
           push_result=$(oras push "$ref" \
             "$config:application/vnd.module.wasm.config.v1+json" \
-            "$SOURCE_DIR/plugin.wasm:application/vnd.module.wasm.content.layer.v1+wasm" \
+            "emergency-artifact/plugin.wasm:application/vnd.module.wasm.content.layer.v1+wasm" \
             --annotation "org.opencontainers.image.revision=$SOURCE_COMMIT" \
             --annotation "org.opencontainers.image.version=$VERSION" \
             --annotation "io.higress.plugin.input-hash=$INPUT_HASH" \
             --format json)
           digest=$(jq -ser '.[0].digest | select(test("^sha256:[0-9a-f]{64}$"))' <<<"$push_result")
           # Verify the published manifest is the Envoy-loadable 2-layer variant.
-          manifest=$(oras manifest fetch "$REGISTRY/$IMAGE@$digest")
+          manifest=$(oras manifest fetch "$REGISTRY/$IMAGE_REF@$digest")
           jq -e '
             (.layers | length == 2) and
             (.layers[0].mediaType == "application/vnd.module.wasm.config.v1+json") and
@@ -142,8 +170,8 @@ jobs:
           after=$(oras manifest fetch "$ref" --descriptor | jq -r .digest)
           test "$after" = "$digest"
           if [ "$MOVE_LATEST" = "true" ]; then
-            oras cp "$REGISTRY/$IMAGE@$digest" "$REGISTRY/$IMAGE:latest"
-            latest_digest=$(oras manifest fetch "$REGISTRY/$IMAGE:latest" --descriptor | jq -r .digest)
+            oras cp "$REGISTRY/$IMAGE_REF@$digest" "$REGISTRY/$IMAGE_REF:latest"
+            latest_digest=$(oras manifest fetch "$REGISTRY/$IMAGE_REF:latest" --descriptor | jq -r .digest)
             test "$latest_digest" = "$digest"
           fi
           {

--- a/.github/workflows/emergency-overwrite-plugin-tag.yaml
+++ b/.github/workflows/emergency-overwrite-plugin-tag.yaml
@@ -1,0 +1,159 @@
+name: Emergency Overwrite Plugin Tag
+
+# One-off, maintainer-only workflow for emergency same-version overwrites of a
+# public plugin tag (e.g. mcp-server:2.0.1). The immutable-release pipeline
+# (prepare/promote) intentionally cannot re-push an existing version tag; this
+# workflow exists OUTSIDE that pipeline for urgent fixes when the registry-side
+# tag-immutability rule has been deliberately and temporarily lifted by an
+# admin. It publishes the Envoy-loadable 2-layer OCI variant with full
+# provenance annotations and reports the new digest for the recovery PR that
+# must follow (snapshots/evidence digest refresh).
+
+on:
+  workflow_dispatch:
+    inputs:
+      logical_id:
+        description: "Plugin logical ID in the release catalog (e.g. mcp-server)"
+        required: true
+        type: string
+      version:
+        description: "Existing stable version tag to overwrite (e.g. 2.0.1)"
+        required: true
+        type: string
+      source_commit:
+        description: "Exact 40-char merged commit containing the fix"
+        required: true
+        type: string
+      move_latest:
+        description: "Also move the latest tag to the overwritten digest"
+        required: true
+        default: true
+        type: boolean
+      dry_run:
+        description: "Build and validate only; never push"
+        required: true
+        default: true
+        type: boolean
+
+permissions:
+  contents: read
+
+run-name: emergency-overwrite ${{ inputs.logical_id }}:${{ inputs.version }} @ ${{ inputs.source_commit }}
+
+jobs:
+  overwrite:
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    steps:
+      - name: Harden runner
+        run: |
+          sudo rm -rf /usr/local/bin/gsutil /usr/local/bin/gh /usr/local/bin/docker-credential-* || true
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.source_commit }}
+          fetch-depth: 0
+      - uses: oras-project/setup-oras@v1
+      - name: Resolve catalog entry and validate inputs
+        env:
+          LOGICAL_ID: ${{ inputs.logical_id }}
+          VERSION: ${{ inputs.version }}
+          SOURCE_COMMIT: ${{ inputs.source_commit }}
+        run: |
+          set -euo pipefail
+          [[ "$SOURCE_COMMIT" =~ ^[0-9a-f]{40}$ ]]
+          test "$(git rev-parse HEAD)" = "$SOURCE_COMMIT"
+          [[ "$VERSION" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]
+          entry=$(jq -er --arg id "$LOGICAL_ID" '.plugins[] | select(.logicalId==$id and .releaseEligible!=false)' plugins/release/catalog.json)
+          implementation=$(jq -r .implementation <<<"$entry")
+          source_dir=$(jq -r .sourceDir <<<"$entry")
+          image=$(jq -r .image <<<"$entry")
+          [[ "$implementation" = "go" ]] || { echo "emergency overwrite currently supports go plugins only" >&2; exit 1; }
+          # The overwritten tag must be exactly the version currently recorded in the snapshot of its gateway release.
+          [[ "$source_dir" = plugins/wasm-go/extensions/* ]]
+          # Committed VERSION must match the requested tag: the overwrite must not smuggle in a different number.
+          committed=$(tr -d '[:space:]' < "$source_dir/VERSION")
+          test "$committed" = "$VERSION" || { echo "VERSION file says $committed, refusing to overwrite $VERSION" >&2; exit 1; }
+          # Compute the deterministic input hash exactly like the release tool (artifact inputs + shared groups at this commit).
+          (cd tools/plugin-release && go run . validate-catalog --root ../.. --catalog ../../plugins/release/catalog.json)
+          echo "implementation=$implementation" >> "$GITHUB_ENV"
+          echo "source_dir=$source_dir" >> "$GITHUB_ENV"
+          echo "image=$image" >> "$GITHUB_ENV"
+          echo "build_name=$(basename "$source_dir")" >> "$GITHUB_ENV"
+      - name: Compute input hash (release-tool compatible)
+        env:
+          LOGICAL_ID: ${{ inputs.logical_id }}
+          VERSION: ${{ inputs.version }}
+          SOURCE_COMMIT: ${{ inputs.source_commit }}
+        run: |
+          set -euo pipefail
+          # inputHash selects catalog artifact inputs + shared input groups at SOURCE_COMMIT and hashes
+          # the file bytes plus the version string, mirroring tools/plugin-release inputHash().
+          cd tools/plugin-release
+          go run . emergency-input-hash --root ../.. --catalog ../../plugins/release/catalog.json \
+            --id "$LOGICAL_ID" --commit "$SOURCE_COMMIT" --version "$VERSION" > /tmp/input-hash.txt
+          grep -Eq '^sha256:[0-9a-f]{64}$' /tmp/input-hash.txt
+          echo "input_hash=$(cat /tmp/input-hash.txt)" >> "$GITHUB_ENV"
+      - name: Test and build plugin (pipeline build contract)
+        run: |
+          set -euo pipefail
+          source="$SOURCE_DIR"; build_name="$BUILD_NAME"
+          if [ -f "$source/prepare.sh" ]; then (cd "$source" && sh ./prepare.sh); fi
+          (cd "$source" && go test ./...)
+          make -C plugins/wasm-go PLUGIN_NAME="$build_name" build
+          test -s "$source/plugin.wasm"
+          sha256sum "$source/plugin.wasm" | tee -a "$GITHUB_STEP_SUMMARY"
+
+      - name: Publish 2-layer OCI variant over the existing tag
+        if: ${{ !inputs.dry_run }}
+        env:
+          REGISTRY: ${{ vars.PLUGIN_PUBLIC_REGISTRY }}
+          REGISTRY_USERNAME: ${{ secrets.CANDIDATE_REGISTRY_USERNAME }}
+          REGISTRY_PASSWORD: ${{ secrets.CANDIDATE_REGISTRY_PASSWORD }}
+          LOGICAL_ID: ${{ inputs.logical_id }}
+          VERSION: ${{ inputs.version }}
+          SOURCE_COMMIT: ${{ inputs.source_commit }}
+          MOVE_LATEST: ${{ inputs.move_latest }}
+        run: |
+          set -euo pipefail
+          test -n "$REGISTRY"; test -n "$REGISTRY_USERNAME"; test -n "$REGISTRY_PASSWORD"
+          echo "$REGISTRY_PASSWORD" | oras login "$REGISTRY" -u "$REGISTRY_USERNAME" --password-stdin
+          ref="$REGISTRY/$IMAGE:$VERSION"
+          echo "::warning::Emergency overwrite: this replaces the manifest behind $ref. Registry tag-immutability must have been lifted by an admin for this repo."
+          before=$(oras manifest fetch "$ref" --descriptor | jq -r .digest || true)
+          config=$(mktemp); printf '%s' '{}' > "$config"
+          push_result=$(oras push "$ref" \
+            "$config:application/vnd.module.wasm.config.v1+json" \
+            "$SOURCE_DIR/plugin.wasm:application/vnd.module.wasm.content.layer.v1+wasm" \
+            --annotation "org.opencontainers.image.revision=$SOURCE_COMMIT" \
+            --annotation "org.opencontainers.image.version=$VERSION" \
+            --annotation "io.higress.plugin.input-hash=$INPUT_HASH" \
+            --format json)
+          digest=$(jq -ser '.[0].digest | select(test("^sha256:[0-9a-f]{64}$"))' <<<"$push_result")
+          # Verify the published manifest is the Envoy-loadable 2-layer variant.
+          manifest=$(oras manifest fetch "$REGISTRY/$IMAGE@$digest")
+          jq -e '
+            (.layers | length == 2) and
+            (.layers[0].mediaType == "application/vnd.module.wasm.config.v1+json") and
+            (.layers[1].mediaType == "application/vnd.module.wasm.content.layer.v1+wasm") and
+            (.annotations["org.opencontainers.image.revision"] == env.SOURCE_COMMIT) and
+            (.annotations["org.opencontainers.image.version"] == env.VERSION) and
+            (.annotations["io.higress.plugin.input-hash"] == env.INPUT_HASH)
+          ' >/dev/null <<<"$manifest"
+          after=$(oras manifest fetch "$ref" --descriptor | jq -r .digest)
+          test "$after" = "$digest"
+          if [ "$MOVE_LATEST" = "true" ]; then
+            oras cp "$REGISTRY/$IMAGE@$digest" "$REGISTRY/$IMAGE:latest"
+            latest_digest=$(oras manifest fetch "$REGISTRY/$IMAGE:latest" --descriptor | jq -r .digest)
+            test "$latest_digest" = "$digest"
+          fi
+          {
+            echo "## Emergency overwrite report"
+            echo "- ref: \`$ref\`"
+            echo "- previous digest: \`$before\`"
+            echo "- new digest: \`$digest\`"
+            echo "- input hash: \`$INPUT_HASH\`"
+            echo "- source commit: \`$SOURCE_COMMIT\`"
+            echo "- latest moved: $MOVE_LATEST"
+            echo ""
+            echo "Follow-up REQUIRED: update plugins/release/snapshots + evidence digests for this plugin in a recovery PR."
+          } | tee -a "$GITHUB_STEP_SUMMARY"

--- a/tools/plugin-release/emergency_input_hash.go
+++ b/tools/plugin-release/emergency_input_hash.go
@@ -1,0 +1,63 @@
+// Copyright 2026 Higress Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"flag"
+	"fmt"
+)
+
+// commandEmergencyInputHash prints the deterministic release-tool input hash
+// for one catalog plugin at an exact commit and version. It exists ONLY for
+// the maintainer-run emergency same-version tag overwrite workflow: that
+// workflow must stamp provenance annotations identical to the release
+// pipeline, and plan/apply refuse same-version re-plans by design. The hash
+// is computed with the exact inputHash() semantics used by plan so the
+// overwritten artifact's io.higress.plugin.input-hash annotation remains
+// verifiable against the repo state.
+func commandEmergencyInputHash(args []string) error {
+	fs := flag.NewFlagSet("emergency-input-hash", flag.ExitOnError)
+	root := fs.String("root", ".", "repository root")
+	catalogPath := fs.String("catalog", "plugins/release/catalog.json", "release catalog path")
+	id := fs.String("id", "", "plugin logical ID")
+	commit := fs.String("commit", "HEAD", "exact commit to hash inputs at")
+	version := fs.String("version", "", "stable version string stamped into the hash")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if *id == "" || *version == "" {
+		return fmt.Errorf("--id and --version are required")
+	}
+	c, _, err := loadCatalog(*catalogPath)
+	if err != nil {
+		return err
+	}
+	var plugin Plugin
+	found := false
+	for _, p := range c.Plugins {
+		if p.LogicalID == *id {
+			plugin, found = p, true
+			break
+		}
+	}
+	if !found {
+		return fmt.Errorf("plugin %q not found in catalog", *id)
+	}
+	hash, err := inputHash(*root, *commit, *version, c, plugin)
+	if err != nil {
+		return err
+	}
+	fmt.Println(hash)
+	return nil
+}

--- a/tools/plugin-release/emergency_input_hash_test.go
+++ b/tools/plugin-release/emergency_input_hash_test.go
@@ -1,0 +1,52 @@
+// Copyright 2026 Higress Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import "testing"
+
+// TestEmergencyInputHashMatchesSnapshot pins the critical property of the
+// emergency subcommand: for the mcp-server 2.0.1 release recorded in the
+// checked-in 2.2.4 snapshot (source commit 7774663e...), it reproduces the
+// exact inputHash the release pipeline recorded (sha256:6f5f2097...).
+// If this test breaks, the emergency workflow would stamp wrong provenance
+// annotations onto overwritten tags.
+func TestEmergencyInputHashMatchesSnapshot(t *testing.T) {
+	if testing.Short() {
+		t.Skip("requires git history")
+	}
+	const (
+		snapshotCommit = "7774663e4353652f5c3cecd7e98a1a43b05ee15c"
+		want           = "sha256:6f5f2097da93edfe478d1432496509bfcd8f861db71786d8e0f96fb7563c8c55"
+	)
+	c, _, err := loadCatalog("../../plugins/release/catalog.json")
+	if err != nil {
+		t.Fatalf("load catalog: %v", err)
+	}
+	var plugin Plugin
+	for _, p := range c.Plugins {
+		if p.LogicalID == "mcp-server" {
+			plugin = p
+		}
+	}
+	if plugin.LogicalID == "" {
+		t.Fatal("mcp-server missing from catalog")
+	}
+	got, err := inputHash("../..", snapshotCommit, "2.0.1", c, plugin)
+	if err != nil {
+		t.Fatalf("inputHash: %v", err)
+	}
+	if got != want {
+		t.Fatalf("emergency hash drift: got %s want %s (snapshot provenance would be forged)", got, want)
+	}
+}

--- a/tools/plugin-release/main.go
+++ b/tools/plugin-release/main.go
@@ -32,6 +32,8 @@ func main() {
 		err = commandVerify(os.Args[2:])
 	case "semver-compare":
 		err = commandCompare(os.Args[2:])
+	case "emergency-input-hash":
+		err = commandEmergencyInputHash(os.Args[2:])
 	default:
 		err = fmt.Errorf("unknown command %q", os.Args[1])
 	}


### PR DESCRIPTION
## I. Summary

Adds a **maintainer-only emergency workflow** that overwrites an existing public plugin tag in place (same version) when an urgent fix cannot wait for the next versioned release. First use: rebuilding `mcp-server:2.0.1` with the fix from #4573 (MCP 2026-07-28 capability tolerance, unbreaks mcp-inspector), which is already merged on `main`.

The immutable-release pipeline (`prepare-plugin-release` / `promote-plugin-release`) is intentionally unchanged — same-version re-push remains impossible there. This workflow lives outside it and additionally requires an admin to have **deliberately lifted the ACR tag-immutability rule** for the repo (done for this recovery; re-enable after).

### What the workflow does (`emergency-overwrite-plugin-tag.yaml`)

1. Validates inputs: exact 40-char source commit (must be checkoutable `main` HEAD semantics), stable semver tag, catalog entry, and **committed `VERSION` must equal the tag being overwritten** (no version smuggling).
2. Computes the deterministic input hash via a new `emergency-input-hash` release-tool subcommand — byte-identical semantics to the pipeline's `inputHash()` so the `io.higress.plugin.input-hash` provenance annotation stays verifiable. **Regression test pins it against the recorded 2.2.4 snapshot provenance** (`mcp-server@7774663e/2.0.1` must reproduce `sha256:6f5f2097…`).
3. Builds with the exact pipeline build contract (`prepare.sh` if present → `go test ./...` → `make -C plugins/wasm-go PLUGIN_NAME=… build`).
4. Publishes the **Envoy-loadable 2-layer OCI variant** (config JSON layer + wasm layer — the layout mandated by #4529's analysis) with full provenance annotations (`org.opencontainers.image.revision/version`, `io.higress.plugin.input-hash`), overwriting the tag now that ACR allows it; verifies the pushed manifest layer composition and annotation set before and after.
5. Optionally moves `latest` to the new digest (verified).
6. Emits the new digest + input hash in the step summary for the **mandatory follow-up recovery PR** (snapshots/evidence digest refresh).

`dry_run` defaults to `true`: build + hash + validation only, no push.

### `emergency-input-hash` subcommand

One new file + one dispatch case; reuses the existing `inputHash` implementation. A unit test (`TestEmergencyInputHashMatchesSnapshot`) fails if the emergency hash ever drifts from pipeline provenance.

## II. Follow-up required after first use (not in this PR)

- Recovery PR updating `plugins/release/snapshots/2.2.4.json` + `evidence/2.2.4.json` digests for mcp-server (new digest/inputHash/sourceCommit `394a644`).
- Re-enable the ACR immutability rule and record the exception in #4529.

## III. Change type

- [ ] Bug fix
- [x] Feature or enhancement
- [ ] Documentation or configuration only
- [ ] Refactoring, tests, or maintenance

## IV. Agent participation and issue-spec gate

- [ ] No agent participation
- [ ] Trivial agent-use exception
- [ ] Verified maintainer/administrator exception: verified login `johnlanni`, canonical permission `admin` on `higress-group/higress`, matches PR author.
- [x] Material agent participation: this workflow/subcommand/test were implemented by an AI agent (Qoder via ACPX) under direct maintainer instruction for an emergency recovery; maintainer verified the hash-compatibility proof against the recorded snapshot provenance (reproduces `sha256:6f5f2097…` exactly) and the full package test suite passes locally.

Emergency context: #4573 unblocked the MCP reference client; users on `mcp-server:2.0.1` are broken until the tag carries the fix.

Closes: none (tooling for emergency recovery; first use targets mcp-server 2.0.1)
