### PR TITLE
fix(release): emergency overwrite workflow — paths, toolchain, and outputs wiring

### DIFF
--- a/.github/workflows/emergency-overwrite-plugin-tag.yaml
+++ b/.github/workflows/emergency-overwrite-plugin-tag.yaml
@@ -45,6 +45,9 @@ jobs:
     name: Validate + build (no registry writes)
     runs-on: ubuntu-latest
     timeout-minutes: 40
+    outputs:
+      image: ${{ steps.resolve.outputs.image }}
+      input_hash: ${{ steps.hash.outputs.input_hash }}
     steps:
       - name: Harden runner
         run: |
@@ -56,6 +59,9 @@ jobs:
           # is switched to source_commit below, after the tool is built.
           ref: main
           fetch-depth: 0
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.24.0"
       - uses: oras-project/setup-oras@v1
       - name: Build release tool and switch tree to the source commit
         env:
@@ -67,6 +73,7 @@ jobs:
           (cd tools/plugin-release && go build -o /usr/local/bin/plugin-release .)
           git checkout -q "$SOURCE_COMMIT"
       - name: Resolve catalog entry and validate inputs
+        id: resolve
         env:
           LOGICAL_ID: ${{ inputs.logical_id }}
           VERSION: ${{ inputs.version }}
@@ -87,12 +94,14 @@ jobs:
           committed=$(tr -d '[:space:]' < "$source_dir/VERSION")
           test "$committed" = "$VERSION" || { echo "VERSION file says $committed, refusing to overwrite $VERSION" >&2; exit 1; }
           # Compute the deterministic input hash exactly like the release tool (artifact inputs + shared groups at this commit).
-          plugin-release validate-catalog --root ../.. --catalog ../../plugins/release/catalog.json
-          echo "implementation=$implementation" >> "$GITHUB_ENV"
-          echo "source_dir=$source_dir" >> "$GITHUB_ENV"
-          echo "image=$image" >> "$GITHUB_ENV"
-          echo "build_name=$(basename "$source_dir")" >> "$GITHUB_ENV"
+          plugin-release validate-catalog --root . --catalog plugins/release/catalog.json
+          echo "IMPLEMENTATION=$implementation" >> "$GITHUB_ENV"
+          echo "SOURCE_DIR=$source_dir" >> "$GITHUB_ENV"
+          echo "IMAGE=$image" >> "$GITHUB_ENV"
+          echo "BUILD_NAME=$(basename "$source_dir")" >> "$GITHUB_ENV"
+          echo "image=$image" >> "$GITHUB_OUTPUT"
       - name: Compute input hash (release-tool compatible)
+        id: hash
         env:
           LOGICAL_ID: ${{ inputs.logical_id }}
           VERSION: ${{ inputs.version }}
@@ -101,11 +110,12 @@ jobs:
           set -euo pipefail
           # inputHash selects catalog artifact inputs + shared input groups at SOURCE_COMMIT and hashes
           # the file bytes plus the version string, mirroring tools/plugin-release inputHash().
-          cd tools/plugin-release
-          go run . emergency-input-hash --root ../.. --catalog ../../plugins/release/catalog.json \
+          # Run the binary built from main above: the checked-out source_commit tree may predate
+          # the emergency-input-hash subcommand, so go run here could compile a tool without it.
+          plugin-release emergency-input-hash --root . --catalog plugins/release/catalog.json \
             --id "$LOGICAL_ID" --commit "$SOURCE_COMMIT" --version "$VERSION" > /tmp/input-hash.txt
           grep -Eq '^sha256:[0-9a-f]{64}$' /tmp/input-hash.txt
-          echo "input_hash=$(cat /tmp/input-hash.txt)" >> "$GITHUB_ENV"
+          echo "input_hash=$(cat /tmp/input-hash.txt)" >> "$GITHUB_OUTPUT"
       - name: Test and build plugin (pipeline build contract)
         run: |
           set -euo pipefail


### PR DESCRIPTION
Replaces #4580 (clean branch from current main HEAD 40a280d0). Fixes the two failures from dry-run run 32225122896:

- `actions/setup-go@v5` (Go 1.24.0) added — required for the release-tool build and the plugin's `go test`, matching the release pipelines;
- `validate-catalog` / `emergency-input-hash` now run from the repository root with `--root . --catalog plugins/release/catalog.json` against the prebuilt binary (the previous `../../` relative paths escaped the checkout);
- validate job outputs (`image`, `input_hash`) properly wired via `GITHUB_OUTPUT` + step ids; publish job consumes `needs.validate.outputs`;
- per-step env exports renamed to unambiguous upper-case names.

Local verification on this branch: YAML parses; release tool builds; `validate-catalog` passes from repo root; `emergency-input-hash --id mcp-server --commit 394a644a724b6ef6e56b2fab0e9b086999937b39 --version 2.0.1` prints exactly `sha256:17518be24d7e0c16e685f78318045a0d2f14a5db0d17873cdd8678b5ea113951` (pre-computed ground truth). The wasm build step matches the Makefile contract (`make -C plugins/wasm-go PLUGIN_NAME=mcp-server build` → `extensions/mcp-server/plugin.wasm`).

Implementation: Kimi-K3 via Qoder ACPX under maintainer direction; verified and committed by the maintainer agent.