### PR TITLE
docs: add official Kubernetes implementation links to localized README files

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -30,6 +30,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
+          cache: false
 
       - name: Setup Golang Caches
         uses: actions/cache@v4
@@ -70,6 +71,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
+          cache: false
 
       - name: Setup Golang Caches
         uses: actions/cache@v4
@@ -153,6 +155,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version-file: ${{ matrix.test-directory }}/go.mod
+          cache: false
 
       - name: Setup Golang Caches
         uses: actions/cache@v4
@@ -253,6 +256,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go-version }}
+          cache: false
 
       - name: Setup Golang Caches
         uses: actions/cache@v4
@@ -333,6 +337,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
+          cache: false
 
       - name: Setup Golang Caches
         uses: actions/cache@v4

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -30,7 +30,6 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
-          cache: false
 
       - name: Setup Golang Caches
         uses: actions/cache@v4
@@ -71,7 +70,6 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
-          cache: false
 
       - name: Setup Golang Caches
         uses: actions/cache@v4
@@ -155,7 +153,6 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version-file: ${{ matrix.test-directory }}/go.mod
-          cache: false
 
       - name: Setup Golang Caches
         uses: actions/cache@v4
@@ -256,7 +253,6 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go-version }}
-          cache: false
 
       - name: Setup Golang Caches
         uses: actions/cache@v4
@@ -337,7 +333,6 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
-          cache: false
 
       - name: Setup Golang Caches
         uses: actions/cache@v4

--- a/README.md
+++ b/README.md
@@ -124,13 +124,15 @@ For other installation methods such as Helm deployment under K8s, please refer t
 
   Higress connects to all LLM model providers using a unified protocol, with AI observability, multi-model load balancing, token rate limiting, and caching capabilities:
 
