### PR TITLE
fix(ext-auth): avoid double-forward on fail-open call dispatch errors

### DIFF
--- a/plugins/wasm-go/extensions/ext-auth/main.go
+++ b/plugins/wasm-go/extensions/ext-auth/main.go
@@ -45,6 +45,12 @@ const (
 	HeaderFailureModeAllow = "x-envoy-auth-failure-mode-allowed"
 )
 
+var (
+	replaceHttpRequestHeader = proxywasm.ReplaceHttpRequestHeader
+	resumeHttpRequest        = proxywasm.ResumeHttpRequest
+	sendResponse             = util.SendResponse
+)
+
 // Currently, x-forwarded-xxx headers only apply for forward_auth.
 const (
 	HeaderOriginalMethod   = "x-original-method"
@@ -123,7 +129,8 @@ func checkExtAuth(ctx wrapper.HttpContext, cfg config.ExtAuthConfig, body []byte
 		func(statusCode int, responseHeaders http.Header, responseBody []byte) {
 			if statusCode != http.StatusOK {
 				log.Errorf("failed to call ext auth server, status: %d", statusCode)
-				callExtAuthServerErrorHandler(cfg, statusCode, responseHeaders, responseBody)
+				// The callback only runs after the request has been paused for the external auth response.
+				callExtAuthServerErrorHandler(cfg, statusCode, responseHeaders, responseBody, true)
 				return
 			}
 
@@ -141,7 +148,8 @@ func checkExtAuth(ctx wrapper.HttpContext, cfg config.ExtAuthConfig, body []byte
 	if err != nil {
 		log.Errorf("failed to call ext auth server: %v", err)
 		// Since the handling logic for call errors and HTTP status code 500 is the same, we directly use 500 here.
-		callExtAuthServerErrorHandler(cfg, http.StatusInternalServerError, nil, nil)
+		// Dispatch errors return ActionContinue below, so there is no paused request to resume.
+		callExtAuthServerErrorHandler(cfg, http.StatusInternalServerError, nil, nil, false)
 		return types.ActionContinue
 	}
 	return pauseAction
@@ -196,12 +204,14 @@ func buildExtAuthRequestHeaders(ctx wrapper.HttpContext, cfg config.ExtAuthConfi
 	return extAuthReqHeaders
 }
 
-func callExtAuthServerErrorHandler(config config.ExtAuthConfig, statusCode int, extAuthRespHeaders http.Header, responseBody []byte) {
+func callExtAuthServerErrorHandler(config config.ExtAuthConfig, statusCode int, extAuthRespHeaders http.Header, responseBody []byte, requestPaused bool) {
 	if statusCode >= http.StatusInternalServerError && config.FailureModeAllow {
 		if config.FailureModeAllowHeaderAdd {
-			_ = proxywasm.ReplaceHttpRequestHeader(HeaderFailureModeAllow, "true")
+			_ = replaceHttpRequestHeader(HeaderFailureModeAllow, "true")
 		}
-		proxywasm.ResumeHttpRequest()
+		if requestPaused {
+			resumeHttpRequest()
+		}
 		return
 	}
 
@@ -221,5 +231,5 @@ func callExtAuthServerErrorHandler(config config.ExtAuthConfig, statusCode int, 
 	if statusCode >= http.StatusInternalServerError {
 		statusToUse = int(config.StatusOnError)
 	}
-	_ = util.SendResponse(uint32(statusToUse), "ext-auth.unauthorized", respHeaders, responseBody)
+	_ = sendResponse(uint32(statusToUse), "ext-auth.unauthorized", respHeaders, responseBody)
 }

--- a/plugins/wasm-go/extensions/ext-auth/main_test.go
+++ b/plugins/wasm-go/extensions/ext-auth/main_test.go
@@ -16,8 +16,11 @@ package main
 
 import (
 	"encoding/json"
+	"net/http"
 	"strings"
 	"testing"
+
+	"ext-auth/config"
 
 	"github.com/higress-group/proxy-wasm-go-sdk/proxywasm/types"
 	"github.com/higress-group/wasm-go/pkg/test"
@@ -159,6 +162,25 @@ var failureModeConfig = func() json.RawMessage {
 	return data
 }()
 
+var failureModeDispatchErrorConfig = func() json.RawMessage {
+	data, _ := json.Marshal(map[string]interface{}{
+		"http_service": map[string]interface{}{
+			"endpoint_mode": "forward_auth",
+			"endpoint": map[string]interface{}{
+				"service_name":   "ext-auth.backend.svc.cluster.local",
+				"service_port":   8090,
+				"path":           "%zz",
+				"request_method": "POST",
+			},
+			"timeout": 1000,
+		},
+		"failure_mode_allow":            true,
+		"failure_mode_allow_header_add": true,
+		"status_on_error":               500,
+	})
+	return data
+}()
+
 // 测试配置：带 allowed_properties 的配置
 var allowedPropertiesConfig = func() json.RawMessage {
 	data, _ := json.Marshal(map[string]interface{}{
@@ -260,6 +282,87 @@ func TestParseConfig(t *testing.T) {
 			require.NotNil(t, config)
 		})
 	})
+}
+
+func TestCallExtAuthServerErrorHandlerFailOpenResumesOnlyPausedRequests(t *testing.T) {
+	originalReplaceHeader := replaceHttpRequestHeader
+	originalResume := resumeHttpRequest
+	originalSendResponse := sendResponse
+	defer func() {
+		replaceHttpRequestHeader = originalReplaceHeader
+		resumeHttpRequest = originalResume
+		sendResponse = originalSendResponse
+	}()
+
+	resumeCount := 0
+	replacedHeaders := map[string]string{}
+	sendResponseCalled := false
+
+	replaceHttpRequestHeader = func(name, value string) error {
+		replacedHeaders[name] = value
+		return nil
+	}
+	resumeHttpRequest = func() error {
+		resumeCount++
+		return nil
+	}
+	sendResponse = func(statusCode uint32, statusCodeDetailData string, headers http.Header, body []byte) error {
+		sendResponseCalled = true
+		return nil
+	}
+
+	cfg := config.ExtAuthConfig{
+		FailureModeAllow:          true,
+		FailureModeAllowHeaderAdd: true,
+	}
+
+	callExtAuthServerErrorHandler(cfg, http.StatusInternalServerError, nil, nil, false)
+	require.Equal(t, 0, resumeCount, "synchronous call failures return ActionContinue and must not resume an unpaused request")
+	require.Equal(t, "true", replacedHeaders[HeaderFailureModeAllow])
+	require.False(t, sendResponseCalled)
+
+	callExtAuthServerErrorHandler(cfg, http.StatusInternalServerError, nil, nil, true)
+	require.Equal(t, 1, resumeCount, "asynchronous fail-open callbacks must still resume the paused request")
+	require.False(t, sendResponseCalled)
+}
+
+func TestCallExtAuthServerErrorHandlerFailClosedSendsLocalResponse(t *testing.T) {
+	originalReplaceHeader := replaceHttpRequestHeader
+	originalResume := resumeHttpRequest
+	originalSendResponse := sendResponse
+	defer func() {
+		replaceHttpRequestHeader = originalReplaceHeader
+		resumeHttpRequest = originalResume
+		sendResponse = originalSendResponse
+	}()
+
+	resumeCount := 0
+	var gotStatusCode uint32
+	var gotDetail string
+
+	replaceHttpRequestHeader = func(name, value string) error {
+		t.Fatalf("fail-closed path must not replace request header %s=%s", name, value)
+		return nil
+	}
+	resumeHttpRequest = func() error {
+		resumeCount++
+		return nil
+	}
+	sendResponse = func(statusCode uint32, statusCodeDetailData string, headers http.Header, body []byte) error {
+		gotStatusCode = statusCode
+		gotDetail = statusCodeDetailData
+		return nil
+	}
+
+	cfg := config.ExtAuthConfig{
+		FailureModeAllow: false,
+		StatusOnError:    http.StatusServiceUnavailable,
+	}
+
+	callExtAuthServerErrorHandler(cfg, http.StatusInternalServerError, nil, []byte("unavailable"), false)
+	require.Equal(t, 0, resumeCount)
+	require.Equal(t, uint32(http.StatusServiceUnavailable), gotStatusCode)
+	require.Equal(t, "ext-auth.unauthorized", gotDetail)
 }
 
 func TestOnHttpRequestHeaders(t *testing.T) {
@@ -503,6 +606,30 @@ func TestOnHttpRequestHeaders(t *testing.T) {
 
 			// 验证请求是否被恢复（失败模式允许的情况下）
 			require.Equal(t, types.ActionContinue, host.GetHttpStreamAction())
+
+			host.CompleteHttp()
+		})
+
+		t.Run("failure mode allow on dispatch error", func(t *testing.T) {
+			host, status := test.NewTestHost(failureModeDispatchErrorConfig)
+			defer host.Reset()
+			require.Equal(t, types.OnPluginStartStatusOK, status)
+
+			action := host.CallOnHttpRequestHeaders([][2]string{
+				{":authority", "example.com"},
+				{":path", "/users"},
+				{":method", "POST"},
+				{"authorization", "Bearer token123"},
+			})
+
+			require.Equal(t, types.ActionContinue, action)
+			require.Empty(t, host.GetHttpCalloutAttributes(), "invalid ext-auth URL should fail before dispatching a callout")
+
+			requestHeaders := map[string]string{}
+			for _, h := range host.GetRequestHeaders() {
+				requestHeaders[strings.ToLower(h[0])] = h[1]
+			}
+			require.Equal(t, "true", requestHeaders[HeaderFailureModeAllow])
 
 			host.CompleteHttp()
 		})


### PR DESCRIPTION
## I. Summary

Fix ext-auth fail-open handling when the outbound authorization call fails before the request is paused.

Previously, the synchronous `Client.Call` error path reused the same failure handler as asynchronous callout responses. With `failure_mode_allow` enabled, that handler always called `ResumeHttpRequest()`. For synchronous call dispatch errors, the plugin returns `ActionContinue` and the request was never paused, so resuming it can double-forward the request.

This change tracks whether the request has actually been paused before resuming it. Asynchronous fail-open callout responses still resume paused requests. Synchronous call dispatch failures only add the configured failure-mode header and continue.

No configuration or compatibility migration is required.

## II. Related issue

Fixes #4622

## III. Change type

- [x] Bug fix
- [ ] Feature or enhancement
- [ ] Documentation or configuration only
- [x] Refactoring, tests, or maintenance

## IV. Agent participation and issue-spec gate

- [ ] **No agent participation:** This PR is human-only.
- [ ] **Trivial agent-use exception:** Agent use was limited to spelling,
      punctuation, whitespace, or formatting with no substantive choice or
      behavioral effect; the explanation is below.
- [ ] **Verified maintainer/administrator exception:** Material agent
      participation occurred, and authenticated `gh` verification confirmed
      a `role_name` of `maintain` or `admin` on `higress-group/higress`, and the
      verified login matches this PR's GitHub author; record the required
      evidence and rationale below.
- [x] **Material agent participation:** An AI or coding agent materially
      participated in analysis, design, implementation, testing, or PR
      preparation.

For material participation that does not use the verified maintainer/administrator
exception, check each timed obligation:

- [ ] **Before implementation began:** A Higress maintainer had approved the
      Proposal and Design Issues, and authorized implementation TASKs linked the
      work to the applicable SPECs.
- [ ] **Before verification began:** The Design contained a concrete
      Verification Plan.
- [ ] **Before requesting maintainer review or acceptance:** Applicable
      implementation and verification TASKs were `done` with exact commands,
      results, evidence links, and hashes.

Then choose exactly one overall gate status:

- [ ] Complete: all three timed obligations above were satisfied.
- [x] Noncompliant: one or more obligations were not satisfied; explain below.
- [ ] Verified exception: material agent participation used the
      verified-maintainer/administrator exception; provide the required evidence
      and rationale below.
- [ ] N/A because the PR is human-only or qualifies for the trivial exception.

**Gate-status explanation (or N/A):**

Material agent participation occurred before approved Proposal/Design/TASK issue-spec artifacts were available. No retroactive approval is claimed.

**Trivial-exception explanation (or N/A):**

N/A.

**Verified maintainer/administrator exception evidence (or N/A):**

N/A.

**Approved Proposal Issue URL (or N/A with explanation):**

N/A. No approved Proposal Issue was available before implementation.

**Approved Design Issue URL (or N/A with explanation):**

N/A. No approved Design Issue was available before implementation.

**Maintainer approval link(s) (or N/A with explanation):**

N/A. No maintainer approval link is available for the issue-spec gate.

**Authorized implementation TASK link(s) (or N/A with explanation):**

N/A. No authorized implementation TASK was available before implementation.

**Verification Plan and verification TASK/evidence link(s) (or N/A with explanation):**

N/A. Verification was performed locally with Go tests, but no approved issue-spec Verification Plan or verification TASK is available.

## V. Testing and verification

**Test and deterministic rerun commands (or N/A with explanation):**

```text
cd plugins/wasm-go/extensions/ext-auth
GOTOOLCHAIN=auto GOPROXY=https://goproxy.cn,direct GOSUMDB=sum.golang.org go test -count=1 -run 'TestCallExtAuthServerErrorHandler|TestOnHttpRequestHeaders/failure_mode_allow' ./...
GOTOOLCHAIN=auto GOPROXY=https://goproxy.cn,direct GOSUMDB=sum.golang.org go test -count=1 ./...

cd ../../../../
git diff --check