### PR TITLE
feat(helm): grant controller cluster role access to alpha Gateway API

### DIFF
--- a/helm/core/templates/controller-clusterrole.yaml
+++ b/helm/core/templates/controller-clusterrole.yaml
@@ -37,6 +37,9 @@ rules:
   - apiGroups: ["gateway.networking.k8s.io"]
     resources: ["*"]
     verbs: ["get", "watch", "list", "create", "update", "delete", "patch"]
+  - apiGroups: ["gateway.networking.x-k8s.io"]
+    resources: ["*"]
+    verbs: ["get", "watch", "list", "create", "update", "delete", "patch"]
 
   # Gateway api inference extension
   - apiGroups: ["inference.networking.k8s.io"]


### PR DESCRIPTION
## What

Add a `ClusterRole` rule in the Higress Helm chart so the controller can manage resources from the **experimental / alpha Gateway API** group `gateway.networking.x-k8s.io`, alongside the already-supported standard group `gateway.networking.k8s.io` and the Inference Extension group `inference.networking.k8s.io`.

## Why

Higress already supports the standard Gateway API and the Inference Extension. Several alpha / experimental Gateway API resources (e.g. `xRoute*`, `xBackendTrafficPolicy`, etc. that ship under the `x-k8s.io` group before graduating to `k8s.io`) require the controller to have CRUD access to `gateway.networking.x-k8s.io`. Without this rule the controller logs permission-denied errors and cannot reconcile those resources.

## Changes

```diff
--- a/helm/core/templates/controller-clusterrole.yaml
+++ b/helm/core/templates/controller-clusterrole.yaml
@@ -37,6 +37,9 @@ rules:
   - apiGroups: ["gateway.networking.k8s.io"]
     resources: ["*"]
     verbs: ["get", "watch", "list", "create", "update", "delete", "patch"]
+  - apiGroups: ["gateway.networking.x-k8s.io"]
+    resources: ["*"]
+    verbs: ["get", "watch", "list", "create", "update", "delete", "patch"]
 
   # Gateway api inference extension
   - apiGroups: ["inference.networking.k8s.io"]
```

## Scope

- **Helm chart only** — no controller / Go code changes.
- Pure RBAC addition; no rule is removed or tightened.
- New verbs match the existing rule for the standard `gateway.networking.k8s.io` group, keeping behavior symmetric.

## Test plan

- [ ] `helm template` against a test values file renders the new rule unchanged.
- [ ] `kubectl auth can-i create gateway.networking.x-k8s.io/<resource>` returns `yes` for the controller service account after install.
- [ ] Deploy an alpha Gateway API resource and verify the controller can reconcile it (no `forbidden` events in controller logs).

## Notes

- Branch: `feat/cluster-role-alpha-gateway-api`
- Commit: `bcc77026`