### PR TITLE
fix(ai-data-masking): avoid CPU stalls in hash restore

### DIFF
--- a/plugins/wasm-rust/extensions/ai-data-masking/Cargo.lock
+++ b/plugins/wasm-rust/extensions/ai-data-masking/Cargo.lock
@@ -213,9 +213,9 @@ checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
 name = "fancy-regex"
-version = "0.14.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e24cb5a94bcae1e5408b0effca5cd7172ea3c5755049c5f3af4cd283a165298"
+checksum = "476de73bddf2ef8490aa4ee8f1cf40b430bf1d56c48c22080e5186952cd580e6"
 dependencies = [
  "bit-set",
  "regex-automata",
@@ -804,9 +804,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.9"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
 dependencies = [
  "aho-corasick",
  "memchr",

--- a/plugins/wasm-rust/extensions/ai-data-masking/Cargo.lock
+++ b/plugins/wasm-rust/extensions/ai-data-masking/Cargo.lock
@@ -33,6 +33,7 @@ dependencies = [
 name = "ai-data-masking"
 version = "0.1.0"
 dependencies = [
+ "aho-corasick",
  "fancy-regex",
  "grok",
  "higress-wasm-rust",

--- a/plugins/wasm-rust/extensions/ai-data-masking/Cargo.toml
+++ b/plugins/wasm-rust/extensions/ai-data-masking/Cargo.toml
@@ -9,6 +9,7 @@ publish = false
 crate-type = ["cdylib"]
 
 [dependencies]
+aho-corasick = "1"
 higress-wasm-rust = { path = "../../", version = "0.1.0" }
 proxy-wasm = { git="https://github.com/higress-group/proxy-wasm-rust-sdk", branch="main", version="0.2.2" }
 serde = { version = "1.0", features = ["derive"] }

--- a/plugins/wasm-rust/extensions/ai-data-masking/Cargo.toml
+++ b/plugins/wasm-rust/extensions/ai-data-masking/Cargo.toml
@@ -14,7 +14,7 @@ higress-wasm-rust = { path = "../../", version = "0.1.0" }
 proxy-wasm = { git="https://github.com/higress-group/proxy-wasm-rust-sdk", branch="main", version="0.2.2" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-fancy-regex = "0"
+fancy-regex = "0.19"
 hmac-sha256 = "1"
 grok = "2"
 lazy_static = "1"

--- a/plugins/wasm-rust/extensions/ai-data-masking/src/ai_data_masking.rs
+++ b/plugins/wasm-rust/extensions/ai-data-masking/src/ai_data_masking.rs
@@ -14,6 +14,7 @@
 
 use crate::deny_word::DenyWord;
 use crate::msg_win_openai::MsgWindow;
+use aho_corasick::{AhoCorasick, AhoCorasickBuilder, AhoCorasickKind, MatchKind};
 use fancy_regex::Regex;
 use grok::patterns;
 use higress_wasm_rust::log::Log;
@@ -61,6 +62,7 @@ struct AiDataMasking {
     weak: Weak<RefCell<Box<dyn HttpContextWrapper<AiDataMaskingConfig>>>>,
     config: Option<Rc<AiDataMaskingConfig>>,
     mask_map: HashMap<String, Option<String>>,
+    mask_restore: Option<MaskRestore>,
     is_openai: bool,
     is_openai_stream: Option<bool>,
     stream: bool,
@@ -148,6 +150,131 @@ struct Rule {
     restore: bool,
     #[serde(default)]
     value: String,
+}
+
+struct MaskRestore {
+    matcher: AhoCorasick,
+    replacements: Vec<String>,
+}
+
+impl MaskRestore {
+    fn from_map(
+        mask_map: &HashMap<String, Option<String>>,
+    ) -> Result<Option<Self>, aho_corasick::BuildError> {
+        let mut pairs: Vec<(String, String)> = mask_map
+            .iter()
+            .filter_map(|(masked, original)| {
+                original
+                    .as_ref()
+                    .map(|original| (masked.clone(), original.clone()))
+            })
+            .collect();
+        if pairs.is_empty() {
+            return Ok(None);
+        }
+        pairs.sort_unstable_by(|left, right| left.0.cmp(&right.0));
+
+        let matcher = AhoCorasickBuilder::new()
+            .match_kind(MatchKind::LeftmostLongest)
+            .kind(Some(AhoCorasickKind::ContiguousNFA))
+            .build(pairs.iter().map(|(masked, _)| masked))?;
+        let replacements = pairs.into_iter().map(|(_, original)| original).collect();
+        Ok(Some(Self {
+            matcher,
+            replacements,
+        }))
+    }
+
+    fn restore(&self, message: &str) -> String {
+        let mut restored = String::with_capacity(message.len());
+        let mut last_end = 0;
+        for matched in self.matcher.find_iter(message) {
+            restored.push_str(&message[last_end..matched.start()]);
+            restored.push_str(&self.replacements[matched.pattern().as_usize()]);
+            last_end = matched.end();
+        }
+        if last_end == 0 {
+            return message.to_string();
+        }
+        restored.push_str(&message[last_end..]);
+        restored
+    }
+}
+
+fn record_restore_mapping(
+    mask_map: &mut HashMap<String, Option<String>>,
+    masked: String,
+    original: &str,
+) {
+    use std::collections::hash_map::Entry;
+
+    match mask_map.entry(masked) {
+        Entry::Vacant(entry) => {
+            entry.insert(Some(original.to_string()));
+        }
+        Entry::Occupied(mut entry) => match entry.get() {
+            Some(existing) if existing == original => {}
+            Some(_) => {
+                entry.insert(None);
+            }
+            None => {}
+        },
+    }
+}
+
+fn replace_rule_message(
+    rule: &Rule,
+    message: &str,
+    mask_map: &mut HashMap<String, Option<String>>,
+    byte_window_size: &mut usize,
+    char_window_size: &mut usize,
+) -> (String, usize) {
+    let mut replaced = String::with_capacity(message.len());
+    let mut last_end = 0;
+    let mut match_count = 0;
+
+    for captures in rule.regex.captures_iter(message) {
+        let captures = match captures {
+            Ok(captures) => captures,
+            Err(_) => continue,
+        };
+        let matched = captures.get(0).unwrap();
+        replaced.push_str(&message[last_end..matched.start()]);
+
+        let original = matched.as_str();
+        let masked = match rule.type_ {
+            Type::Hash => {
+                let digest = hmac_sha256::Hash::hash(original.as_bytes());
+                digest.iter().fold(String::new(), |mut output, byte| {
+                    let _ = write!(output, "{byte:02x}");
+                    output
+                })
+            }
+            Type::Replace => {
+                let mut expanded = String::new();
+                captures.expand(&rule.value, &mut expanded);
+                expanded
+            }
+        };
+
+        if rule.type_ == Type::Hash || rule.restore {
+            *byte_window_size = (*byte_window_size).max(masked.len());
+            *char_window_size = (*char_window_size).max(masked.chars().count());
+        }
+        if rule.restore && !masked.is_empty() {
+            record_restore_mapping(mask_map, masked.clone(), original);
+        }
+
+        replaced.push_str(&masked);
+        last_end = matched.end();
+        match_count += 1;
+    }
+
+    if match_count == 0 {
+        return (message.to_string(), 0);
+    }
+    replaced.push_str(&message[last_end..]);
+    (replaced, match_count)
 }
 fn default_deny_openai() -> bool {
     true
@@ -354,6 +481,7 @@ impl RootContextWrapper<AiDataMaskingConfig> for AiDataMaskingRoot {
         Some(Box::new(AiDataMasking {
             weak: Weak::default(),
             mask_map: HashMap::new(),
+            mask_restore: None,
             config: None,
             is_openai: false,
             is_openai_stream: None,
@@ -431,58 +559,42 @@ impl AiDataMasking {
     fn replace_request_msg(&mut self, message: &str) -> String {
         let config = self.config.as_ref().unwrap();
         let mut msg = message.to_string();
+        let mut match_count = 0;
         for rule in &config.replace_roles {
-            let mut replace_pair = Vec::new();
-            if rule.type_ == Type::Replace && !rule.restore {
-                msg = rule.regex.replace_all(&msg, &rule.value).to_string();
-            } else {
-                for mc in rule.regex.find_iter(&msg) {
-                    if mc.is_err() {
-                        continue;
-                    }
-                    let m = mc.unwrap();
-                    let from_word = m.as_str();
-
-                    let to_word = match rule.type_ {
-                        Type::Hash => {
-                            let digest = hmac_sha256::Hash::hash(from_word.as_bytes());
-                            digest.iter().fold(String::new(), |mut output, b| {
-                                let _ = write!(output, "{b:02x}");
-                                output
-                            })
-                        }
-                        Type::Replace => rule.regex.replace(from_word, &rule.value).to_string(),
-                    };
-                    if to_word.len() > self.byte_window_size {
-                        self.byte_window_size = to_word.len();
-                    }
-                    if to_word.chars().count() > self.char_window_size {
-                        self.char_window_size = to_word.chars().count();
-                    }
-
-                    replace_pair.push((from_word.to_string(), to_word.clone()));
-
-                    if rule.restore && !to_word.is_empty() {
-                        match self.mask_map.entry(to_word) {
-                            std::collections::hash_map::Entry::Occupied(mut e) => {
-                                e.insert(None);
-                            }
-                            std::collections::hash_map::Entry::Vacant(e) => {
-                                e.insert(Some(from_word.to_string()));
-                            }
-                        }
-                    }
-                }
-                for (from_word, to_word) in replace_pair {
-                    msg = msg.replace(&from_word, &to_word);
-                }
-            }
+            let (new_msg, rule_match_count) = replace_rule_message(
+                rule,
+                &msg,
+                &mut self.mask_map,
+                &mut self.byte_window_size,
+                &mut self.char_window_size,
+            );
+            msg = new_msg;
+            match_count += rule_match_count;
         }
         if msg != message {
-            self.log()
-                .debug(&format!("replace_request_msg from {} to {}", message, msg));
+            self.log().debug(&format!(
+                "replace_request_msg completed: input_bytes={}, output_bytes={}, matches={}",
+                message.len(),
+                msg.len(),
+                match_count
+            ));
         }
         msg
+    }
+
+    fn forward_request_body(&mut self, body: &str) -> DataAction {
+        match MaskRestore::from_map(&self.mask_map) {
+            Ok(mask_restore) => self.mask_restore = mask_restore,
+            Err(error) => {
+                self.log().error(&format!(
+                    "failed to build response restore matcher: {}",
+                    error
+                ));
+                return self.deny(false);
+            }
+        }
+        self.replace_http_request_body(body.as_bytes());
+        DataAction::Continue
     }
 }
 
@@ -523,6 +635,7 @@ impl HttpContext for AiDataMasking {
                     .push(&body, self.is_openai_stream.unwrap_or_default());
                 let mut deny = false;
                 let log = Log::new(PLUGIN_NAME.to_string());
+                let mask_restore = self.mask_restore.as_ref();
                 for message in self.msg_window.messages_iter_mut() {
                     if let Ok(mut msg) = String::from_utf8(message.clone()) {
                         if let Some(config) = &self.config {
@@ -531,12 +644,8 @@ impl HttpContext for AiDataMasking {
                                 break;
                             }
                         }
-                        if !self.mask_map.is_empty() {
-                            for (from_word, to_word) in self.mask_map.iter() {
-                                if let Some(to) = to_word {
-                                    msg = msg.replace(from_word, to);
-                                }
-                            }
+                        if let Some(mask_restore) = mask_restore {
+                            msg = mask_restore.restore(&msg);
                         }
                         message.clear();
                         message.extend_from_slice(msg.as_bytes());
@@ -620,8 +729,7 @@ impl HttpContextWrapper<AiDataMaskingConfig> for AiDataMasking {
                         );
                     }
                 }
-                self.replace_http_request_body(req_body.as_bytes());
-                return DataAction::Continue;
+                return self.forward_request_body(&req_body);
             }
         }
         if !config.deny_jsonpath.is_empty() {
@@ -645,8 +753,7 @@ impl HttpContextWrapper<AiDataMaskingConfig> for AiDataMasking {
                         }
                     }
                 }
-                self.replace_http_request_body(req_body.as_bytes());
-                return DataAction::Continue;
+                return self.forward_request_body(&req_body);
             }
         }
         if config.deny_raw {
@@ -655,7 +762,7 @@ impl HttpContextWrapper<AiDataMaskingConfig> for AiDataMasking {
             }
             let new_body = self.replace_request_msg(&req_body);
             if new_body != req_body {
-                self.replace_http_request_body(new_body.as_bytes())
+                return self.forward_request_body(&new_body);
             }
             return DataAction::Continue;
         }
@@ -686,18 +793,12 @@ impl HttpContextWrapper<AiDataMaskingConfig> for AiDataMasking {
                             return self.deny(true);
                         }
 
-                        if self.mask_map.is_empty() {
+                        let Some(mask_restore) = &self.mask_restore else {
                             continue;
-                        }
-                        let mut new_content = message.content.clone();
-                        let mut new_reasoning_content = message.reasoning_content.clone();
-                        for (from_word, to_word) in self.mask_map.iter() {
-                            if let Some(to) = to_word {
-                                new_content = new_content.replace(from_word, to);
-                                new_reasoning_content =
-                                    new_reasoning_content.replace(from_word, to);
-                            }
-                        }
+                        };
+                        let new_content = mask_restore.restore(&message.content);
+                        let new_reasoning_content =
+                            mask_restore.restore(&message.reasoning_content);
                         if new_content != message.content {
                             res_body = res_body.replace(
                                 &Value::String(message.content).to_string(),
@@ -721,16 +822,124 @@ impl HttpContextWrapper<AiDataMaskingConfig> for AiDataMasking {
             if self.check_message(&res_body) {
                 return self.deny(true);
             }
-            if !self.mask_map.is_empty() {
-                for (from_word, to_word) in self.mask_map.iter() {
-                    if let Some(to) = to_word {
-                        res_body = res_body.replace(from_word, to);
-                    }
-                }
+            if let Some(mask_restore) = &self.mask_restore {
+                res_body = mask_restore.restore(&res_body);
             }
             self.replace_http_response_body(res_body.as_bytes());
             return DataAction::Continue;
         }
         DataAction::Continue
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::{Duration, Instant};
+
+    fn rule(regex: &str, type_: Type, restore: bool, value: &str) -> Rule {
+        Rule {
+            regex: Regex::new(regex).unwrap(),
+            type_,
+            restore,
+            value: value.to_string(),
+        }
+    }
+
+    fn replace(rule: &Rule, message: &str) -> (String, HashMap<String, Option<String>>, usize) {
+        let mut mask_map = HashMap::new();
+        let mut byte_window_size = 0;
+        let mut char_window_size = 0;
+        let (replaced, match_count) = replace_rule_message(
+            rule,
+            message,
+            &mut mask_map,
+            &mut byte_window_size,
+            &mut char_window_size,
+        );
+        (replaced, mask_map, match_count)
+    }
+
+    #[test]
+    fn replacement_expands_captures_for_each_match_context() {
+        let rule = rule(
+            r"(?<=(?<context>[ab]))x",
+            Type::Replace,
+            false,
+            "${context}-x",
+        );
+
+        let (replaced, _, match_count) = replace(&rule, "ax bx");
+
+        assert_eq!(replaced, "aa-x bb-x");
+        assert_eq!(match_count, 2);
+    }
+
+    #[test]
+    fn repeated_hash_keeps_restore_mapping() {
+        let rule = rule(r"\d{8}", Type::Hash, true, "");
+        let original = "12345678 12345678";
+
+        let (masked, mut mask_map, match_count) = replace(&rule, original);
+        let mask_restore = MaskRestore::from_map(&mask_map).unwrap().unwrap();
+
+        assert_eq!(match_count, 2);
+        assert_eq!(mask_map.len(), 1);
+        assert_eq!(
+            mask_map.values().next().unwrap().as_deref(),
+            Some("12345678")
+        );
+        assert_eq!(mask_restore.restore(&masked), original);
+
+        let masked_value = mask_map.keys().next().unwrap().clone();
+        record_restore_mapping(&mut mask_map, masked_value, "87654321");
+        assert_eq!(mask_map.values().next().unwrap(), &None);
+    }
+
+    #[test]
+    fn restores_more_than_five_thousand_unique_values() {
+        let mask_map: HashMap<_, _> = (0..6_001)
+            .map(|index| {
+                (
+                    format!("__mask_{index:06}__"),
+                    Some(format!("secret-{index:06}")),
+                )
+            })
+            .collect();
+        let masked = (0..6_001)
+            .map(|index| format!("__mask_{index:06}__"))
+            .collect::<Vec<_>>()
+            .join("|");
+        let expected = (0..6_001)
+            .map(|index| format!("secret-{index:06}"))
+            .collect::<Vec<_>>()
+            .join("|");
+
+        let mask_restore = MaskRestore::from_map(&mask_map).unwrap().unwrap();
+
+        assert_eq!(mask_restore.restore(&masked), expected);
+    }
+
+    #[test]
+    fn masks_forty_five_thousand_unique_values_without_per_word_replacement() {
+        let rule = rule(r"\d{11}", Type::Hash, true, "");
+        let message = (0..45_000)
+            .map(|index| format!("{index:011}"))
+            .collect::<Vec<_>>()
+            .join(",");
+        let started = Instant::now();
+
+        let (masked, mask_map, match_count) = replace(&rule, &message);
+        let mask_restore = MaskRestore::from_map(&mask_map).unwrap().unwrap();
+        let restored = mask_restore.restore(&masked);
+
+        assert_eq!(match_count, 45_000);
+        assert_eq!(mask_map.len(), 45_000);
+        assert_eq!(masked.len(), 45_000 * 64 + 44_999);
+        assert_eq!(restored, message);
+        assert!(
+            started.elapsed() < Duration::from_secs(30),
+            "45,000-value regression guard exceeded its intentionally broad limit"
+        );
     }
 }

--- a/plugins/wasm-rust/extensions/ai-data-masking/src/ai_data_masking.rs
+++ b/plugins/wasm-rust/extensions/ai-data-masking/src/ai_data_masking.rs
@@ -14,7 +14,7 @@
 
 use crate::deny_word::DenyWord;
 use crate::msg_win_openai::MsgWindow;
-use aho_corasick::{AhoCorasick, AhoCorasickBuilder, AhoCorasickKind, MatchKind};
+use aho_corasick::{AhoCorasick, AhoCorasickBuilder, AhoCorasickKind, Input, MatchKind};
 use fancy_regex::Regex;
 use grok::patterns;
 use higress_wasm_rust::log::Log;
@@ -61,7 +61,7 @@ struct AiDataMaskingRoot {
 struct AiDataMasking {
     weak: Weak<RefCell<Box<dyn HttpContextWrapper<AiDataMaskingConfig>>>>,
     config: Option<Rc<AiDataMaskingConfig>>,
-    mask_map: HashMap<String, Option<String>>,
+    mask_map: HashMap<String, RestoreEntry>,
     mask_restore: Option<MaskRestore>,
     is_openai: bool,
     is_openai_stream: Option<bool>,
@@ -153,45 +153,168 @@ struct Rule {
 }
 
 struct MaskRestore {
+    general: Option<GeneralRestore>,
+    hashes: HashMap<String, String>,
+}
+
+struct GeneralRestore {
     matcher: AhoCorasick,
     replacements: Vec<String>,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum RestoreKind {
+    Hash,
+    General,
+}
+
+struct RestoreEntry {
+    original: Option<String>,
+    kind: RestoreKind,
+}
+
+#[derive(Debug)]
+enum RestoreBuildError {
+    TooManyGeneralPatterns(usize),
+    GeneralPatternBytesExceeded(usize),
+    Matcher(aho_corasick::BuildError),
+}
+
+impl std::fmt::Display for RestoreBuildError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::TooManyGeneralPatterns(count) => write!(
+                formatter,
+                "general restore pattern count {} exceeds limit {}",
+                count, MAX_GENERAL_RESTORE_PATTERNS
+            ),
+            Self::GeneralPatternBytesExceeded(bytes) => write!(
+                formatter,
+                "general restore pattern bytes {} exceeds limit {}",
+                bytes, MAX_GENERAL_RESTORE_PATTERN_BYTES
+            ),
+            Self::Matcher(error) => write!(formatter, "{}", error),
+        }
+    }
+}
+
+impl From<aho_corasick::BuildError> for RestoreBuildError {
+    fn from(error: aho_corasick::BuildError) -> Self {
+        Self::Matcher(error)
+    }
+}
+
+const HASH_MASK_BYTES: usize = 64;
+const MAX_GENERAL_RESTORE_PATTERNS: usize = 1_024;
+const MAX_GENERAL_RESTORE_PATTERN_BYTES: usize = 64 * 1_024;
+
 impl MaskRestore {
     fn from_map(
-        mask_map: &HashMap<String, Option<String>>,
-    ) -> Result<Option<Self>, aho_corasick::BuildError> {
-        let mut pairs: Vec<(String, String)> = mask_map
-            .iter()
-            .filter_map(|(masked, original)| {
-                original
-                    .as_ref()
-                    .map(|original| (masked.clone(), original.clone()))
-            })
-            .collect();
-        if pairs.is_empty() {
+        mask_map: HashMap<String, RestoreEntry>,
+    ) -> Result<Option<Self>, RestoreBuildError> {
+        let mut hashes = HashMap::new();
+        let mut general_pairs = Vec::new();
+        let mut general_pattern_bytes = 0;
+        for (masked, entry) in mask_map {
+            let Some(original) = entry.original else {
+                continue;
+            };
+            match entry.kind {
+                RestoreKind::Hash => {
+                    hashes.insert(masked, original);
+                }
+                RestoreKind::General => {
+                    general_pattern_bytes += masked.len();
+                    general_pairs.push((masked, original));
+                }
+            }
+        }
+
+        if general_pairs.len() > MAX_GENERAL_RESTORE_PATTERNS {
+            return Err(RestoreBuildError::TooManyGeneralPatterns(
+                general_pairs.len(),
+            ));
+        }
+        if general_pattern_bytes > MAX_GENERAL_RESTORE_PATTERN_BYTES {
+            return Err(RestoreBuildError::GeneralPatternBytesExceeded(
+                general_pattern_bytes,
+            ));
+        }
+        if hashes.is_empty() && general_pairs.is_empty() {
             return Ok(None);
         }
-        pairs.sort_unstable_by(|left, right| left.0.cmp(&right.0));
+        general_pairs.sort_unstable_by(|left, right| left.0.cmp(&right.0));
 
-        let matcher = AhoCorasickBuilder::new()
-            .match_kind(MatchKind::LeftmostLongest)
-            .kind(Some(AhoCorasickKind::ContiguousNFA))
-            .build(pairs.iter().map(|(masked, _)| masked))?;
-        let replacements = pairs.into_iter().map(|(_, original)| original).collect();
-        Ok(Some(Self {
-            matcher,
-            replacements,
-        }))
+        let general = if general_pairs.is_empty() {
+            None
+        } else {
+            let matcher = AhoCorasickBuilder::new()
+                .match_kind(MatchKind::LeftmostLongest)
+                .kind(Some(AhoCorasickKind::ContiguousNFA))
+                .build(general_pairs.iter().map(|(masked, _)| masked))?;
+            let replacements = general_pairs
+                .into_iter()
+                .map(|(_, original)| original)
+                .collect();
+            Some(GeneralRestore {
+                matcher,
+                replacements,
+            })
+        };
+        Ok(Some(Self { general, hashes }))
     }
 
     fn restore(&self, message: &str) -> String {
         let mut restored = String::with_capacity(message.len());
         let mut last_end = 0;
-        for matched in self.matcher.find_iter(message) {
-            restored.push_str(&message[last_end..matched.start()]);
-            restored.push_str(&self.replacements[matched.pattern().as_usize()]);
-            last_end = matched.end();
+        let mut next_general = self.next_general_match(message, 0);
+        let mut hash_cursor = 0;
+        let mut next_hash = next_hash_match(message, &self.hashes, &mut hash_cursor);
+
+        while next_general.is_some() || next_hash.is_some() {
+            let use_general = match (&next_general, &next_hash) {
+                (Some(general), Some((hash_start, hash_end, _))) => {
+                    general.start() < *hash_start
+                        || (general.start() == *hash_start
+                            && general.end() - general.start() >= hash_end - hash_start)
+                }
+                (Some(_), None) => true,
+                (None, Some(_)) => false,
+                (None, None) => break,
+            };
+
+            let (start, end, replacement) = if use_general {
+                let matched = next_general.take().unwrap();
+                let general = self.general.as_ref().unwrap();
+                let replacement = &general.replacements[matched.pattern().as_usize()];
+                (matched.start(), matched.end(), replacement.as_str())
+            } else {
+                let (start, end, replacement) = next_hash.take().unwrap();
+                (start, end, replacement)
+            };
+
+            restored.push_str(&message[last_end..start]);
+            restored.push_str(replacement);
+            last_end = end;
+
+            if use_general {
+                next_general = self.next_general_match(message, last_end);
+                if next_hash
+                    .as_ref()
+                    .is_some_and(|(hash_start, _, _)| *hash_start < last_end)
+                {
+                    hash_cursor = last_end;
+                    next_hash = next_hash_match(message, &self.hashes, &mut hash_cursor);
+                }
+            } else {
+                next_hash = next_hash_match(message, &self.hashes, &mut hash_cursor);
+                if next_general
+                    .as_ref()
+                    .is_some_and(|general| general.start() < last_end)
+                {
+                    next_general = self.next_general_match(message, last_end);
+                }
+            }
         }
         if last_end == 0 {
             return message.to_string();
@@ -199,23 +322,63 @@ impl MaskRestore {
         restored.push_str(&message[last_end..]);
         restored
     }
+
+    fn next_general_match(&self, message: &str, start: usize) -> Option<aho_corasick::Match> {
+        self.general.as_ref().and_then(|general| {
+            general
+                .matcher
+                .find(Input::new(message).span(start..message.len()))
+        })
+    }
+}
+
+fn next_hash_match<'a>(
+    message: &str,
+    hashes: &'a HashMap<String, String>,
+    cursor: &mut usize,
+) -> Option<(usize, usize, &'a str)> {
+    let bytes = message.as_bytes();
+    while *cursor + HASH_MASK_BYTES <= bytes.len() {
+        let start = *cursor;
+        *cursor += 1;
+        let candidate = &bytes[start..start + HASH_MASK_BYTES];
+        if candidate
+            .iter()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(byte))
+        {
+            let candidate = std::str::from_utf8(candidate).unwrap();
+            if let Some(original) = hashes.get(candidate) {
+                *cursor = start + HASH_MASK_BYTES;
+                return Some((start, start + HASH_MASK_BYTES, original));
+            }
+        }
+    }
+    None
 }
 
 fn record_restore_mapping(
-    mask_map: &mut HashMap<String, Option<String>>,
+    mask_map: &mut HashMap<String, RestoreEntry>,
     masked: String,
     original: &str,
+    kind: RestoreKind,
 ) {
     use std::collections::hash_map::Entry;
 
     match mask_map.entry(masked) {
         Entry::Vacant(entry) => {
-            entry.insert(Some(original.to_string()));
+            entry.insert(RestoreEntry {
+                original: Some(original.to_string()),
+                kind,
+            });
         }
-        Entry::Occupied(mut entry) => match entry.get() {
-            Some(existing) if existing == original => {}
+        Entry::Occupied(mut entry) => match entry.get().original.as_deref() {
+            Some(existing) if existing == original => {
+                if kind == RestoreKind::Hash {
+                    entry.get_mut().kind = RestoreKind::Hash;
+                }
+            }
             Some(_) => {
-                entry.insert(None);
+                entry.get_mut().original = None;
             }
             None => {}
         },
@@ -225,19 +388,16 @@ fn record_restore_mapping(
 fn replace_rule_message(
     rule: &Rule,
     message: &str,
-    mask_map: &mut HashMap<String, Option<String>>,
+    mask_map: &mut HashMap<String, RestoreEntry>,
     byte_window_size: &mut usize,
     char_window_size: &mut usize,
-) -> (String, usize) {
+) -> Result<(String, usize), fancy_regex::Error> {
     let mut replaced = String::with_capacity(message.len());
     let mut last_end = 0;
     let mut match_count = 0;
 
     for captures in rule.regex.captures_iter(message) {
-        let captures = match captures {
-            Ok(captures) => captures,
-            Err(_) => continue,
-        };
+        let captures = captures?;
         let matched = captures.get(0).unwrap();
         replaced.push_str(&message[last_end..matched.start()]);
 
@@ -262,7 +422,12 @@ fn replace_rule_message(
             *char_window_size = (*char_window_size).max(masked.chars().count());
         }
         if rule.restore && !masked.is_empty() {
-            record_restore_mapping(mask_map, masked.clone(), original);
+            let kind = if rule.type_ == Type::Hash {
+                RestoreKind::Hash
+            } else {
+                RestoreKind::General
+            };
+            record_restore_mapping(mask_map, masked.clone(), original, kind);
         }
 
         replaced.push_str(&masked);
@@ -271,10 +436,10 @@ fn replace_rule_message(
     }
 
     if match_count == 0 {
-        return (message.to_string(), 0);
+        return Ok((message.to_string(), 0));
     }
     replaced.push_str(&message[last_end..]);
-    (replaced, match_count)
+    Ok((replaced, match_count))
 }
 fn default_deny_openai() -> bool {
     true
@@ -556,7 +721,7 @@ impl AiDataMasking {
         DataAction::StopIterationAndBuffer
     }
 
-    fn replace_request_msg(&mut self, message: &str) -> String {
+    fn replace_request_msg(&mut self, message: &str) -> Result<String, fancy_regex::Error> {
         let config = self.config.as_ref().unwrap();
         let mut msg = message.to_string();
         let mut match_count = 0;
@@ -567,7 +732,7 @@ impl AiDataMasking {
                 &mut self.mask_map,
                 &mut self.byte_window_size,
                 &mut self.char_window_size,
-            );
+            )?;
             msg = new_msg;
             match_count += rule_match_count;
         }
@@ -579,11 +744,11 @@ impl AiDataMasking {
                 match_count
             ));
         }
-        msg
+        Ok(msg)
     }
 
     fn forward_request_body(&mut self, body: &str) -> DataAction {
-        match MaskRestore::from_map(&self.mask_map) {
+        match MaskRestore::from_map(std::mem::take(&mut self.mask_map)) {
             Ok(mask_restore) => self.mask_restore = mask_restore,
             Err(error) => {
                 self.log().error(&format!(
@@ -595,6 +760,12 @@ impl AiDataMasking {
         }
         self.replace_http_request_body(body.as_bytes());
         DataAction::Continue
+    }
+
+    fn deny_request_masking_error(&mut self, error: &fancy_regex::Error) -> DataAction {
+        self.log()
+            .error(&format!("request masking regex failed: {}", error));
+        self.deny(false)
     }
 }
 
@@ -714,8 +885,15 @@ impl HttpContextWrapper<AiDataMaskingConfig> for AiDataMasking {
                     {
                         return self.deny(false);
                     }
-                    let new_content = self.replace_request_msg(&msg.content);
-                    let new_reasoning_content = self.replace_request_msg(&msg.reasoning_content);
+                    let new_content = match self.replace_request_msg(&msg.content) {
+                        Ok(content) => content,
+                        Err(error) => return self.deny_request_masking_error(&error),
+                    };
+                    let new_reasoning_content =
+                        match self.replace_request_msg(&msg.reasoning_content) {
+                            Ok(content) => content,
+                            Err(error) => return self.deny_request_masking_error(&error),
+                        };
                     if new_content != msg.content {
                         req_body = req_body.replace(
                             &Value::String(msg.content).to_string(),
@@ -742,7 +920,10 @@ impl HttpContextWrapper<AiDataMaskingConfig> for AiDataMasking {
                                     return self.deny(false);
                                 }
                                 let content = s.to_string();
-                                let new_content = self.replace_request_msg(&content);
+                                let new_content = match self.replace_request_msg(&content) {
+                                    Ok(content) => content,
+                                    Err(error) => return self.deny_request_masking_error(&error),
+                                };
                                 if new_content != content {
                                     req_body = req_body.replace(
                                         &Value::String(content).to_string(),
@@ -760,7 +941,10 @@ impl HttpContextWrapper<AiDataMaskingConfig> for AiDataMasking {
             if self.check_message(&req_body) {
                 return self.deny(false);
             }
-            let new_body = self.replace_request_msg(&req_body);
+            let new_body = match self.replace_request_msg(&req_body) {
+                Ok(body) => body,
+                Err(error) => return self.deny_request_masking_error(&error),
+            };
             if new_body != req_body {
                 return self.forward_request_body(&new_body);
             }
@@ -846,7 +1030,7 @@ mod tests {
         }
     }
 
-    fn replace(rule: &Rule, message: &str) -> (String, HashMap<String, Option<String>>, usize) {
+    fn replace(rule: &Rule, message: &str) -> (String, HashMap<String, RestoreEntry>, usize) {
         let mut mask_map = HashMap::new();
         let mut byte_window_size = 0;
         let mut char_window_size = 0;
@@ -856,7 +1040,8 @@ mod tests {
             &mut mask_map,
             &mut byte_window_size,
             &mut char_window_size,
-        );
+        )
+        .unwrap();
         (replaced, mask_map, match_count)
     }
 
@@ -880,20 +1065,42 @@ mod tests {
         let rule = rule(r"\d{8}", Type::Hash, true, "");
         let original = "12345678 12345678";
 
-        let (masked, mut mask_map, match_count) = replace(&rule, original);
-        let mask_restore = MaskRestore::from_map(&mask_map).unwrap().unwrap();
+        let (masked, mask_map, match_count) = replace(&rule, original);
 
         assert_eq!(match_count, 2);
         assert_eq!(mask_map.len(), 1);
         assert_eq!(
-            mask_map.values().next().unwrap().as_deref(),
+            mask_map.values().next().unwrap().original.as_deref(),
             Some("12345678")
         );
+        assert_eq!(mask_map.values().next().unwrap().kind, RestoreKind::Hash);
+        let mask_restore = MaskRestore::from_map(mask_map).unwrap().unwrap();
         assert_eq!(mask_restore.restore(&masked), original);
 
-        let masked_value = mask_map.keys().next().unwrap().clone();
-        record_restore_mapping(&mut mask_map, masked_value, "87654321");
-        assert_eq!(mask_map.values().next().unwrap(), &None);
+        let mut collision_map = HashMap::new();
+        record_restore_mapping(
+            &mut collision_map,
+            "token".to_string(),
+            "12345678",
+            RestoreKind::Hash,
+        );
+        record_restore_mapping(
+            &mut collision_map,
+            "token".to_string(),
+            "12345678",
+            RestoreKind::Hash,
+        );
+        assert_eq!(
+            collision_map.get("token").unwrap().original.as_deref(),
+            Some("12345678")
+        );
+        record_restore_mapping(
+            &mut collision_map,
+            "token".to_string(),
+            "87654321",
+            RestoreKind::General,
+        );
+        assert!(collision_map.get("token").unwrap().original.is_none());
     }
 
     #[test]
@@ -901,13 +1108,16 @@ mod tests {
         let mask_map: HashMap<_, _> = (0..6_001)
             .map(|index| {
                 (
-                    format!("__mask_{index:06}__"),
-                    Some(format!("secret-{index:06}")),
+                    format!("{index:064x}"),
+                    RestoreEntry {
+                        original: Some(format!("secret-{index:06}")),
+                        kind: RestoreKind::Hash,
+                    },
                 )
             })
             .collect();
         let masked = (0..6_001)
-            .map(|index| format!("__mask_{index:06}__"))
+            .map(|index| format!("{index:064x}"))
             .collect::<Vec<_>>()
             .join("|");
         let expected = (0..6_001)
@@ -915,9 +1125,108 @@ mod tests {
             .collect::<Vec<_>>()
             .join("|");
 
-        let mask_restore = MaskRestore::from_map(&mask_map).unwrap().unwrap();
+        let mask_restore = MaskRestore::from_map(mask_map).unwrap().unwrap();
 
+        assert!(mask_restore.general.is_none());
+        assert_eq!(mask_restore.hashes.len(), 6_001);
         assert_eq!(mask_restore.restore(&masked), expected);
+    }
+
+    #[test]
+    fn regex_runtime_error_is_returned_without_retrying() {
+        let regex = fancy_regex::RegexBuilder::new("(?i)(a|b|ab)*(?=c)")
+            .backtrack_limit(100)
+            .build()
+            .unwrap();
+        let rule = Rule {
+            regex,
+            type_: Type::Replace,
+            restore: false,
+            value: "masked".to_string(),
+        };
+        let mut mask_map = HashMap::new();
+        let mut byte_window_size = 0;
+        let mut char_window_size = 0;
+        let started = Instant::now();
+
+        let result = replace_rule_message(
+            &rule,
+            "abababababababababababababababababababababababababababab",
+            &mut mask_map,
+            &mut byte_window_size,
+            &mut char_window_size,
+        );
+
+        assert!(matches!(
+            result,
+            Err(fancy_regex::Error::RuntimeError(
+                fancy_regex::RuntimeError::BacktrackLimitExceeded
+            ))
+        ));
+        assert!(started.elapsed() < Duration::from_secs(5));
+    }
+
+    #[test]
+    fn general_restore_limit_is_explicit() {
+        let mask_map: HashMap<_, _> = (0..=MAX_GENERAL_RESTORE_PATTERNS)
+            .map(|index| {
+                (
+                    format!("mask-{index}"),
+                    RestoreEntry {
+                        original: Some(format!("secret-{index}")),
+                        kind: RestoreKind::General,
+                    },
+                )
+            })
+            .collect();
+
+        assert!(matches!(
+            MaskRestore::from_map(mask_map),
+            Err(RestoreBuildError::TooManyGeneralPatterns(count))
+                if count == MAX_GENERAL_RESTORE_PATTERNS + 1
+        ));
+
+        let mask_map = HashMap::from([(
+            "x".repeat(MAX_GENERAL_RESTORE_PATTERN_BYTES + 1),
+            RestoreEntry {
+                original: Some("secret".to_string()),
+                kind: RestoreKind::General,
+            },
+        )]);
+        assert!(matches!(
+            MaskRestore::from_map(mask_map),
+            Err(RestoreBuildError::GeneralPatternBytesExceeded(bytes))
+                if bytes == MAX_GENERAL_RESTORE_PATTERN_BYTES + 1
+        ));
+    }
+
+    #[test]
+    fn hash_and_general_matches_use_global_leftmost_longest_order() {
+        let hash = "a".repeat(HASH_MASK_BYTES);
+        let longer_general = "a".repeat(HASH_MASK_BYTES + 1);
+        let later_general = format!("{}Z", "a".repeat(HASH_MASK_BYTES - 1));
+        let earlier_general = format!("g{}", "a".repeat(HASH_MASK_BYTES / 2));
+        let mut mask_map = HashMap::new();
+        for (masked, original, kind) in [
+            (hash.clone(), "HASH", RestoreKind::Hash),
+            (longer_general.clone(), "LONG", RestoreKind::General),
+            (later_general, "LATER", RestoreKind::General),
+            (earlier_general.clone(), "EARLIER", RestoreKind::General),
+        ] {
+            record_restore_mapping(&mut mask_map, masked, original, kind);
+        }
+        let message = format!(
+            "{}|{}Z|{}{}",
+            longer_general,
+            hash,
+            earlier_general,
+            "a".repeat(HASH_MASK_BYTES / 2)
+        );
+        let expected = format!("LONG|HASHZ|EARLIER{}", "a".repeat(HASH_MASK_BYTES / 2));
+
+        let mask_restore = MaskRestore::from_map(mask_map).unwrap().unwrap();
+
+        assert_eq!(mask_restore.restore(&message), expected);
     }
 
     #[test]
@@ -930,11 +1239,14 @@ mod tests {
         let started = Instant::now();
 
         let (masked, mask_map, match_count) = replace(&rule, &message);
-        let mask_restore = MaskRestore::from_map(&mask_map).unwrap().unwrap();
+        let mask_count = mask_map.len();
+        let mask_restore = MaskRestore::from_map(mask_map).unwrap().unwrap();
         let restored = mask_restore.restore(&masked);
 
         assert_eq!(match_count, 45_000);
-        assert_eq!(mask_map.len(), 45_000);
+        assert_eq!(mask_count, 45_000);
+        assert!(mask_restore.general.is_none());
+        assert_eq!(mask_restore.hashes.len(), 45_000);
         assert_eq!(masked.len(), 45_000 * 64 + 44_999);
         assert_eq!(restored, message);
         assert!(

--- a/plugins/wasm-rust/extensions/ai-data-masking/src/ai_data_masking.rs
+++ b/plugins/wasm-rust/extensions/ai-data-masking/src/ai_data_masking.rs
@@ -1134,8 +1134,8 @@ mod tests {
 
     #[test]
     fn regex_runtime_error_is_returned_without_retrying() {
-        let regex = fancy_regex::RegexBuilder::new("(?i)(a|b|ab)*(?=c)")
-            .backtrack_limit(100)
+        let regex = fancy_regex::RegexBuilder::new("(x+x+)+(?>y)")
+            .backtrack_limit(1)
             .build()
             .unwrap();
         let rule = Rule {
@@ -1151,7 +1151,7 @@ mod tests {
 
         let result = replace_rule_message(
             &rule,
-            "abababababababababababababababababababababababababababab",
+            "xxxxxxxxxxy",
             &mut mask_map,
             &mut byte_window_size,
             &mut char_window_size,


### PR DESCRIPTION
## I. Summary

This change prevents `ai-data-masking` from monopolizing an Envoy worker when
`type: hash` and `restore: true` produce many distinct restore entries.

The request path now constructs the masked message in one pass instead of
replacing the complete message once per match. The response path separates
SHA-256 restore keys from general replacement strings: hash keys are found by
a bounded-width scan with hash-map lookups, while general strings use a bounded
Aho-Corasick matcher. Existing collision and leftmost-longest restore semantics
are preserved.

The plugin also pins `fancy-regex` 0.19.0, which includes the upstream fix for an infinite loop after the backtracking limit is exceeded.

There is no configuration or migration change.

## II. Related issue

N/A: the diagnosis originated from a private incident/work item and there is no
public GitHub issue. No private incident identifiers or credentials are included
in this PR.

## III. Change type

- [x] Bug fix
- [ ] Feature or enhancement
- [ ] Documentation or configuration only
- [x] Refactoring, tests, or maintenance

## IV. Agent participation and issue-spec gate

See the [agent-assisted contribution policy](https://github.com/higress-group/higress/blob/main/docs/developers/agent-assisted-contributions.md).
Materially agent-assisted PRs that miss the gate receive low review priority,
and timely maintainer review is not guaranteed; this author declaration is the
deterministic prioritization signal.

- [ ] **No agent participation:** This PR is human-only.
- [ ] **Trivial agent-use exception:** Agent use was limited to spelling,
      punctuation, whitespace, or formatting with no substantive choice or
      behavioral effect; the explanation is below.
- [x] **Material agent participation:** An AI or coding agent materially
      participated in analysis, design, implementation, testing, and PR
      preparation.

For material participation:

- [ ] **Before implementation began:** A Higress maintainer had approved the
      Proposal and Design Issues, and authorized implementation TASKs linked the
      work to the applicable SPECs.
- [ ] **Before verification began:** The Design contained a concrete
      Verification Plan.
- [ ] **Before requesting maintainer review or acceptance:** Applicable
      implementation and verification TASKs were `done` with exact commands,
      results, evidence links, and hashes.

Overall gate status:

- [ ] Complete: all three timed obligations above were satisfied.
- [x] Noncompliant: one or more obligations were not satisfied; explain below.
- [ ] N/A because the PR is human-only or qualifies for the trivial exception.

**Gate-status explanation (or N/A):**

The implementation and verification began without maintainer-approved Proposal
and Design Issues. This is declared as noncompliant rather than fabricating
retroactive approval. The PR is opened as a draft and should not be treated as
review-ready under the agent-assisted contribution policy.

**Trivial-exception explanation (or N/A):**

N/A: agent participation was material.

**Approved Proposal Issue URL (or N/A with explanation):**

N/A: no Proposal Issue was approved before implementation.

**Approved Design Issue URL (or N/A with explanation):**

N/A: no Design Issue was approved before implementation.

**Maintainer approval link(s) (or N/A with explanation):**

N/A: no pre-implementation maintainer approval exists.

**Authorized implementation TASK link(s) (or N/A with explanation):**

N/A: no authorized implementation TASK existed before implementation.

**Verification Plan and verification TASK/evidence link(s) (or N/A with explanation):**

N/A: verification was performed before an issue-spec Verification Plan/TASK was
created. Exact locally retained results are reported below, but no public
evidence artifact was uploaded.

## V. Testing and verification

**Test and deterministic rerun commands (or N/A with explanation):**

```text
cd plugins/wasm-rust/extensions/ai-data-masking
cargo test --locked
cargo test --release --locked
make -C plugins/wasm-rust build PLUGIN_NAME=ai-data-masking
```

Both test commands pass 9/9 tests on PR revision
`7373bb5a24b6c11f28a3115172690b1d8ba7eaa5`. The Wasm build also completes
successfully and its artifact hash is recorded below.

The regression suite includes 45,000 distinct 11-digit values, repeated hashes,
more than 5,000 unique restore values, collision behavior, mixed hash/general
leftmost-longest matching, general-pattern limits, capture expansion, and regex
runtime errors.

**Environment and configuration (or N/A with explanation):**

- Native tests: macOS arm64, Rust/Cargo lockfile dependencies.
- Runtime check: private Kubernetes test gateway with two Envoy data-plane pods,
  Envoy `1.27.2-custom-credit-20260707`.
- Plugin rule: `%{MOBILE}`, `type: hash`, `restore: true`.
- Trigger: 540,092-byte OpenAI-compatible request containing 45,000 distinct
  11-digit values. A two-request concurrent run was also performed.
- Credentials and private gateway addresses are intentionally omitted.

**Exact tested revision, version, image tag/digest, manifests, and values (or N/A with explanation):**

- PR revision for native tests:
  `7373bb5a24b6c11f28a3115172690b1d8ba7eaa5`.
- Runtime-tested source revision:
  `cbd60afda29473b6ef62252909faf27e14b718c5`.
- That live test predates the `fancy-regex` 0.19.0 dependency upgrade in this PR.
  The dependency bump is covered by native tests and a fresh Wasm build, not a
  repeated private-gateway run.
- Fixed image tag:
  `crpi-weotfxlsdxvf8tfd.cn-hangzhou.personal.cr.aliyuncs.com/higress-wasm-plugin/ai-security-guard:zhengji-test-ai-data-masking-cbd60afd-20260819-080738`.
- Fixed image manifest digest:
  `sha256:748bf30ef0910843a5bb0e215761f3342e73ab079bc477e33d3d6b5441d38bf0`.
- Baseline affected image tag: `ai-data-masking:1.0.0`; its resolved digest and
  source/module hashes were not retained, so the repository's full public
  baseline-evidence requirement is not complete.
- The private gateway resource and plugin configuration were restored after the
  run; both Envoy pods loaded the original module/configuration and remained
  ready with zero restarts and zero OOM kills.

**Baseline reproduction evidence for bug fixes (or N/A with explanation):**

Using the affected image and the same 540,092-byte/high-cardinality input, two
requests completed in 65.83 s and 131.07 s. The Envoy pods accumulated about
131.09 CPU seconds and the second request serialized behind the first. No public
artifact URL was produced, and the missing baseline digest/module hash is a
known verification gap.

**Fixed-version verification evidence for bug fixes (or N/A with explanation):**

- Single 45,000-value request: 6.34 s end-to-end, 826 ms gateway request phase,
  about 0.82 aggregate Envoy CPU seconds. The upstream returned HTTP 400 after
  receiving the transformed request because its input exceeded 1,000,000
  characters; this was not a Wasm failure.
- Concurrent 2 x 45,000-value requests: 5.76 s and 6.02 s, with gateway request
  phases of 89 ms and 571 ms. They ran on separate Envoy pods without serialized
  worker blocking and used about 1.16 aggregate CPU seconds.
- Both Envoy pods remained ready with zero restarts and zero OOM kills.
- A smaller request returned HTTP 200 and confirmed response restoration.

No public log/metrics bundle was uploaded. A public, pinned proxy-Wasm harness
run remains necessary before this draft should be considered fully verified.

**Wasm source revision and SHA-256 (or N/A with explanation):**

- Source revision: `cbd60afda29473b6ef62252909faf27e14b718c5`.
- `plugin.wasm` SHA-256:
  `4106511ce7735b9c3686e30bf8cd4aa24571ec775fd951b213521bc37f4e1575`.
- The Wasm bytes extracted from the pushed OCI image matched the local module
  byte-for-byte.
- Current PR source revision: `7373bb5a24b6c11f28a3115172690b1d8ba7eaa5`.
- A fresh current-PR Wasm build produced SHA-256
  `3e155b07bfbd8da249ecdade5ee785d7a6a00c3d2e3ea3e03c130291cec2ea32`.
  This new module was build-validated but was not pushed to the private registry
  or rerun on the private gateway.

## VI. Special notes for reviewers

- This draft is intentionally declared noncompliant with the prospective
  issue-spec gate and should receive no implied review priority.
- Runtime results came from a private gateway; a public deterministic baseline
  and fixed proxy-Wasm evidence bundle has not been published.
- A 130 KB multi-chunk SSE response, old-context behavior across ECDS updates,
  and explicit 1-2 vCPU resource budgets have not yet been verified in the
  repository harness.
- General restore patterns are bounded to 1,024 entries and 64 KiB of pattern
  bytes. SHA-256 restore entries use the fixed-width scanner and are not put in
  the Aho-Corasick automaton, avoiding the high memory cost seen with tens of
  thousands of hashes.
- Review focus: preservation of replacement/collision semantics and the merge
  ordering between general and SHA-256 matches.

## VII. AI coding disclosure

**Tool(s) used (or N/A):**

OpenAI Codex.

### Prompts or instructions

The agent was instructed to diagnose the performance issue from first
principles, reproduce it on a test gateway using the affected plugin version,
implement the smallest local repository fix, build and publish a Wasm image,
and validate that image against the high-cardinality scenario. Secrets,
credentials, private hostnames, and internal incident identifiers have been
removed from this disclosure.

### AI-assisted work summary

The agent traced the request-side repeated whole-string replacement and the
response-side full restore-map scan, implemented single-pass masking and
bounded-memory response restoration, added regression tests, reviewed the
changes, built the Wasm module, packaged and pushed a scratch OCI image, and
interpreted native and live gateway results. The author directed the work and
requested the upstream PR. Important verification and issue-spec limitations
are listed above.
