### PR TITLE
feat(release): one-click plugin release trigger + hotfix overwrite polish

### DIFF
--- a/.github/workflows/emergency-overwrite-plugin-tag.yaml
+++ b/.github/workflows/emergency-overwrite-plugin-tag.yaml
@@ -25,9 +25,9 @@ on:
         required: true
         type: string
       move_latest:
-        description: "Also move the latest tag to the overwritten digest"
+        description: "Also move the latest tag to the overwritten digest (opt-in: moving latest for an older version can regress it below a newer release)"
         required: true
-        default: true
+        default: false
         type: boolean
       dry_run:
         description: "Build and validate only; never push"
@@ -215,5 +215,5 @@ jobs:
             echo "- source commit: \`$SOURCE_COMMIT\`"
             echo "- latest moved: $MOVE_LATEST"
             echo ""
-            echo "Follow-up REQUIRED: update plugins/release/snapshots + evidence digests for this plugin in a recovery PR."
+            echo "Follow-up: no snapshot edit is needed — the fix commit is on main; the next gateway release auto-bumps this plugin and re-releases it through the verified pipeline. (Trigger it with trigger-plugin-release.yaml.)"
           } | tee -a "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/trigger-plugin-release.yaml
+++ b/.github/workflows/trigger-plugin-release.yaml
@@ -1,0 +1,71 @@
+name: Trigger Plugin Release
+
+# One-click entry into the immutable plugin release pipeline: derives what
+# the maintainer used to type by hand (exact main-head target_ref and the
+# latest checked-in snapshot), then dispatches prepare-plugin-release.
+# Changed plugins auto-bump via plan/nextVersion; human review stays at the
+# prep-PR merge and the promote step.
+
+on:
+  workflow_dispatch:
+    inputs:
+      gateway_version:
+        description: "Upcoming gateway version (e.g. 2.2.5)"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  actions: write
+
+concurrency:
+  group: trigger-plugin-release
+  cancel-in-progress: false
+
+run-name: trigger-plugin-release ${{ inputs.gateway_version }}
+
+jobs:
+  trigger:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          ref: main
+          fetch-depth: 1
+      - name: Derive inputs and guard against duplicate snapshot
+        id: derive
+        env:
+          GATEWAY_VERSION: ${{ inputs.gateway_version }}
+        run: |
+          set -euo pipefail
+          [[ "$GATEWAY_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]
+          if [ -f "plugins/release/snapshots/$GATEWAY_VERSION.json" ]; then
+            echo "snapshot for this gateway version already exists: plugins/release/snapshots/$GATEWAY_VERSION.json" >&2
+            exit 1
+          fi
+          target_ref=$(git rev-parse HEAD)
+          previous_snapshot=$(ls plugins/release/snapshots/*.json | sort -V | tail -1)
+          test -n "$previous_snapshot"
+          echo "target_ref=$target_ref" >> "$GITHUB_OUTPUT"
+          echo "previous_snapshot=$previous_snapshot" >> "$GITHUB_OUTPUT"
+      - name: Dispatch prepare-plugin-release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GATEWAY_VERSION: ${{ inputs.gateway_version }}
+          TARGET_REF: ${{ steps.derive.outputs.target_ref }}
+          PREVIOUS_SNAPSHOT: ${{ steps.derive.outputs.previous_snapshot }}
+        run: |
+          set -euo pipefail
+          gh workflow run prepare-plugin-release.yaml --ref main \
+            -f gateway_version="$GATEWAY_VERSION" \
+            -f target_ref="$TARGET_REF" \
+            -f previous_snapshot="$PREVIOUS_SNAPSHOT" \
+            -f version_overrides='{}' \
+            -f dry_run=false
+          # dry_run must be passed explicitly: prepare's default is true and
+          # would no-op without candidate uploads or a preparation PR.
+          # gh workflow run returns before the run starts; resolve the newest
+          # run for the summary.
+          sleep 5
+          run_url=$(gh run list --workflow=prepare-plugin-release.yaml --limit 1 --json url --jq '.[0].url')
+          echo "Dispatched prepare-plugin-release for $GATEWAY_VERSION: $run_url" | tee -a "$GITHUB_STEP_SUMMARY"

--- a/docs/developers/immutable-plugin-releases.md
+++ b/docs/developers/immutable-plugin-releases.md
@@ -196,6 +196,20 @@ earlier verified digest set. If `latest` needs repair, use the serialized
 promotion flow with an audited recovery approval; released Console, gateway,
 and Standalone defaults remain pinned and do not depend on `latest`.
 
+### Emergency same-version overwrite
+
+- An ACR admin temporarily lifts the tag-immutability rule for the plugin
+  repo; a maintainer then runs `emergency-overwrite-plugin-tag` (first
+  `dry_run=true`, then the real run, which waits for the
+  `plugin-release-production` approval), and the admin re-arms the rule
+  immediately after the run reports the new digest.
+- A plugin whose tag was overwritten must receive a version bump at the next
+  gateway release. This happens automatically: the fix commit changes the
+  input hash, so plan re-plans it.
+- Bundled plugin-server/Console images embed snapshot bytes and are healed
+  only by the next gateway release; the overwrite heals tag-pulling
+  (Envoy-direct) consumers immediately.
+
 ## Exact Standalone packaging
 
 `deploy-standalone-to-oss` is manual and requires one verified Standalone


### PR DESCRIPTION
Implements the maintainer-approved minimal plugin-lifecycle design: changed plugins follow gateway releases via one dispatch, and fast same-version overwrite is documented via the existing emergency workflow.

New trigger-plugin-release workflow takes a single gateway_version input, auto-derives target_ref (main HEAD) and previous_snapshot (newest checked-in snapshot), and dispatches the unchanged prepare-plugin-release with dry_run explicitly false. Guards refuse an already-snapshotted version; concurrency-serialized. Emergency overwrite workflow: move_latest default flipped to false (opt-in), follow-up note corrected to the self-heal semantics (next gateway release auto-bumps an overwritten plugin through the verified pipeline). Docs gain the overwrite runbook and the honest scope note about bundled consumers.

Design by three-expert independent panel over two rounds; implementation by one expert session; dispatch-flag fidelity, guards, YAML and DCO verified.