### PR TITLE
bugfix: 修复 replay-protection 插件对带请求体请求的重放漏放

### DIFF
--- a/changes/replay-protection-body-replay-fix.md
+++ b/changes/replay-protection-body-replay-fix.md
@@ -1,0 +1,26 @@
+# replay-protection 插件修复带请求体请求的重放漏放
+
+## 问题
+
+`replay-protection` 插件仅在请求头阶段（`ProcessRequestHeaders`）发起 Redis `SETNX` 异步调用并返回 `ActionPause` 等待回调。对于携带请求体的请求（如 POST），请求头阶段的 `ActionPause` 无法挂住后续请求体阶段，导致 Redis 回调常常在请求已被放行之后才到达，重放请求未被拦截（应返回 429，实际放行为 200）。
+
+无请求体的请求（如 GET）因请求头阶段即请求的全部，`ActionPause` 能挂住请求直到回调返回，重放拦截正常。
+
+详见 issue #4601。
+
+## 修复
+
+按请求有无 body 分阶段处理：
+
+1. 额外注册请求体阶段处理器 `ProcessRequestBody(onHttpRequestBody)`。
+2. 请求头阶段只做不依赖 Redis 的快速校验（缺失/长度/base64），然后：
+   - 无 body 请求（`!wrapper.HasRequestBody()`，如 GET）：在请求头阶段直接做 Redis 重放检查。
+   - 有 body 请求（如 POST）：将 nonce 通过 `ctx.SetContext` 暂存，返回 `ActionPause` 暂停 header 流转，交由请求体阶段做 Redis 检查。
+3. 请求体阶段取出暂存的 nonce，发起 Redis `SETNX` 并返回 `ActionPause` 等待回调。请求体阶段是处理请求的最后一道工序，在此挂住能确保异步回调先于响应到达。
+4. 将 Redis 重放检查逻辑抽为公共函数 `checkNonceReplay`，供两个阶段复用。
+
+## 影响范围
+
+- 插件：`plugins/wasm-go/extensions/replay-protection`
+- 配置结构不变，无兼容性影响。
+- 行为变化：带请求体请求的重放检查从请求头阶段移至请求体阶段，修复重放漏放。

--- a/plugins/wasm-go/extensions/replay-protection/main.go
+++ b/plugins/wasm-go/extensions/replay-protection/main.go
@@ -13,6 +13,9 @@ import (
 	"github.com/tidwall/resp"
 )
 
+// nonceContextKey 用于在请求头阶段向请求体阶段传递 nonce。
+const nonceContextKey = "replay-protection-nonce"
+
 func main() {}
 
 func init() {
@@ -20,9 +23,20 @@ func init() {
 		"replay-protection",
 		wrapper.ParseConfig(config.ParseConfig),
 		wrapper.ProcessRequestHeaders(onHttpRequestHeaders),
+		wrapper.ProcessRequestBody(onHttpRequestBody),
 	)
 }
 