+  Higress is also listed as a conformant [Gateway API Inference Extension implementation](https://gateway-api-inference-extension.sigs.k8s.io/implementations/gateways/#higress), supporting inference-aware routing on Kubernetes.
+
   ![](https://img.alicdn.com/imgextra/i2/O1CN01izmBNX1jbHT7lP3Yr_!!6000000004566-0-tps-1920-1080.jpg)
 
 - **Kubernetes ingress controller**:
 
-  Higress can function as a feature-rich ingress controller, which is compatible with many annotations of K8s' nginx ingress controller.
+  Higress can function as a feature-rich ingress controller and is listed in the official [Kubernetes Ingress Controllers documentation](https://kubernetes.io/docs/concepts/services-networking/ingress-controllers/). It is compatible with many annotations of the Kubernetes NGINX Ingress Controller.
 
-  [Gateway API](https://gateway-api.sigs.k8s.io/) is already supported, and it supports a smooth migration from Ingress API to Gateway API.
+  Higress supports the [Gateway API](https://gateway-api.sigs.k8s.io/) standard and is listed as a [conformant Gateway API implementation](https://gateway-api.sigs.k8s.io/implementations/#higress), enabling smooth migration from the Ingress API to the Gateway API.
 
   Compared to ingress-nginx, the resource overhead has significantly decreased, and the speed at which route changes take effect has improved by ten times.
 

--- a/README_JP.md
+++ b/README_JP.md
@@ -83,6 +83,8 @@ K8sでのHelmデプロイなどの他のインストール方法については�
 
   Higressは、国内外のすべてのLLMモデルプロバイダーと統一されたプロトコルで接続でき、豊富なAI可観測性、多モデル負荷分散/フォールバック、AIトークンフロー制御、AIキャッシュなどの機能を備えています。
 
+  Higressは、Kubernetesで推論を考慮したルーティングをサポートする[Gateway API Inference Extension準拠実装](https://gateway-api-inference-extension.sigs.k8s.io/implementations/gateways/#higress)としても掲載されています。
+
   ![](https://img.alicdn.com/imgextra/i1/O1CN01fNnhCp1cV8mYPRFeS_!!6000000003605-0-tps-1080-608.jpg)
 
 - **MCP Server ホスティング**:
@@ -101,9 +103,9 @@ K8sでのHelmデプロイなどの他のインストール方法については�
 
 - **Kubernetes Ingressゲートウェイ**:
 
-  HigressはK8sクラスターのIngressエントリーポイントゲートウェイとして機能し、多くのK8s Nginx Ingressの注釈に対応しています。K8s Nginx IngressからHigressへのスムーズな移行が可能です。
+  Higressは[Kubernetes Ingress Controllersの公式ドキュメント](https://kubernetes.io/docs/concepts/services-networking/ingress-controllers/)に掲載されており、K8sクラスターのIngressエントリーポイントゲートウェイとして機能します。多くのK8s Nginx Ingressの注釈に対応しているため、K8s Nginx IngressからHigressへのスムーズな移行が可能です。
   
-  [Gateway API](https://gateway-api.sigs.k8s.io/)標準をサポートし、ユーザーがIngress APIからGateway APIにスムーズに移行できるようにします。
+  Higressは[Gateway API](https://gateway-api.sigs.k8s.io/)標準をサポートし、[Gateway API準拠実装](https://gateway-api.sigs.k8s.io/implementations/#higress)として掲載されています。Ingress APIからGateway APIへのスムーズな移行が可能です。
 
   ingress-nginxと比較して、リソースの消費が大幅に減少し、ルーティングの変更が10倍速く反映されます。
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -106,6 +106,8 @@ K8s 下使用 Helm 部署等其他安装方式可以参考官网 [Quick Start �
 
   Higress 能够用统一的协议对接国内外所有 LLM 模型厂商，同时具备丰富的 AI 可观测、多模型负载均衡/fallback、AI token 流控、AI 缓存等能力：
 
+  Higress 同时也是 [Gateway API Inference Extension 一致性实现](https://gateway-api-inference-extension.sigs.k8s.io/implementations/gateways/#higress)，支持在 Kubernetes 上进行推理感知路由。
+
   ![](https://img.alicdn.com/imgextra/i1/O1CN01fNnhCp1cV8mYPRFeS_!!6000000003605-0-tps-1080-608.jpg)
 
 - **MCP Server 托管**:
@@ -124,9 +126,9 @@ K8s 下使用 Helm 部署等其他安装方式可以参考官网 [Quick Start �
 
 - **Kubernetes Ingress 网关**:
 
-  Higress 可以作为 K8s 集群的 Ingress 入口网关, 并且兼容了大量 K8s Nginx Ingress 的注解，可以从 K8s Nginx Ingress 快速平滑迁移到 Higress。
+  Higress 已被 [Kubernetes Ingress Controllers 官方文档](https://kubernetes.io/docs/concepts/services-networking/ingress-controllers/)收录，可作为 K8s 集群的 Ingress 入口网关，并且兼容大量 K8s Nginx Ingress 注解，可以从 K8s Nginx Ingress 快速平滑迁移到 Higress。
   
-  支持 [Gateway API](https://gateway-api.sigs.k8s.io/) 标准，支持用户从 Ingress API 平滑迁移到 Gateway API。
+  Higress 支持 [Gateway API](https://gateway-api.sigs.k8s.io/) 标准，并被列为 [Gateway API 一致性实现](https://gateway-api.sigs.k8s.io/implementations/#higress)，支持用户从 Ingress API 平滑迁移到 Gateway API。
 
   相比 ingress-nginx，资源开销大幅下降，路由变更生效速度有十倍提升：
 


### PR DESCRIPTION
## I. Summary

Add upstream community links to the existing English, Chinese, and Japanese README use-case descriptions:

- Link the Gateway API Inference Extension conformant implementation listing from the AI Gateway section.
- Link the Kubernetes Ingress Controllers documentation and Gateway API conformant implementation listing from the Kubernetes ingress controller section.

This is documentation-only and has no compatibility or migration impact.

## II. Related issue

N/A. This is a small documentation update that uses the verified administrator exception described below.

## III. Change type

- [ ] Bug fix
- [ ] Feature or enhancement
- [x] Documentation or configuration only
- [ ] Refactoring, tests, or maintenance

## IV. Agent participation and issue-spec gate

- [ ] **No agent participation:** This PR is human-only.
- [ ] **Trivial agent-use exception:** Agent use was limited to spelling, punctuation, whitespace, or formatting with no substantive choice or behavioral effect; the explanation is below.
- [x] **Verified maintainer/administrator exception:** Material agent participation occurred, and authenticated `gh` verification confirmed a `role_name` of `maintain` or `admin` on `higress-group/higress`, and the verified login matches this PR's GitHub author; record the required evidence and rationale below.
- [ ] **Material agent participation:** An AI or coding agent materially participated in analysis, design, implementation, testing, or PR preparation.

- [ ] **Before implementation began:** A Higress maintainer had approved the Proposal and Design Issues, and authorized implementation TASKs linked the work to the applicable SPECs.
- [ ] **Before verification began:** The Design contained a concrete Verification Plan.
- [ ] **Before requesting maintainer review or acceptance:** Applicable implementation and verification TASKs were `done` with exact commands, results, evidence links, and hashes.

- [ ] Complete: all three timed obligations above were satisfied.
- [ ] Noncompliant: one or more obligations were not satisfied; explain below.
- [x] Verified exception: material agent participation used the verified-maintainer/administrator exception; provide the required evidence and rationale below.
- [ ] N/A because the PR is human-only or qualifies for the trivial exception.

**Gate-status explanation (or N/A):** The verified administrator exception is used for this bounded, documentation-only README update.

**Trivial-exception explanation (or N/A):** N/A. The wording and placement involved substantive choices, so this PR does not claim the trivial exception.

**Verified maintainer/administrator exception evidence (or N/A):**

- This PR's number or URL: https://github.com/higress-group/higress/pull/4612
- Authenticated `gh` login: `EndlessSeeker`
- Canonical-repository `role_name`: `admin`
- Actual PR author from `gh pr view`: `EndlessSeeker`
- Login/author match: `yes`
- Token override attestation (`GH_TOKEN` and `GITHUB_TOKEN` were unset for every verification command; required: `yes`): `yes`
- Bypass rationale: The change only adds the same three upstream documentation and conformance links to existing localized README use-case text. A full Proposal and Design workflow would be disproportionate to the scope.
- Maintainer live validation (review URL or N/A until performed): N/A until independently validated by the accepting or merging maintainer.

**Approved Proposal Issue URL (or N/A with explanation):** N/A because the verified administrator exception is used.

**Approved Design Issue URL (or N/A with explanation):** N/A because the verified administrator exception is used.

**Maintainer approval link(s) (or N/A with explanation):** N/A because the verified administrator exception is used.

**Authorized implementation TASK link(s) (or N/A with explanation):** N/A because the verified administrator exception is used.

**Verification Plan and verification TASK/evidence link(s) (or N/A with explanation):** N/A because the verified administrator exception is used. Documentation checks are recorded below.

## V. Testing and verification

**Test and deterministic rerun commands (or N/A with explanation):**

```text
git diff --check c55d9825c90868f50edbff9764a6b3cf2eb13162..9503e0f998905efb971a23fea89ef7fe6229ddf8

for url in \
  'https://kubernetes.io/docs/concepts/services-networking/ingress-controllers/' \
  'https://gateway-api.sigs.k8s.io/implementations/#higress' \
  'https://gateway-api-inference-extension.sigs.k8s.io/implementations/gateways/#higress'; do
  curl -L --max-time 30 -sS -o /dev/null -w '%{http_code} %{url_effective}\n' "$url"
done
```

Result: `git diff --check` passed, and all three links returned HTTP 200 after redirects.

**Environment and configuration (or N/A with explanation):** macOS development environment; no Kubernetes, build toolchain, or runtime configuration is involved.

**Exact tested revision, version, image tag/digest, manifests, and values (or N/A with explanation):** Commit `9503e0f998905efb971a23fea89ef7fe6229ddf8`. Images, manifests, and values are N/A for a README-only change.

**Baseline reproduction evidence for bug fixes (or N/A with explanation):** N/A. This is not a bug fix.

**Fixed-version verification evidence for bug fixes (or N/A with explanation):** N/A. This is not a bug fix.

**Wasm source revision and SHA-256 (or N/A with explanation):** N/A. No Wasm source changed.

## VI. Special notes for reviewers

The final diff is limited to `README.md`, `README_ZH.md`, and `README_JP.md`. It does not describe Higress as maintained by Kubernetes; it states that Higress is listed in the official Kubernetes documentation and links the two accepted conformance implementation listings.

Independent read-only review of exact head `9503e0f998905efb971a23fea89ef7fe6229ddf8` reported zero P0/P1/P2 findings and confirmed that the final diff contains only the three localized README files.

## VII. AI coding disclosure

**Tool(s) used (or N/A):** OpenAI Codex

### Prompts or instructions

Update the existing English, Chinese, and Japanese README use-case descriptions to add the official Kubernetes Ingress Controllers, Gateway API conformant implementation, and Gateway API Inference Extension conformant implementation links. Place the GIE information under AI Gateway and the Kubernetes/Gateway API information under Kubernetes ingress controller. Avoid the term "third-party" and keep the change minimal.

### AI-assisted work summary

Codex inspected the localized READMEs and upstream pages, selected wording that distinguishes official documentation listing from project maintenance, updated the relevant English, Chinese, and Japanese paragraphs, verified link reachability and whitespace, and arranged an independent read-only review. No runtime behavior, tests, workflow, or configuration is changed.
