### PR TITLE
fix(release): emergency overwrite workflow must build its tool from main

### DIFF
--- a/.github/workflows/emergency-overwrite-plugin-tag.yaml
+++ b/.github/workflows/emergency-overwrite-plugin-tag.yaml
@@ -51,9 +51,21 @@ jobs:
           sudo rm -rf /usr/local/bin/gsutil /usr/local/bin/gh /usr/local/bin/docker-credential-* || true
       - uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.source_commit }}
+          # Check out main: the emergency-input-hash subcommand ships with this
+          # workflow, which may postdate inputs.source_commit. The plugin tree
+          # is switched to source_commit below, after the tool is built.
+          ref: main
           fetch-depth: 0
       - uses: oras-project/setup-oras@v1
+      - name: Build release tool and switch tree to the source commit
+        env:
+          SOURCE_COMMIT: ${{ inputs.source_commit }}
+        run: |
+          set -euo pipefail
+          git cat-file -e "$SOURCE_COMMIT^{commit}"
+          git merge-base --is-ancestor "$SOURCE_COMMIT" origin/main
+          (cd tools/plugin-release && go build -o /usr/local/bin/plugin-release .)
+          git checkout -q "$SOURCE_COMMIT"
       - name: Resolve catalog entry and validate inputs
         env:
           LOGICAL_ID: ${{ inputs.logical_id }}
@@ -75,7 +87,7 @@ jobs:
           committed=$(tr -d '[:space:]' < "$source_dir/VERSION")
           test "$committed" = "$VERSION" || { echo "VERSION file says $committed, refusing to overwrite $VERSION" >&2; exit 1; }
           # Compute the deterministic input hash exactly like the release tool (artifact inputs + shared groups at this commit).
-          (cd tools/plugin-release && go run . validate-catalog --root ../.. --catalog ../../plugins/release/catalog.json)
+          plugin-release validate-catalog --root ../.. --catalog ../../plugins/release/catalog.json
           echo "implementation=$implementation" >> "$GITHUB_ENV"
           echo "source_dir=$source_dir" >> "$GITHUB_ENV"
           echo "image=$image" >> "$GITHUB_ENV"


### PR DESCRIPTION
First dry-run of the emergency overwrite workflow (run 32221044680) failed: it checked out `inputs.source_commit` (394a644) before running `emergency-input-hash`, but that subcommand only exists from the workflow's own merge (#4576, 10b0f6fb) — chicken-and-egg for any fix commit predating the workflow.

Fix: checkout `main` (full depth) → build the release-tool binary → `git checkout $SOURCE_COMMIT` switches the tree for catalog validation, input hashing (reads blobs at that exact commit), and the plugin build. Provenance semantics unchanged: the hashed commit is still exactly the source commit. `go run .` switched to the prebuilt binary.

Replaces #4578 (same change, clean branch without squash-merged history). Failing run: https://github.com/higress-group/higress/actions/runs/32221044680