### PR TITLE
chore: enable updateCacheWhenEmpty by default to prevent stale Higress cache when Nacos returns no instances

### DIFF
--- a/registry/nacos/v2/watcher.go
+++ b/registry/nacos/v2/watcher.go
@@ -86,12 +86,13 @@ type WatcherOption func(w *watcher)
 
 func NewWatcher(cache memory.Cache, opts ...WatcherOption) (provider.Watcher, error) {
 	w := &watcher{
-		WatchingServices: make(map[string]bool),
-		RegistryType:     provider.Nacos2,
-		Status:           provider.UnHealthy,
-		cache:            cache,
-		mutex:            &sync.Mutex{},
-		stop:             make(chan struct{}),
+		WatchingServices:     make(map[string]bool),
+		RegistryType:         provider.Nacos2,
+		Status:               provider.UnHealthy,
+		cache:                cache,
+		mutex:                &sync.Mutex{},
+		stop:                 make(chan struct{}),
+		updateCacheWhenEmpty: DefaultUpdateCacheWhenEmpty,
 	}
 
 	w.NacosRefreshInterval = int64(DefaultRefreshInterval)


### PR DESCRIPTION
## I. Summary
尝试解决#4595。Nacos SDK有段逻辑会识别updateCacheWhenEmpty，对于nacos服务为空时，会触发higress的缓存实例更新。因此在此设为原本提供的默认值DefaultUpdateCacheWhenEmpty（true）。
Nacos SDK的逻辑在：github.com/nacos-group/nacos-sdk-go/v2@v2.3.5/clients/naming_client/naming_cache/service_info_holder.go:74
ProcessService这个方法下。

## II. Related issue
fix #4595

## III. Change type

- [×] Bug fix
- [ ] Feature or enhancement
- [ ] Documentation or configuration only
- [ ] Refactoring, tests, or maintenance