+// onHttpRequestHeaders 处理请求头阶段。
+//
+// 该阶段只做不依赖 Redis 的快速校验（缺失/长度/base64），
+// 然后按请求是否携带 body 分流：
+//   - 无 body（如 GET）：ActionPause 在此阶段即可挂住整条请求，
+//     直接做 Redis 重放检查。
+//   - 有 body（如 POST）：将 nonce 暂存到 ctx，返回 ActionPause
+//     暂停 header 流转，交由 onHttpRequestBody 在请求体阶段做
+//     Redis 重放检查。请求体阶段是处理请求的最后一道工序，
+//     在此挂住才能确保异步回调先于响应到达。
 func onHttpRequestHeaders(ctx wrapper.HttpContext, cfg config.ReplayProtectionConfig) types.Action {
 	nonce, _ := proxywasm.GetHttpRequestHeader(cfg.NonceHeader)
 	if cfg.ForceNonce && nonce == "" {
@@ -44,9 +58,50 @@ func onHttpRequestHeaders(ctx wrapper.HttpContext, cfg config.ReplayProtectionCo
 		return types.ActionPause
 	}
 
+	// No request body: the header phase is the entire request, ActionPause
+	// can hold it until the Redis callback returns.
+	if !wrapper.HasRequestBody() {
+		ctx.DontReadRequestBody()
+		return checkNonceReplay(nonce, &cfg)
+	}
+
+	// Has request body: defer the Redis check to the body phase so that
+	// ActionPause there can hold the entire request. Stash the nonce for
+	// onHttpRequestBody to pick up.
+	ctx.SetContext(nonceContextKey, nonce)
+	return types.ActionPause
+}
+
+// onHttpRequestBody 处理请求体阶段。
+//
+// 仅当请求头阶段判定请求携带 body 时才会到达此处。取出暂存的 nonce，
+// 在请求体阶段发起 Redis 重放检查。请求体阶段是处理请求的最后一道
+// 工序，在此 ActionPause 能挂住整条请求直到异步回调返回。
+func onHttpRequestBody(ctx wrapper.HttpContext, cfg config.ReplayProtectionConfig, body []byte) types.Action {
+	nonce, ok := ctx.GetContext(nonceContextKey).(string)
+	if !ok || nonce == "" {
+		// No nonce stashed (e.g. request had no nonce and was allowed through
+		// in the header phase). Nothing to do.
+		return types.ActionContinue
+	}
+	// Clear the stashed nonce so a potential retry of the body phase
+	// does not re-check a stale value.
+	ctx.SetContext(nonceContextKey, nil)
+	return checkNonceReplay(nonce, &cfg)
+}
+
+// checkNonceReplay 使用 Redis SETNX 检查 nonce 是否为重放。
+//
+// SETNX 是原子操作：key 不存在则写入（首次请求，放行），
+// key 已存在则写入失败（重放，拒绝）。该方法发起异步 Redis 调用，
+// 调用方必须返回 ActionPause 等待回调，回调内通过 ResumeHttpRequest
+// 放行或 SendHttpResponse 拒绝。
+//
+// Redis 调用失败时采用 fail-open 策略（放行），避免 Redis 不可用
+// 导致全部请求被拒绝。
+func checkNonceReplay(nonce string, cfg *config.ReplayProtectionConfig) types.Action {
 	redisKey := fmt.Sprintf("%s:%s", cfg.Redis.KeyPrefix, nonce)
 
-	// Check if the nonce already exists
 	err := cfg.Redis.Client.SetNX(redisKey, "1", cfg.NonceTTL, func(response resp.Value) {
 		if response.Error() != nil {
 			log.Errorf("redis call error: %v", response.Error())

--- a/plugins/wasm-go/extensions/replay-protection/main_test.go
+++ b/plugins/wasm-go/extensions/replay-protection/main_test.go
@@ -425,3 +425,175 @@ func TestCompleteFlow(t *testing.T) {
 		})
 	})
 }
+
+// TestOnHttpRequestBody 验证请求体阶段的重放检查逻辑。
+//
+// 这是 issue #4601 的核心回归测试：带请求体的请求（如 POST）必须在
+// 请求体阶段发起 Redis SETNX 并挂起请求等待回调，而非在请求头阶段
+// 挂起（请求头阶段的 ActionPause 挂不住后续 body 阶段，会导致回调
+// 来晚、重放漏放）。
+func TestOnHttpRequestBody(t *testing.T) {
+	test.RunTest(t, func(t *testing.T) {
+		// 带请求体的首次请求：header 阶段暂存 nonce，body 阶段发 SETNX，
+		// Redis 返回 OK（写入成功）→ 放行。
+		t.Run("POST with body - first request allowed", func(t *testing.T) {
+			host, status := test.NewTestHost(basicConfig)
+			defer host.Reset()
+			require.Equal(t, types.OnPluginStartStatusOK, status)
+
+			// 1. 请求头阶段：有 body，暂存 nonce，返回 ActionPause
+			headerAction := host.CallOnHttpRequestHeaders([][2]string{
+				{":authority", "example.com"},
+				{":path", "/test"},
+				{":method", "POST"},
+				{"content-type", "application/json"},
+				{"X-Higress-Nonce", "dGVzdC1ub25jZS12YWx1ZQ=="},
+			})
+			require.Equal(t, types.ActionPause, headerAction)
+
+			// 2. 请求体阶段：发起 SETNX，返回 ActionPause 等待回调
+			bodyAction := host.CallOnHttpRequestBody([]byte(`{"key":"value"}`))
+			require.Equal(t, types.ActionPause, bodyAction)
+
+			// 3. 模拟 Redis SETNX 成功（首次写入）→ ResumeHttpRequest 放行
+			host.CallOnRedisCall(0, test.CreateRedisRespString("OK"))
+
+			host.CompleteHttp()
+		})
+
+		// 带请求体的重放请求：body 阶段发 SETNX，Redis 返回 nil
+		//（key 已存在，写入失败）→ 应返回 429。
+		t.Run("POST with body - replay request rejected", func(t *testing.T) {
+			host, status := test.NewTestHost(basicConfig)
+			defer host.Reset()
+			require.Equal(t, types.OnPluginStartStatusOK, status)
+
+			// 1. 请求头阶段
+			headerAction := host.CallOnHttpRequestHeaders([][2]string{
+				{":authority", "example.com"},
+				{":path", "/test"},
+				{":method", "POST"},
+				{"content-type", "application/json"},
+				{"X-Higress-Nonce", "dGVzdC1ub25jZS12YWx1ZQ=="},
+			})
+			require.Equal(t, types.ActionPause, headerAction)
+
+			// 2. 请求体阶段：发起 SETNX，返回 ActionPause 等待回调
+			bodyAction := host.CallOnHttpRequestBody([]byte(`{"key":"value"}`))
+			require.Equal(t, types.ActionPause, bodyAction)
+
+			// 3. 模拟 Redis SETNX 失败（key 已存在，重放）→ SendHttpResponse(429)
+			host.CallOnRedisCall(0, test.CreateRedisRespNull())
+
+			localResponse := host.GetLocalResponse()
+			require.NotNil(t, localResponse, "replay request should be rejected with 429")
+			require.Equal(t, uint32(429), localResponse.StatusCode)
+			require.Equal(t, "Replay Attack Detected", string(localResponse.Data))
+
+			host.CompleteHttp()
+		})
+
+		// 带请求体的请求，Redis 返回错误 → fail-open 放行
+		t.Run("POST with body - redis error fail-open", func(t *testing.T) {
+			host, status := test.NewTestHost(basicConfig)
+			defer host.Reset()
+			require.Equal(t, types.OnPluginStartStatusOK, status)
+
+			host.CallOnHttpRequestHeaders([][2]string{
+				{":authority", "example.com"},
+				{":path", "/test"},
+				{":method", "POST"},
+				{"content-type", "application/json"},
+				{"X-Higress-Nonce", "dGVzdC1ub25jZS12YWx1ZQ=="},
+			})
+
+			bodyAction := host.CallOnHttpRequestBody([]byte(`{"key":"value"}`))
+			require.Equal(t, types.ActionPause, bodyAction)
+
+			// Redis 返回错误 → ResumeHttpRequest 放行（fail-open）
+			host.CallOnRedisCall(0, test.CreateRedisRespError("connection refused"))
+
+			host.CompleteHttp()
+		})
+
+		// 带请求体但无 nonce（非强制模式）→ 两阶段都直接放行
+		t.Run("POST with body - no nonce non-force mode", func(t *testing.T) {
+			host, status := test.NewTestHost(customConfig)
+			defer host.Reset()
+			require.Equal(t, types.OnPluginStartStatusOK, status)
+
+			headerAction := host.CallOnHttpRequestHeaders([][2]string{
+				{":authority", "example.com"},
+				{":path", "/test"},
+				{":method", "POST"},
+				{"content-type", "application/json"},
+			})
+			require.Equal(t, types.ActionContinue, headerAction)
+
+			// body 阶段：无 nonce 暂存，直接放行
+			bodyAction := host.CallOnHttpRequestBody([]byte(`{"key":"value"}`))
+			require.Equal(t, types.ActionContinue, bodyAction)
+
+			host.CompleteHttp()
+		})
+	})
+}
+
+// TestCompleteFlowWithBody 验证带请求体的完整请求流程：
+// header 阶段暂存 nonce → body 阶段发 SETNX → Redis 回调判决。
+// 这直接覆盖 issue #4601 报告的 POST 重放漏放场景。
+func TestCompleteFlowWithBody(t *testing.T) {
+	test.RunTest(t, func(t *testing.T) {
+		t.Run("POST complete flow - first then replay", func(t *testing.T) {
+			nonce := "dGVzdC1ub25jZS12YWx1ZQ=="
+
+			// --- 第一次请求（首次，应放行）---
+			host, status := test.NewTestHost(basicConfig)
+			require.Equal(t, types.OnPluginStartStatusOK, status)
+
+			headerAction := host.CallOnHttpRequestHeaders([][2]string{
+				{":authority", "example.com"},
+				{":path", "/test"},
+				{":method", "POST"},
+				{"content-type", "application/json"},
+				{"X-Higress-Nonce", nonce},
+			})
+			require.Equal(t, types.ActionPause, headerAction)
+
+			bodyAction := host.CallOnHttpRequestBody([]byte(`{"key":"value"}`))
+			require.Equal(t, types.ActionPause, bodyAction)
+
+			// SETNX 成功 → 放行
+			host.CallOnRedisCall(0, test.CreateRedisRespString("OK"))
+			host.CompleteHttp()
+			host.Reset()
+
+			// --- 第二次请求（重放，应 429）---
+			host2, status2 := test.NewTestHost(basicConfig)
+			defer host2.Reset()
+			require.Equal(t, types.OnPluginStartStatusOK, status2)
+
+			headerAction2 := host2.CallOnHttpRequestHeaders([][2]string{
+				{":authority", "example.com"},
+				{":path", "/test"},
+				{":method", "POST"},
+				{"content-type", "application/json"},
+				{"X-Higress-Nonce", nonce},
+			})
+			require.Equal(t, types.ActionPause, headerAction2)
+
+			bodyAction2 := host2.CallOnHttpRequestBody([]byte(`{"key":"value"}`))
+			require.Equal(t, types.ActionPause, bodyAction2)
+
+			// SETNX 失败（key 已存在）→ 429
+			host2.CallOnRedisCall(0, test.CreateRedisRespNull())
+
+			localResponse := host2.GetLocalResponse()
+			require.NotNil(t, localResponse, "replay POST should be rejected")
+			require.Equal(t, uint32(429), localResponse.StatusCode)
+			require.Equal(t, "Replay Attack Detected", string(localResponse.Data))
+
+			host2.CompleteHttp()
+		})
+	})
+}


### PR DESCRIPTION

## I. Summary

<!-- What changed, why, and any compatibility or migration impact? -->

replay-protection 插件仅在请求头阶段（`ProcessRequestHeaders`）发起 Redis `SETNX` 异步调用并返回 `ActionPause` 等待回调。对于携带请求体的请求（如 POST），请求头阶段的 `ActionPause` 无法挂住后续请求体阶段，导致 Redis 回调常常在请求已被放行之后才到达，重放请求未被拦截（应返回 429，实际放行为 200）。无请求体的请求（如 GET）因请求头阶段即请求全部，拦截正常。

修复方式：按请求有无 body 分阶段处理。

- 注册请求体阶段处理器 `ProcessRequestBody`。
- 请求头阶段只做不依赖 Redis 的快速校验（缺失/长度/base64）：
  - 无 body（GET）：直接做 Redis 重放检查。
  - 有 body（POST）：暂存 nonce 到 `ctx`，交由请求体阶段检查。
- 请求体阶段发起 `SETNX` 并挂起，回调先于响应到达，重放被稳定拦截。
- Redis 重放检查逻辑抽为公共函数 `checkNonceReplay` 供两阶段复用。

无配置结构变更，无兼容性或迁移影响。

## II. Related issue

<!-- Use "Fixes #123" when this PR closes an issue, or explain N/A. -->

Fixes #4601

## III. Change type

<!-- Check all that apply. -->

- [x] Bug fix
- [ ] Feature or enhancement
- [ ] Documentation or configuration only
- [ ] Refactoring, tests, or maintenance


## IV. Agent participation and issue-spec gate

See the [agent-assisted contribution policy](https://github.com/higress-group/higress/blob/main/docs/developers/agent-assisted-contributions.md).
Materially agent-assisted PRs that miss the gate receive low review priority,
and timely maintainer review is not guaranteed; this author declaration is the
deterministic prioritization signal.
Choose exactly one participation declaration:

- [ ] **No agent participation:** This PR is human-only.
- [ ] **Trivial agent-use exception:** Agent use was limited to spelling,
      punctuation, whitespace, or formatting with no substantive choice or
      behavioral effect; the explanation is below.
- [ ] **Verified maintainer/administrator exception:** Material agent
      participation occurred, and authenticated `gh` verification confirmed
      a `role_name` of `maintain` or `admin` on `higress-group/higress`, and the
      verified login matches this PR's GitHub author; record the required
      evidence and rationale below.
- [x] **Material agent participation:** An AI or coding agent materially
      participated in analysis, design, implementation, testing, or PR
      preparation.

For material participation that does not use the verified maintainer/administrator
exception, check each timed obligation:

- [ ] **Before implementation began:** A Higress maintainer had approved the
      Proposal and Design Issues, and authorized implementation TASKs linked the
      work to the applicable SPECs.
- [ ] **Before verification began:** The Design contained a concrete
      Verification Plan.
- [ ] **Before requesting maintainer review or acceptance:** Applicable
      implementation and verification TASKs were `done` with exact commands,
      results, evidence links, and hashes.

Then choose exactly one overall gate status:

- [ ] Complete: all three timed obligations above were satisfied.
- [x] Noncompliant: one or more obligations were not satisfied; explain below.
- [ ] Verified exception: material agent participation used the
      verified-maintainer/administrator exception; provide the required evidence
      and rationale below.
- [ ] N/A because the PR is human-only or qualifies for the trivial exception.

**Gate-status explanation (or N/A):**

AI 编程代理实质性参与了此 PR 的根因分析、修复方案设计、代码实现与测试编写。未在实现前进入 Higress issue-spec 工作流（未开设经维护者批准的 Proposal Issue 和 Design Issue），三个时序义务均未满足。作者知晓此 PR 将被安排为较低审查优先级，不保证维护者及时审查。

**Trivial-exception explanation (or N/A):**

N/A — 不适用，本 PR 属于实质性 AI 参与，非 trivial 例外。


**Verified maintainer/administrator exception evidence (or N/A):**
<!-- Required when the verified exception is checked; otherwise write N/A. Run the policy's commands with GH_TOKEN and GITHUB_TOKEN unset after this PR is created but before requesting review. Record this PR's number or URL, the authenticated login, returned `role_name` of `maintain` or `admin`, and the author returned by `gh pr view`; the two logins must match. Explicitly attest that both token override variables were unset for every verification command. Never paste a token. The accepting or merging maintainer independently validates the current live evidence. -->

N/A — 未使用已验证的维护者/管理员例外。

- This PR's number or URL: N/A
- Authenticated `gh` login: N/A
- Canonical-repository `role_name`: N/A
- Actual PR author from `gh pr view`: N/A
- Login/author match: N/A
- Token override attestation (`GH_TOKEN` and `GITHUB_TOKEN` were unset for every verification command; required: `yes`): N/A
- Bypass rationale: N/A
- Maintainer live validation (review URL or N/A until performed): N/A


**Approved Proposal Issue URL (or N/A with explanation):**

N/A — 未在实现前开设 Proposal Issue，未获得维护者批准。


**Approved Design Issue URL (or N/A with explanation):**

N/A — 未在实现前开设 Design Issue，未获得维护者批准。


**Maintainer approval link(s) (or N/A with explanation):**

N/A — 未获得维护者对实现的事先批准。


**Authorized implementation TASK link(s) (or N/A with explanation):**

N/A — 未通过 issue-spec 工作流授权实现 TASK。


**Verification Plan and verification TASK/evidence link(s) (or N/A with explanation):**

N/A — 未通过 issue-spec 工作流制定验证计划。验证证据见下方第 V 节。

## V. Testing and verification

**Test and deterministic rerun commands (or N/A with explanation):**

```text
cd plugins/wasm-go/extensions/replay-protection
go test -v -count=1 ./...
```

完整输出中关键结果：

- `TestOnHttpRequestBody/go/POST_with_body_-_first_request_allowed` PASS — 带请求体的首次请求放行
- `TestOnHttpRequestBody/go/POST_with_body_-_replay_request_rejected` PASS — 带请求体的重放请求返回 429
- `TestOnHttpRequestBody/go/POST_with_body_-_redis_error_fail-open` PASS — Redis 错误时 fail-open 放行
- `TestOnHttpRequestBody/go/POST_with_body_-_no_nonce_non-force_mode` PASS — 非强制模式无 nonce 放行
- `TestCompleteFlowWithBody/go/POST_complete_flow_-_first_then_replay` PASS — 首次放行 + 重放 429 完整流程
- `TestParseConfig` / `TestOnHttpRequestHeaders` / `TestValidateNonce` / `TestCompleteFlow` PASS — 现有测试零回归

**Environment and configuration (or N/A with explanation):**
<!-- Include OS/architecture and relevant Kubernetes, kind/k3s, Envoy, Go, Rust, or other tool versions. -->

- OS: Windows 11 Enterprise (x64)
- Go: go1.24.4
- 插件依赖: higress-group/wasm-go v1.0.2-0.20250821081215-b573359becf8, higress-group/proxy-wasm-go-sdk v0.0.0-20250822030947-8345453fddd0
- 测试模式: go 模式（wasm 模式因未构建 main.wasm 而 SKIP，不影响逻辑验证）

**Exact tested revision, version, image tag/digest, manifests, and values (or N/A with explanation):**

分支 `bugfix/replay-protection-body-replay`，提交 `d91b9792`。未涉及镜像或 Kubernetes 部署。

**Baseline reproduction evidence for bug fixes (or N/A with explanation):**
<!-- Link affected/pre-fix results using the same inputs and configuration as the fixed run. -->

修复前行为由 issue #4601 报告：用同一合法 nonce 连续发起 10 次 POST 请求，实际输出 `200 200 200 200 200 200 200 200 200 200`（全部漏放，应为 `200 429 429 ...`）。GET 请求输出 `200 429 429 ...` 正常。根因：插件仅在请求头阶段发起 `SETNX` 并返回 `ActionPause`，对带 body 的请求挂不住后续请求体阶段，回调来晚导致漏放。

**Fixed-version verification evidence for bug fixes (or N/A with explanation):**
<!-- Link expected/actual results, assertions, logs/metrics, and artifact hashes. -->

修复后单元测试（go 模式）验证：

- `TestOnHttpRequestBody/go/POST_with_body_-_replay_request_rejected`：POST + body + 重放 nonce → 模拟 Redis `SETNX` 返回 nil（key 已存在）→ 断言 `localResponse.StatusCode == 429` 且 `Data == "Replay Attack Detected"` PASS。
- `TestCompleteFlowWithBody/go/POST_complete_flow_-_first_then_replay`：同一 nonce 第一次 POST → `SETNX` 返回 "OK" → 放行；第二次 POST → `SETNX` 返回 nil → 断言 429 PASS。

日志中可观察到重放场景打印 `duplicate nonce detected`，证明回调在请求体阶段被正确触发并完成判决。

注意：单元测试使用 mock host 的同步 Redis 回调，无法完全模拟真实异步延迟。issue #4601 作者已在真实 Envoy + 远端 Redis 环境验证修复有效（POST 与 GET 均稳定 `200 429 429 ...`），此处单元测试验证的是判决逻辑正确性与两阶段路由正确性。

**Wasm source revision and SHA-256 (or N/A with explanation):**

N/A — 本 PR 未构建 wasm 二进制，wasm 模式测试因缺少 main.wasm 而 SKIP。go 模式测试覆盖全部逻辑。


## VI. Special notes for reviewers

<!-- Call out risk, compatibility, limitations, follow-up work, or review focus. -->

- **行为变化**：带请求体请求的 Redis 重放检查从请求头阶段移至请求体阶段。对正常请求无感知，仅影响此前被漏放的重放请求（现在会被正确拦截）。
- **fail-open 策略未改动**：Redis 调用失败/出错时仍放行（与修复前一致）。issue #4601 提到可考虑增加 fail-close 选项，作为独立增强，本 PR 不涉及。
- **依赖版本未升级**：沿用现有 wasm-go v1.0.2，使用 `wrapper.HasRequestBody()` 包级函数判断有无 body，未升级到新版接口的 `ctx.HasRequestBody()` 方法，避免引入不必要的依赖变更。
- **审查重点**：`onHttpRequestHeaders` 中 `wrapper.HasRequestBody()` 分支逻辑、`onHttpRequestBody` 中 nonce 取出与清除、`checkNonceReplay` 公共函数复用。


## VII. AI coding disclosure

<!--
Required whenever an AI or coding agent was used, including the trivial-use
exception. Human-only PRs should write N/A. Do not include credentials or
sensitive data.
-->

**Tool(s) used (or N/A):**

OpenCodeGo / GLM-5.2 编程代理（通过 Oh My Pi harness 交互）。

### Prompts or instructions

<!-- Paste or link the prompts/instructions given to the tool, with secrets removed. -->

主要指令（脱敏摘要）：

1. 解释 Higress issue #4601 的内容。
2. 分析 replay-protection 插件中 ActionPause 对带请求体请求挂不住的根因。
3. 在 fork 仓库的 higress 目录中定位相关代码，先不修复。
4. 查看仓库 PR 规范，确认分支命名方式。
5. 确认 PR 路径：直接提 PR 并声明 AI 参与。
6. 开始在 higress 目录写代码，提交到 fork 仓库，中文 commit message。
7. 填写 PR 模板。

### AI-assisted work summary

<!-- Include key decisions, major changes, and important considerations or limitations. -->

**关键决策：**

- **不升级依赖版本**：replay-protection 使用 wasm-go v1.0.2，该版本 HttpContext 接口无 `HasRequestBody()` 方法。选择使用已有的 `wrapper.HasRequestBody()` 包级函数而非升级依赖，避免引入兼容性风险。
- **分阶段处理策略**：参照仓库内 ai-context-limit 插件的模式——请求头阶段用 `HasRequestBody()` 分流，无 body 在 header 阶段查 Redis，有 body 暂存 nonce 交给 body 阶段。这是 issue #4601 建议的修复方案。
- **公共函数抽取**：将 Redis `SETNX` 重放检查逻辑抽为 `checkNonceReplay`，供 header 和 body 两个阶段复用，避免重复代码。

**主要变更：**

- `main.go`：`init()` 注册 `ProcessRequestBody`；`onHttpRequestHeaders` 拆分有无 body 分支；新增 `onHttpRequestBody`；新增 `checkNonceReplay` 公共函数。
- `main_test.go`：新增 `TestOnHttpRequestBody`（4 子用例）和 `TestCompleteFlowWithBody`（完整首次+重放流程），使用 `CallOnHttpRequestBody` 和 `CallOnRedisCall` 模拟 body 阶段与 Redis 回调。
- `changes/replay-protection-body-replay-fix.md`：变更说明。

**重要限制：**

- 单元测试使用 mock host 的同步 Redis 回调，无法完全模拟真实异步延迟。issue 作者已在真实 Envoy + 远端 Redis 环境验证修复有效，本 PR 单元测试验证判决逻辑与两阶段路由正确性。
