### PR TITLE
feat(release): opt-in adoption of unannotated legacy latest tags in promote

### DIFF
--- a/.github/workflows/promote-plugin-release.yaml
+++ b/.github/workflows/promote-plugin-release.yaml
@@ -20,6 +20,11 @@ on:
         required: true
         default: true
         type: boolean
+      adopt_unannotated_latest:
+        description: "Adopt unannotated legacy latest tags: replace them with the snapshot-verified digest (journaled as adopt-legacy). Bridge for pre-pipeline manual latests."
+        required: true
+        default: false
+        type: boolean
 
 permissions:
   contents: read
@@ -189,6 +194,7 @@ jobs:
       - name: Promote latest only after complete verified batch
         env:
           REGISTRY: ${{ vars.PLUGIN_PUBLIC_REGISTRY }}
+          ADOPT_UNANNOTATED_LATEST: ${{ inputs.adopt_unannotated_latest }}
           REGISTRY_USERNAME: ${{ secrets.PRODUCTION_REGISTRY_USERNAME }}
           REGISTRY_PASSWORD: ${{ secrets.PRODUCTION_REGISTRY_PASSWORD }}
           SNAPSHOT_PATH: ${{ inputs.snapshot_path }}
@@ -280,20 +286,27 @@ jobs:
               else
                 old=$(oras manifest fetch "$latest" --format json | jq -r '.annotations["org.opencontainers.image.version"] // empty')
                 if [ -z "$old" ]; then
-                  test "$bootstrap_latest_migration" = true || { echo "existing latest lacks a stable version annotation outside a verified bootstrap snapshot: $latest" >&2; exit 1; }
-                  bootstrap_entry=$(jq -cer --arg id "$id" '.plugins[$id] | select(.status == "public" or .status == "missing")' "$bootstrap_evidence_path") || { echo "bootstrap evidence does not authorize unclassified legacy latest replacement: $id" >&2; exit 1; }
-                  bootstrap_status=$(jq -er .status <<<"$bootstrap_entry")
-                  bootstrap_version=$(jq -er .version <<<"$bootstrap_entry")
-                  test "$(jq -er .publicRef <<<"$bootstrap_entry")" = "$image:$bootstrap_version" || { echo "bootstrap evidence public reference does not match latest image: $id" >&2; exit 1; }
-                  if [ "$bootstrap_status" = public ]; then
-                    [[ "$(jq -er .digest <<<"$bootstrap_entry")" =~ ^sha256:[0-9a-f]{64}$ ]]
-                    (cd tools/plugin-release && go run . semver-compare --current "$bootstrap_version" --candidate "$version")
-                    test "$bootstrap_version" != "$version" || { echo "latest alias conflict: $latest is unannotated and bootstrap does not authorize replacing the same stable version" >&2; exit 1; }
+                  if [ "${ADOPT_UNANNOTATED_LATEST:-false}" = "true" ]; then
+                    # Bridge for pre-pipeline manual latest tags: adopt the
+                    # snapshot-verified digest; journal the displaced one.
+                    old=""; state=adopt-legacy
+                  elif test "$bootstrap_latest_migration" = true; then
+                    bootstrap_entry=$(jq -cer --arg id "$id" '.plugins[$id] | select(.status == "public" or .status == "missing")' "$bootstrap_evidence_path") || { echo "bootstrap evidence does not authorize unclassified legacy latest replacement: $id" >&2; exit 1; }
+                    bootstrap_status=$(jq -er .status <<<"$bootstrap_entry")
+                    bootstrap_version=$(jq -er .version <<<"$bootstrap_entry")
+                    test "$(jq -er .publicRef <<<"$bootstrap_entry")" = "$image:$bootstrap_version" || { echo "bootstrap evidence public reference does not match latest image: $id" >&2; exit 1; }
+                    if [ "$bootstrap_status" = public ]; then
+                      [[ "$(jq -er .digest <<<"$bootstrap_entry")" =~ ^sha256:[0-9a-f]{64}$ ]]
+                      (cd tools/plugin-release && go run . semver-compare --current "$bootstrap_version" --candidate "$version")
+                      test "$bootstrap_version" != "$version" || { echo "latest alias conflict: $latest is unannotated and bootstrap does not authorize replacing the same stable version" >&2; exit 1; }
+                    else
+                      test "$bootstrap_version" = "$version" || { echo "missing bootstrap entry version does not match selected plugin version: $id" >&2; exit 1; }
+                      test -z "$(jq -r '.digest // empty' <<<"$bootstrap_entry")" || { echo "missing bootstrap entry unexpectedly carries a digest: $id" >&2; exit 1; }
+                    fi
+                    old=""; state=bootstrap-replace-unclassified
                   else
-                    test "$bootstrap_version" = "$version" || { echo "missing bootstrap entry version does not match selected plugin version: $id" >&2; exit 1; }
-                    test -z "$(jq -r '.digest // empty' <<<"$bootstrap_entry")" || { echo "missing bootstrap entry unexpectedly carries a digest: $id" >&2; exit 1; }
+                    echo "existing latest lacks a stable version annotation outside a verified bootstrap snapshot: $latest" >&2; exit 1
                   fi
-                  old=""; state=bootstrap-replace-unclassified
                 else
                   (cd tools/plugin-release && go run . semver-compare --current "$old" --candidate "$version")
                   if [ "$old" = "$version" ]; then


### PR DESCRIPTION
feat(release): let promote adopt unannotated legacy latest tags with a one-time migration input

Problem: 43 plugins still carry pre-pipeline manual `latest` tags with no version annotation and digests matching no managed snapshot (e.g. `ai-agent:latest=a49452b7` vs 2.2.4=`1ff8b5c1`/2.2.5=`31938d20`). The 2.2.4 promote never moved latest, and the one-time bootstrap-evidence mechanism was consumed by 2.2.4, so every later promote's latest phase hard-fails with "existing latest lacks a stable version annotation". The only sanctioned path today is manually deleting 43 latest tags in ACR — an unreasonably heavy operation for a routine release.

Change (minimal, opt-in): add a workflow input `adopt_unannotated_latest` (default `false`). When true, an unannotated existing latest tag is replaced by the snapshot's verified digest — journaled as `state=adopt-legacy` with the old digest recorded. When false (default), behavior is byte-identical to today. The version-tag phase is untouched: immutable digest verification, monotonic version checks, and the annotated-latest advance/replace/conflict logic all keep working exactly as before.

Why this is safe: the snapshot's digests are content-verified against the immutable version tags just copied in the same run; replacing a `latest` pointer whose content is provably stale (matches no managed release) with the newly published, verified version is the intended semantic of a release. The old digest is journaled before the write.

This is intentionally a bridge until the release-pipeline redesign (layout unification + pre-publish OCI smoke gate) lands.
