### PR TITLE
fix(release): emergency overwrite uses production registry credentials

### DIFF
--- a/.github/workflows/emergency-overwrite-plugin-tag.yaml
+++ b/.github/workflows/emergency-overwrite-plugin-tag.yaml
@@ -154,9 +154,13 @@ jobs:
       - uses: oras-project/setup-oras@v1
       - name: Publish 2-layer OCI variant over the existing tag
         env:
-          REGISTRY: ${{ vars.PLUGIN_PUBLIC_REGISTRY }}
-          REGISTRY_USERNAME: ${{ secrets.CANDIDATE_REGISTRY_USERNAME }}
-          REGISTRY_PASSWORD: ${{ secrets.CANDIDATE_REGISTRY_PASSWORD }}
+          # Match the promote pipeline exactly: public pushes use the
+          # PRODUCTION registry credentials, and the registry host resolves
+          # from the same variable promote reads (candidate host is an
+          # identical fallback observed in successful promote runs).
+          REGISTRY: ${{ vars.PLUGIN_PUBLIC_REGISTRY || vars.PLUGIN_CANDIDATE_REGISTRY }}
+          REGISTRY_USERNAME: ${{ secrets.PRODUCTION_REGISTRY_USERNAME }}
+          REGISTRY_PASSWORD: ${{ secrets.PRODUCTION_REGISTRY_PASSWORD }}
           LOGICAL_ID: ${{ inputs.logical_id }}
           VERSION: ${{ inputs.version }}
           SOURCE_COMMIT: ${{ inputs.source_commit }}


### PR DESCRIPTION
The real overwrite run (32230825326) failed at the first line of the publish step: `REGISTRY`/`REGISTRY_USERNAME`/`REGISTRY_PASSWORD` rendered empty. Two credential-name mistakes vs the promote pipeline:

- public-tag pushes authenticate with `secrets.PRODUCTION_REGISTRY_USERNAME/PASSWORD`, not the candidate credentials (see `promote-plugin-release.yaml` "Promote candidate manifests by digest");
- registry host now reads `vars.PLUGIN_PUBLIC_REGISTRY` with a fallback to `vars.PLUGIN_CANDIDATE_REGISTRY` (both resolve to the same host in successful promote runs, e.g. 31761216718).

Validate job already passed (green in 32230037033 and re-validated in 32230825326); only the publish step's env block changes. The wasm digest and input-hash provenance are unchanged.