### PR TITLE
docs: make GitHub the primary security intake

### DIFF
--- a/.github/ISSUE_TEMPLATE/non--crash-security--bug.md
+++ b/.github/ISSUE_TEMPLATE/non--crash-security--bug.md
@@ -8,10 +8,12 @@ assignees: ''
 ---
 
 **If you are reporting a potential security issue, do not open a public issue.
-You must submit the same substantive report through both
-[GitHub Private Security Advisories](https://github.com/higress-group/higress/security/advisories/new)
-and the [Alibaba Security Response Center](https://security.alibaba.com/), as
-required by the project's [security policy](https://github.com/higress-group/higress/blob/main/SECURITY.md).
+Please submit it through a
+[GitHub Private Security Advisory](https://github.com/higress-group/higress/security/advisories/new),
+the project's required and sufficient private intake. You may also submit the
+same report to the [Alibaba Security Response Center](https://security.alibaba.com/)
+as an optional additional channel, as described in the project's
+[security policy](https://github.com/higress-group/higress/blob/main/SECURITY.md).
 A crash with no suspected security impact may be reported with this template.**
 
 - [ ] I have searched the [issues](https://github.com/higress-group/higress/issues) of this repository and believe that this is not a duplicate.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -17,16 +17,17 @@ your contributions.
 **Please do NOT report security vulnerabilities through public GitHub issues,
 discussions, or pull requests.**
 
-Every vulnerability report must be submitted through both of the following
-private channels. Please provide the same substantive report to each channel
-and, when available, include the case identifier from the other channel so the
-Security Response Team can correlate the records. Do not wait for one channel
-to acknowledge the report before submitting it to the other.
+Submit vulnerability reports through the project's vendor-neutral,
+authoritative private intake:
 
-1. **GitHub Private Security Advisory (required)**:
+1. **GitHub Private Security Advisory (required and sufficient)**:
    <https://github.com/higress-group/higress/security/advisories/new>
-2. **Alibaba Security Response Center (required)**:
-   <https://security.alibaba.com/>
+
+Reporters may also submit the same report to the
+[Alibaba Security Response Center](https://security.alibaba.com/) when the
+issue affects an Alibaba Cloud service or they prefer that additional channel.
+An ASRC submission is optional and is not required for the Higress project to
+receive or act on a report.
 
 Please include as much of the following information as possible to help us
 triage and address the issue:
@@ -90,11 +91,13 @@ independent review.
 
 ### Report handling, conflicts, and escalation
 
-1. The SRT correlates the required GitHub Private Security Advisory and Alibaba
-   Security Response Center submissions. The GitHub advisory or an equivalent
-   access-controlled project record contains the report, assignments,
-   decisions, timeline, fix, and disclosure plan; material status and
-   disclosure updates are reflected in both required reporting records.
+1. The GitHub Private Security Advisory, or an equivalent project-controlled
+   confidential record, is the system of record for the report, assignments,
+   decisions, timeline, fix, and disclosure plan. If a reporter also opens an
+   ASRC case, an SRT member with ASRC access may correlate it with the project
+   record. ASRC access is not required for SRT membership, and project handling
+   does not depend on every SRT member having access to that vendor-operated
+   system.
 2. An SRT member with a personal, employer, or product conflict must disclose
    it privately and recuse from severity, release, or disclosure decisions for
    that case. The triage coordinator assigns an unconflicted replacement.
@@ -103,9 +106,9 @@ independent review.
    case to the full unconflicted SRT and records a revised plan. Critical
    vulnerabilities are escalated immediately.
 4. If a reporter receives no acknowledgement within three business days, they
-   should follow up through both private reporting channels and reference both
-   case identifiers when available. No vulnerability details should be posted
-   publicly.
+   should follow up through the GitHub Private Security Advisory and may
+   reference an optional ASRC case identifier when available. No vulnerability
+   details should be posted publicly.
 5. If fewer than two SRT members are unconflicted, the unconflicted member
    escalates confidentially to the CNCF TOC private mailing list at
    [cncf-private-toc@lists.cncf.io](mailto:cncf-private-toc@lists.cncf.io)


### PR DESCRIPTION
## I. Summary

Makes GitHub Private Security Advisories the vendor-neutral, authoritative,
required, and sufficient vulnerability-reporting channel for Higress. Alibaba
Security Response Center remains available as an optional additional channel.

The policy now states that ASRC access is not required for Security Response
Team membership and that project handling remains in a project-controlled
confidential record. The security issue template is aligned with the policy.

This is a documentation and governance-policy change only. It does not change
runtime behavior.

## II. Related issue

N/A. This follows review feedback on cncf/toc#2268:
https://github.com/cncf/toc/pull/2268#discussion_r3892832102

## III. Change type

- [ ] Bug fix
- [ ] Feature or enhancement
- [x] Documentation or configuration only
- [ ] Refactoring, tests, or maintenance

## IV. Agent participation and issue-spec gate

- [ ] **No agent participation:** This PR is human-only.
- [ ] **Trivial agent-use exception:** Agent use was limited to spelling,
      punctuation, whitespace, or formatting with no substantive choice or
      behavioral effect; the explanation is below.
- [x] **Verified maintainer/administrator exception:** Material agent
      participation occurred, and authenticated `gh` verification confirmed
      a `role_name` of `maintain` or `admin` on `higress-group/higress`, and the
      verified login matches this PR's GitHub author; record the required
      evidence and rationale below.
- [ ] **Material agent participation:** An AI or coding agent materially
      participated in analysis, design, implementation, testing, or PR
      preparation.

- [ ] **Before implementation began:** A Higress maintainer had approved the
      Proposal and Design Issues, and authorized implementation TASKs linked the
      work to the applicable SPECs.
- [ ] **Before verification began:** The Design contained a concrete
      Verification Plan.
- [ ] **Before requesting maintainer review or acceptance:** Applicable
      implementation and verification TASKs were `done` with exact commands,
      results, evidence links, and hashes.

- [ ] Complete: all three timed obligations above were satisfied.
- [ ] Noncompliant: one or more obligations were not satisfied; explain below.
- [x] Verified exception: material agent participation used the
      verified-maintainer/administrator exception; provide the required evidence
      and rationale below.
- [ ] N/A because the PR is human-only or qualifies for the trivial exception.

**Gate-status explanation (or N/A):** Verified administrator exception.

**Trivial-exception explanation (or N/A):** N/A; agent participation was material.

**Verified maintainer/administrator exception evidence (or N/A):**

- This PR's number or URL: https://github.com/higress-group/higress/pull/4624
- Authenticated `gh` login: `EndlessSeeker`
- Canonical-repository `role_name`: `admin`
- Actual PR author from `gh pr view`: `EndlessSeeker`
- Login/author match: yes
- Token override attestation (`GH_TOKEN` and `GITHUB_TOKEN` were unset for every verification command; required: `yes`): yes
- Bypass rationale: focused documentation and security-reporting governance clarification in response to CNCF review; no runtime behavior changes.
- Maintainer live validation (review URL or N/A until performed): N/A until performed by the accepting or merging maintainer.

**Approved Proposal Issue URL (or N/A with explanation):** N/A; verified administrator exception used.

**Approved Design Issue URL (or N/A with explanation):** N/A; verified administrator exception used.

**Maintainer approval link(s) (or N/A with explanation):** N/A; verified administrator exception used. Independent review is still required before merge.

**Authorized implementation TASK link(s) (or N/A with explanation):** N/A; verified administrator exception used.

**Verification Plan and verification TASK/evidence link(s) (or N/A with explanation):** N/A; verified administrator exception used. Verification commands are recorded below.

## V. Testing and verification

**Test and deterministic rerun commands (or N/A with explanation):**

```text
git diff HEAD^..HEAD --check
grep -Fq "GitHub Private Security Advisory (required and sufficient)" SECURITY.md
grep -Fq "An ASRC submission is optional" SECURITY.md
grep -Fq "ASRC access is not required for SRT membership" SECURITY.md
grep -Fq "required and sufficient private intake" .github/ISSUE_TEMPLATE/non--crash-security--bug.md
```

All commands passed.

**Environment and configuration (or N/A with explanation):** Darwin arm64; documentation-only verification.

**Exact tested revision, version, image tag/digest, manifests, and values (or N/A with explanation):** Commit `89454924b5990effad542d484a35c0323ed030e3`; no runtime image or manifests apply.

**Baseline reproduction evidence for bug fixes (or N/A with explanation):** N/A; not a bug fix.

**Fixed-version verification evidence for bug fixes (or N/A with explanation):** N/A; not a bug fix.

**Wasm source revision and SHA-256 (or N/A with explanation):** N/A; no Wasm changes.

## VI. Special notes for reviewers

The policy intentionally keeps ASRC as an optional additional channel while
making GitHub PSA sufficient for project handling. Historical meeting notes are
not changed because they record the policy in effect at that time.

## VII. AI coding disclosure

**Tool(s) used (or N/A):** OpenAI Codex.

### Prompts or instructions

The agent was asked to review CNCF feedback on cncf/toc#2268, update Higress's
own policy and source assessment first, and prepare PRs without modifying or
replying to the CNCF PR until the project-side changes are merged. Repository
instructions required minimal scoped changes and the verified administrator
exception.

### AI-assisted work summary

Codex analyzed the reviewer question, selected GitHub PSA as the neutral and
authoritative intake, retained ASRC as optional, updated the policy and issue
template, and ran text consistency and whitespace checks. It did not change
runtime code or access-control settings. Maintainers must confirm that the
documented SRT access model matches operational repository permissions.
