### PR TITLE
bugfix: do not inject a fixed OpenAPI MCP credential

### DIFF
--- a/hgctl/pkg/agent/mcp.go
+++ b/hgctl/pkg/agent/mcp.go
@@ -151,7 +151,6 @@ func (h *MCPAddHandler) addHTTPMCP() error {
 func (h *MCPAddHandler) addOpenAPIMCP() error {
 	// fmt.Printf("get mcp server: %s openapi-spec-file: %s\n", h.arg.name, h.arg.spec)
 	config := h.parseOpenapiSpec()
-	config.Server.SecuritySchemes[0].DefaultCredential = "b5b9752c7ad2cb9c6b19fb5fd6a23be8852eca9c"
 	// fmt.Printf("get config struct: %v", config)
 
 	// publish to higress
@@ -177,7 +176,18 @@ func (h *MCPAddHandler) addOpenAPIMCP() error {
 }
 
 func (h *MCPAddHandler) parseOpenapiSpec() *models.MCPConfig {
-	return parseOpenapi2MCP(h.arg)
+	config := parseOpenapi2MCP(h.arg)
+	prepareOpenAPIMCPConfig(config)
+	return config
+}
+
+// prepareOpenAPIMCPConfig is applied to converted OpenAPI MCP config before
+// publish. It must not inject DefaultCredential; a required-but-missing
+// credential stays empty so request auth returns a configuration error.
+func prepareOpenAPIMCPConfig(config *models.MCPConfig) {
+	if config == nil {
+		return
+	}
 }
 
 func handleAddMCP(w io.Writer, arg MCPAddArg) error {

--- a/hgctl/pkg/agent/mcp_test.go
+++ b/hgctl/pkg/agent/mcp_test.go
@@ -1,0 +1,160 @@
+// Copyright (c) 2025 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package agent
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/higress-group/openapi-to-mcpserver/pkg/models"
+)
+
+// leakedOpenAPIMCPDefaultCredential is the fixed value `hgctl mcp add --type openapi`
+// previously injected into the first generated security scheme.
+const leakedOpenAPIMCPDefaultCredential = "b5b9752c7ad2cb9c6b19fb5fd6a23be8852eca9c"
+
+func requiredAPIKeyMCPConfig() *models.MCPConfig {
+	return &models.MCPConfig{
+		Server: models.ServerConfig{
+			Name: "pets",
+			SecuritySchemes: []models.SecurityScheme{{
+				ID:   "ApiKeyAuth",
+				Type: "apiKey",
+				In:   "header",
+				Name: "X-API-Key",
+			}},
+		},
+		Tools: []models.Tool{{
+			Name: "listPets",
+			RequestTemplate: models.RequestTemplate{
+				URL:    "https://api.example.com/pets",
+				Method: "GET",
+				Security: &models.ToolSecurityRequirement{
+					ID: "ApiKeyAuth",
+				},
+			},
+		}},
+	}
+}
+
+func TestPrepareOpenAPIMCPConfigDoesNotInjectDefaultCredential(t *testing.T) {
+	config := requiredAPIKeyMCPConfig()
+
+	prepareOpenAPIMCPConfig(config)
+
+	if got := config.Server.SecuritySchemes[0].DefaultCredential; got != "" {
+		t.Fatalf("DefaultCredential = %q, want empty", got)
+	}
+
+	published := convertMCPConfigToStr(config)
+	if strings.Contains(published, leakedOpenAPIMCPDefaultCredential) {
+		t.Fatalf("published OpenAPI MCP config contains the fixed DefaultCredential:\n%s", published)
+	}
+	if strings.Contains(published, "defaultCredential") {
+		t.Fatalf("published OpenAPI MCP config must omit defaultCredential, got:\n%s", published)
+	}
+}
+
+func TestPrepareOpenAPIMCPConfigPreservesExplicitCredential(t *testing.T) {
+	config := requiredAPIKeyMCPConfig()
+	config.Server.SecuritySchemes[0].DefaultCredential = "user-supplied-key"
+
+	prepareOpenAPIMCPConfig(config)
+
+	if got := config.Server.SecuritySchemes[0].DefaultCredential; got != "user-supplied-key" {
+		t.Fatalf("DefaultCredential = %q, want %q", got, "user-supplied-key")
+	}
+}
+
+func TestPrepareOpenAPIMCPConfigMissingCredentialPath(t *testing.T) {
+	config := requiredAPIKeyMCPConfig()
+
+	prepareOpenAPIMCPConfig(config)
+
+	scheme := config.Server.SecuritySchemes[0]
+	sec := config.Tools[0].RequestTemplate.Security
+	if sec == nil || sec.ID == "" {
+		t.Fatal("generated tool must require the converted security scheme")
+	}
+	if sec.Passthrough {
+		t.Fatal("generated tool security must not enable passthrough by default")
+	}
+	if scheme.DefaultCredential != "" {
+		t.Fatalf("required-but-missing credential was filled with %q", scheme.DefaultCredential)
+	}
+
+	// ApplySecurity uses DefaultCredential when the request has no passthrough
+	// or per-tool credential. Leaving it empty is the missing-credential path:
+	// the helper must not send an implicit secret to upstream.
+	published := convertMCPConfigToStr(config)
+	if strings.Contains(published, leakedOpenAPIMCPDefaultCredential) {
+		t.Fatal("missing-credential path still publishes the fixed DefaultCredential")
+	}
+}
+
+func TestPrepareOpenAPIMCPConfigEmptySchemes(t *testing.T) {
+	config := &models.MCPConfig{
+		Server: models.ServerConfig{Name: "open"},
+	}
+
+	prepareOpenAPIMCPConfig(config)
+
+	if len(config.Server.SecuritySchemes) != 0 {
+		t.Fatalf("unexpected security schemes: %#v", config.Server.SecuritySchemes)
+	}
+}
+
+func TestParseOpenapiSpecDoesNotInjectDefaultCredential(t *testing.T) {
+	h := &MCPAddHandler{arg: MCPAddArg{
+		name: "pets",
+		spec: "testdata/openapi-apikey.yaml",
+		typ:  OPENAPI,
+	}}
+
+	config := h.parseOpenapiSpec()
+	if config == nil {
+		t.Fatal("parseOpenapiSpec returned nil")
+	}
+	if len(config.Server.SecuritySchemes) == 0 {
+		t.Fatal("expected converted security schemes")
+	}
+
+	for _, scheme := range config.Server.SecuritySchemes {
+		if scheme.DefaultCredential != "" {
+			t.Fatalf("scheme %s DefaultCredential = %q, want empty", scheme.ID, scheme.DefaultCredential)
+		}
+	}
+
+	published := convertMCPConfigToStr(config)
+	if strings.Contains(published, leakedOpenAPIMCPDefaultCredential) {
+		t.Fatalf("published OpenAPI MCP config contains the fixed DefaultCredential:\n%s", published)
+	}
+	if strings.Contains(published, "defaultCredential") {
+		t.Fatalf("published OpenAPI MCP config must omit defaultCredential, got:\n%s", published)
+	}
+
+	foundRequiredScheme := false
+	for _, tool := range config.Tools {
+		if tool.RequestTemplate.Security != nil && tool.RequestTemplate.Security.ID != "" {
+			foundRequiredScheme = true
+			if tool.RequestTemplate.Security.Passthrough {
+				t.Fatalf("tool %s enabled passthrough by default", tool.Name)
+			}
+		}
+	}
+	if !foundRequiredScheme {
+		t.Fatal("expected a tool that requires the converted security scheme")
+	}
+}

--- a/hgctl/pkg/agent/testdata/openapi-apikey.yaml
+++ b/hgctl/pkg/agent/testdata/openapi-apikey.yaml
@@ -1,3 +1,17 @@
+# Copyright (c) 2025 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 openapi: 3.0.0
 info:
   title: Pets

--- a/hgctl/pkg/agent/testdata/openapi-apikey.yaml
+++ b/hgctl/pkg/agent/testdata/openapi-apikey.yaml
@@ -1,0 +1,22 @@
+openapi: 3.0.0
+info:
+  title: Pets
+  version: 1.0.0
+servers:
+  - url: https://api.example.com
+paths:
+  /pets:
+    get:
+      operationId: listPets
+      summary: List pets
+      security:
+        - ApiKeyAuth: []
+      responses:
+        "200":
+          description: ok
+components:
+  securitySchemes:
+    ApiKeyAuth:
+      type: apiKey
+      in: header
+      name: X-API-Key


### PR DESCRIPTION
## I. Summary

`hgctl mcp add --type openapi` assigned a hardcoded `DefaultCredential` on the first generated security scheme. Published OpenAPI MCP servers then used that value whenever a request had no passthrough or per-tool credential, sending an unintended secret upstream.

This change removes that assignment. Converted schemes keep an empty `DefaultCredential` unless the spec already supplied one. A required-but-missing credential stays empty so request auth cannot fall back to the previous fixed value.

## II. Related issue

Fixes #4572

## III. Change type

- [x] Bug fix
- [ ] Feature or enhancement
- [ ] Documentation or configuration only
- [x] Refactoring, tests, or maintenance

## IV. Agent participation and issue-spec gate

- [ ] **No agent participation:** This PR is human-only.
- [ ] **Trivial agent-use exception:** Agent use was limited to spelling, punctuation, whitespace, or formatting with no substantive choice or behavioral effect; the explanation is below.
- [ ] **Verified maintainer/administrator exception:** Material agent participation occurred, and authenticated `gh` verification confirmed a `role_name` of `maintain` or `admin` on `higress-group/higress`, and the verified login matches this PR's GitHub author; record the required evidence and rationale below.
- [x] **Material agent participation:** An AI or coding agent materially participated in analysis, design, implementation, testing, or PR preparation.

- [ ] **Before implementation began:** A Higress maintainer had approved the Proposal and Design Issues, and authorized implementation TASKs linked the work to the applicable SPECs.
- [ ] **Before verification began:** The Design contained a concrete Verification Plan.
- [ ] **Before requesting maintainer review or acceptance:** Applicable implementation and verification TASKs were `done` with exact commands, results, evidence links, and hashes.

- [ ] Complete: all three timed obligations above were satisfied.
- [x] Noncompliant: one or more obligations were not satisfied; explain below.
- [ ] Verified exception: material agent participation used the verified-maintainer/administrator exception; provide the required evidence and rationale below.
- [ ] N/A because the PR is human-only or qualifies for the trivial exception.

**Gate-status explanation (or N/A):** The public issue already described a bounded one-line configuration bug and the expected empty-credential behavior. Implementation started from that issue without a separate maintainer-approved Proposal/Design SPEC.

**Trivial-exception explanation (or N/A):** N/A

**Verified maintainer/administrator exception evidence (or N/A):** N/A

**Approved Proposal Issue URL (or N/A with explanation):** N/A; work follows the existing bug report in #4572.

**Approved Design Issue URL (or N/A with explanation):** N/A; the issue already specified removing the fixed assignment and adding a regression.

**Maintainer approval link(s) (or N/A with explanation):** N/A

**Authorized implementation TASK link(s) (or N/A with explanation):** N/A

**Verification Plan and verification TASK/evidence link(s) (or N/A with explanation):** Unit tests in `hgctl/pkg/agent/mcp_test.go` cover generated configuration and the missing-credential path. Command and result are in section V.

## V. Testing and verification

**Test and deterministic rerun commands (or N/A with explanation):**

```text
cd hgctl && go test ./pkg/agent/ -count=1 -timeout 120s
```

Result: `ok github.com/alibaba/higress/hgctl/pkg/agent 0.027s`

**Environment and configuration (or N/A with explanation):** Linux amd64, Go 1.26

**Exact tested revision, version, image tag/digest, manifests, and values (or N/A with explanation):** This PR head. No Wasm or image change.

**Baseline reproduction evidence for bug fixes (or N/A with explanation):** Before the change, `hgctl mcp add --type openapi` set `SecuritySchemes[0].DefaultCredential` to `b5b9752c7ad2cb9c6b19fb5fd6a23be8852eca9c`. A failing unit test on `parseOpenapiSpec` asserted that field stayed empty and that the published YAML omitted `defaultCredential`.

**Fixed-version verification evidence for bug fixes (or N/A with explanation):** After removing the assignment, `go test ./pkg/agent/` passes. Converted schemes have empty `DefaultCredential`; published config omits `defaultCredential`; empty-scheme specs are unchanged.

**Wasm source revision and SHA-256 (or N/A with explanation):** N/A; hgctl-only change.

## VI. Special notes for reviewers

The previous assignment was a literal in `addOpenAPIMCP`. `parseOpenapiSpec` now runs a no-op prepare step so the production path and tests share one seam and cannot skip it.

## VII. AI coding disclosure

**Tool(s) used (or N/A):** coding agent

### Prompts or instructions

Fix higress-group/higress#4572 with isolated TDD: do not inject a fixed OpenAPI MCP DefaultCredential.

### AI-assisted work summary

Removed the hardcoded DefaultCredential assignment, added a parse-path prepare seam, and added unit tests for generated config and the missing-credential path.