### PR TITLE
feat(release): migration preflight at prepare + label-authorized promote (Proposal #4634 S3+S4)

### DIFF
--- a/.github/workflows/prepare-plugin-release.yaml
+++ b/.github/workflows/prepare-plugin-release.yaml
@@ -115,7 +115,12 @@ jobs:
   prepare:
     needs: preflight
     runs-on: ubuntu-latest
-    environment: plugin-release-candidate
+    # No environment gate: candidate builds publish only into the
+    # content-addressed candidates/ namespace, which nothing public resolves.
+    # The human gate for a release is the preparation PR review plus the
+    # latest-move environment approval in promote. Consequently the candidate
+    # registry credentials and the release App secrets this job reads must be
+    # repository- or organization-scoped, not environment-scoped.
     steps:
       - uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
         if: ${{ !inputs.dry_run }}
@@ -338,6 +343,50 @@ jobs:
             jq --arg id "$id" --arg ref "${candidate%@*}@$digest" --arg digest "$digest" --arg commit "$source_commit" --arg hash "$input_hash" '.plugins[$id]={candidateRef:$ref,digest:$digest,sourceCommit:$commit,inputHash:$hash}' /tmp/candidates.json >/tmp/candidates.next && mv /tmp/candidates.next /tmp/candidates.json
           done
           cp /tmp/candidates.json "plugins/release/evidence/$GATEWAY_VERSION.json"
+      - name: Sweep public registry for planned tag conflicts
+        env:
+          GATEWAY_VERSION: ${{ inputs.gateway_version }}
+          PREVIOUS: ${{ inputs.previous_snapshot }}
+        run: |
+          set -euo pipefail
+          # BEGIN migration-preflight-contract
+          # Onboarding migration preflight: classify every planned public
+          # version tag before the preparation PR is opened, so a legacy
+          # pre-pipeline artifact surfaces here as a reviewed exclusion instead
+          # of hard-failing the promote batch with an immutable tag conflict.
+          # The tool calibrates its probe against a known-good control tag from
+          # the reviewed previous snapshot and fails closed when the control
+          # does not reproduce its recorded digest, when authorization fails, or
+          # when a lookup cannot be classified as explicit absence.
+          args=(migration-preflight --root ../.. --catalog ../../plugins/release/catalog.json --plan /tmp/plan.json --output /tmp/migration-report.json --markdown /tmp/migration-report.md)
+          if [ -n "$PREVIOUS" ]; then args+=(--previous "../../$PREVIOUS"); else args+=(--previous /tmp/bootstrap-snapshot.json); fi
+          # A dry run builds no candidates, so it has no planned digest to
+          # compare: it reports occupied planned tags without excluding them.
+          if [ -f /tmp/candidates.json ]; then args+=(--candidate-evidence /tmp/candidates.json); fi
+          (cd tools/plugin-release && go run . "${args[@]}")
+          # END migration-preflight-contract
+          blocked=$(jq -er '[.entries[] | select(.state == "blocked")] | length' /tmp/migration-report.json)
+          suspected=$(jq -er '[.entries[] | select(.state == "suspected")] | length' /tmp/migration-report.json)
+          probe_mode=$(jq -er .probeMode /tmp/migration-report.json)
+          if [ "$blocked" -gt 0 ]; then
+            {
+              echo "Migration preflight excluded $blocked planned plugin(s) from the promote batch:"
+              echo
+              jq -er '[.entries[] | select(.state == "blocked") | {logicalId, ociRef, existingDigest, plannedDigest, recommendation}]' /tmp/migration-report.json
+            } >> "$GITHUB_STEP_SUMMARY"
+          elif [ "$suspected" -gt 0 ]; then
+            echo "Dry-run migration preflight ($probe_mode): $suspected planned tag(s) already exist publicly and are classified by the non-dry-run sweep." >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "Migration preflight ($probe_mode): no planned version tag is occupied by a different artifact." >> "$GITHUB_STEP_SUMMARY"
+          fi
+      - name: Upload migration preflight report
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: plugin-release-migration-report-${{ inputs.gateway_version }}
+          if-no-files-found: error
+          path: |
+            /tmp/migration-report.json
+            /tmp/migration-report.md
       - name: Render canonical snapshot
         if: ${{ !inputs.dry_run }}
         env:
@@ -346,7 +395,7 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p plugins/release/snapshots
-          args=(render-snapshot --catalog ../../plugins/release/catalog.json --plan /tmp/plan.json --candidate-evidence /tmp/candidates.json --output "../../plugins/release/snapshots/$GATEWAY_VERSION.json")
+          args=(render-snapshot --catalog ../../plugins/release/catalog.json --plan /tmp/plan.json --candidate-evidence /tmp/candidates.json --migration-report /tmp/migration-report.json --output "../../plugins/release/snapshots/$GATEWAY_VERSION.json")
           if [ -n "$PREVIOUS" ]; then args+=(--previous "../../$PREVIOUS"); else args+=(--previous /tmp/bootstrap-snapshot.json --bootstrap-evidence /tmp/bootstrap-evidence.json); fi
           (cd tools/plugin-release && go run . "${args[@]}")
           sha256sum "plugins/release/snapshots/$GATEWAY_VERSION.json" | tee -a "$GITHUB_STEP_SUMMARY"
@@ -378,4 +427,24 @@ jobs:
           git add plugins/wasm-go/extensions plugins/wasm-rust/extensions plugins/release/snapshots plugins/release/plans plugins/release/evidence plugins/release/bootstrap-evidence
           git commit -s -m "chore: prepare plugin snapshot $GATEWAY_VERSION" || true
           git push --force-with-lease origin "$branch"
-          gh pr create --base main --head "$branch" --title "chore: prepare plugin snapshot $GATEWAY_VERSION" --body "Immutable candidate snapshot; review VERSION edits and digest provenance." || gh pr edit "$branch" --title "chore: prepare plugin snapshot $GATEWAY_VERSION" --body "Immutable candidate snapshot; review VERSION edits and digest provenance."
+          # BEGIN preparation-pr-contract
+          title="chore: prepare plugin snapshot $GATEWAY_VERSION"
+          body="Immutable candidate snapshot; review VERSION edits and digest provenance."
+          # The merged, labeled preparation PR is the human approval that
+          # authorizes promote, so the report a reviewer must act on belongs in
+          # that PR body. An all-green sweep leaves the body byte-identical.
+          if [ "$(jq -er '[.entries[] | select(.state == "blocked")] | length' /tmp/migration-report.json)" -gt 0 ]; then
+            body="$body"$'\n\n'"$(cat /tmp/migration-report.md)"
+          fi
+          label="release/$GATEWAY_VERSION"
+          # promote verifies this exact label on the merged PR and fails closed
+          # without it, so the label must exist before the PR is opened. Label
+          # management requires the release App installation to hold label write
+          # permission alongside its contents/pull-requests permissions.
+          label_ref=$(jq -rn --arg label "$label" '$label | @uri')
+          if ! gh api "repos/$GITHUB_REPOSITORY/labels/$label_ref" >/dev/null 2>&1; then
+            gh label create "$label" --color "0969da" --description "Authorizes promote-plugin-release for plugin snapshot $GATEWAY_VERSION"
+          fi
+          test "$(gh api "repos/$GITHUB_REPOSITORY/labels/$label_ref" --jq .name)" = "$label"
+          gh pr create --base main --head "$branch" --title "$title" --body "$body" --label "$label" || gh pr edit "$branch" --title "$title" --body "$body" --add-label "$label"
+          # END preparation-pr-contract

--- a/.github/workflows/promote-plugin-release.yaml
+++ b/.github/workflows/promote-plugin-release.yaml
@@ -28,6 +28,9 @@ on:
 
 permissions:
   contents: read
+  # Read-only: verify-and-promote resolves the merged preparation PR that
+  # authorizes it. No write permission is granted to any job in this workflow.
+  pull-requests: read
 
 concurrency:
   group: promote-plugin-release
@@ -36,12 +39,144 @@ concurrency:
 jobs:
   verify-and-promote:
     runs-on: ubuntu-latest
-    environment: plugin-release-production
+    # No environment gate: the human approval for this phase is the merged
+    # preparation PR labeled release/<gateway_version>, verified by the first
+    # step below. The independent environment gate remains on the latest job,
+    # which has the largest blast radius. Consequently the production registry
+    # credentials this job reads must be repository- or organization-scoped, not
+    # environment-scoped.
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           ref: ${{ inputs.source_commit }}
           fetch-depth: 0
+      - name: Verify a merged labeled preparation PR authorizes promotion
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SOURCE_COMMIT: ${{ inputs.source_commit }}
+          SNAPSHOT_PATH: ${{ inputs.snapshot_path }}
+          RELEASE_PR_APP_LOGIN: ${{ vars.RELEASE_PR_APP_LOGIN }}
+        run: |
+          set -euo pipefail
+          # BEGIN promotion-authorization-contract
+          [[ "$SOURCE_COMMIT" =~ ^[0-9a-f]{40}$ ]]
+          [[ "$SNAPSHOT_PATH" =~ ^plugins/release/snapshots/([0-9]+\.[0-9]+\.[0-9]+)\.json$ ]]
+          gateway_version="${BASH_REMATCH[1]}"
+          test "$(git rev-parse HEAD)" = "$SOURCE_COMMIT"
+          test "$(jq -er .gatewayVersion "$SNAPSHOT_PATH")" = "$gateway_version"
+          # snapshot.sourceCommit is the exact main/code-freeze commit the
+          # preparation PR was generated from, so the merged commit promote was
+          # given must descend from it.
+          freeze_commit=$(jq -er .sourceCommit "$SNAPSHOT_PATH")
+          [[ "$freeze_commit" =~ ^[0-9a-f]{40}$ ]]
+          if ! git merge-base --is-ancestor "$freeze_commit" "$SOURCE_COMMIT"; then
+            echo "promotion is not authorized: $SOURCE_COMMIT does not descend from the code-freeze commit $freeze_commit this snapshot was computed at" >&2
+            exit 1
+          fi
+          git fetch --no-tags origin main
+          if ! git merge-base --is-ancestor "$SOURCE_COMMIT" refs/remotes/origin/main; then
+            echo "promotion is not authorized: $SOURCE_COMMIT is not reachable from main, so no preparation PR was merged at it" >&2
+            exit 1
+          fi
+          # The automation App login is configuration, never a guess: without it
+          # this step cannot tell an App-authored preparation PR from a
+          # collaborator's look-alike, so it refuses to promote.
+          if [ -z "${RELEASE_PR_APP_LOGIN:-}" ]; then
+            echo "promotion is not authorized: vars.RELEASE_PR_APP_LOGIN is not configured; set that repository variable to the login of the GitHub App that opens preparation PRs, as documented in docs/developers/immutable-plugin-releases.md" >&2
+            exit 1
+          fi
+          label="release/$gateway_version"
+          branch="release/plugin-snapshot-$gateway_version"
+          title="chore: prepare plugin snapshot $gateway_version"
+          # Branch names, titles, and labels are mutable metadata that any
+          # collaborator with write access can set, so they only narrow the
+          # search. Authorization rests on what cannot be rewritten after the
+          # merge: the PR must be the automation App's, opened from the canonical
+          # repository with maintainer edits disabled, merged exactly at
+          # source_commit, and approved by a human other than its author before
+          # that merge. Branch protection here does not dismiss stale approvals,
+          # so the review check below is the human review gate.
+          pulls=$(gh api --paginate "repos/$GITHUB_REPOSITORY/commits/$SOURCE_COMMIT/pulls")
+          candidates=$(jq -c --arg commit "$SOURCE_COMMIT" '
+            [ .[] | select(.state == "closed" and .merged_at != null and .base.ref == "main" and .merge_commit_sha == $commit) ]
+          ' <<<"$pulls")
+          candidate_count=$(jq -r 'length' <<<"$candidates")
+          if [ "$candidate_count" != 1 ]; then
+            echo "promotion is not authorized: expected exactly one PR merged into main at $SOURCE_COMMIT, found $candidate_count; review and merge the preparation PR for $gateway_version, then re-run promote" >&2
+            exit 1
+          fi
+          # Booleans are read without jq's alternative operator and without -e:
+          # `false // true` collapses to true in jq, and -e exits non-zero on a
+          # legitimate false, which would abort this step on a valid PR.
+          pr_number=$(jq -r '.[0].number // ""' <<<"$candidates")
+          pr_author=$(jq -r '.[0].user.login // ""' <<<"$candidates")
+          pr_author_type=$(jq -r '.[0].user.type // ""' <<<"$candidates")
+          merged_at=$(jq -r '.[0].merged_at // ""' <<<"$candidates")
+          head_repository=$(jq -r '.[0].head.repo.full_name // ""' <<<"$candidates")
+          head_fork=$(jq -r '.[0].head.repo.fork' <<<"$candidates")
+          head_sha=$(jq -r '.[0].head.sha // ""' <<<"$candidates")
+          maintainer_can_modify=$(jq -r '.[0].maintainer_can_modify' <<<"$candidates")
+          head_ref=$(jq -r '.[0].head.ref // ""' <<<"$candidates")
+          pr_title=$(jq -r '.[0].title // ""' <<<"$candidates")
+          if ! [[ "$pr_number" =~ ^[0-9]+$ ]]; then
+            echo "promotion is not authorized: the PR merged into main at $SOURCE_COMMIT reports no usable number" >&2
+            exit 1
+          fi
+          if ! [[ "$head_sha" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "promotion is not authorized: preparation PR #$pr_number reports no usable head commit" >&2
+            exit 1
+          fi
+          if [ "$pr_author" != "$RELEASE_PR_APP_LOGIN" ] || [ "$pr_author_type" != Bot ]; then
+            echo "promotion is not authorized: preparation PR #$pr_number was authored by ${pr_author:-<none>} (${pr_author_type:-<none>}), not the release automation App $RELEASE_PR_APP_LOGIN; a collaborator-opened look-alike PR cannot authorize promotion" >&2
+            exit 1
+          fi
+          if [ "$head_repository" != "$GITHUB_REPOSITORY" ] || [ "$head_fork" != false ]; then
+            echo "promotion is not authorized: preparation PR #$pr_number head repository ${head_repository:-<none>} (fork=$head_fork) is not the canonical $GITHUB_REPOSITORY" >&2
+            exit 1
+          fi
+          if [ "$maintainer_can_modify" != false ]; then
+            echo "promotion is not authorized: preparation PR #$pr_number still allows maintainer edits (maintainer_can_modify=$maintainer_can_modify), so its reviewed content is not final" >&2
+            exit 1
+          fi
+          if [ "$head_ref" != "$branch" ] || [ "$pr_title" != "$title" ]; then
+            echo "promotion is not authorized: preparation PR #$pr_number does not match the deterministic preparation branch $branch and title \"$title\"" >&2
+            exit 1
+          fi
+          if [ "$(jq --arg label "$label" '[.[0].labels[].name] | any(. == $label)' <<<"$candidates")" != true ]; then
+            echo "promotion is not authorized: preparation PR #$pr_number does not carry the label $label that authorizes this release" >&2
+            exit 1
+          fi
+          reviews=$(gh api --paginate "repos/$GITHUB_REPOSITORY/pulls/$pr_number/reviews")
+          mapfile -t approvals < <(jq -r --arg author "$pr_author" --arg merged "$merged_at" --arg head "$head_sha" '
+            [ .[]
+              | select(.state == "APPROVED" and .submitted_at != null and .submitted_at < $merged)
+              | select((.user.login // "") != $author and (.commit_id // "") == $head)
+              | .user.login
+            ] | unique[]
+          ' <<<"$reviews")
+          if [ "${#approvals[@]}" -lt 1 ] || [ -z "${approvals[0]}" ]; then
+            echo "promotion is not authorized: preparation PR #$pr_number has no review by someone other than its author $pr_author that approved head commit $head_sha before the merge at $merged_at; approvals are not dismissed when the branch moves, so re-approve the current preparation PR content and re-run promote" >&2
+            exit 1
+          fi
+          # The approving review must come from an authorized maintainer (maintain/admin
+          # permission), not merely any non-author write collaborator: a write
+          # collaborator could otherwise modify the App-owned branch and approve
+          # that head themselves while a stale CODEOWNER approval permits the merge.
+          authorized_approvers=0
+          for reviewer in "${approvals[@]}"; do
+            [ -n "$reviewer" ] || continue
+            reviewer_permission=$(gh api "repos/$GITHUB_REPOSITORY/collaborators/$reviewer/permission" 2>/dev/null | jq -r '.permission // "none"' || echo none)
+            case "$reviewer_permission" in
+              maintain|admin) authorized_approvers=$((authorized_approvers + 1)) ;;
+              *) echo "review by $reviewer (permission: $reviewer_permission) does not authorize promotion; require a maintainer approval of head $head_sha" >> "$GITHUB_STEP_SUMMARY" ;;
+            esac
+          done
+          if [ "$authorized_approvers" -lt 1 ]; then
+            echo "promotion is not authorized: preparation PR #$pr_number has no pre-merge APPROVED review of head commit $head_sha from a maintainer/admin (found only non-maintainer approvals); a write collaborator approving the App-owned branch is not sufficient" >&2
+            exit 1
+          fi
+          echo "Promotion of $gateway_version authorized by merged preparation PR #$pr_number (author $pr_author, label $label, head $head_sha, $approvals pre-merge approval(s)) at $SOURCE_COMMIT." >> "$GITHUB_STEP_SUMMARY"
+          # END promotion-authorization-contract
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: "1.24.0"
@@ -125,6 +260,7 @@ jobs:
             cat "$err" >&2; rm -f "$err"; return 2
           }
           # END promotion-descriptor-contract
+          # BEGIN promotion-version-contract
           marker="$REGISTRY/candidates/plugin-release-batches:$SNAPSHOT_SHA256"
           # A completion marker makes a retry read-only. Its layer is the
           # authoritative journal, and every mutable latest tag is rechecked
@@ -145,8 +281,24 @@ jobs:
             test "$status" = 1 || exit "$status"
           fi
           jq -n --arg sha "$SNAPSHOT_SHA256" '{snapshotSha256:$sha,phase:"version-preflight",entries:[]}' > "/tmp/plugin-release-version-$SNAPSHOT_SHA256.json"
+          # A prepare-time migration exclusion keeps its plugin out of this
+          # batch: the planned public tag is occupied by a different artifact,
+          # so probing it would report an immutable tag conflict that the
+          # reviewed preparation PR already resolved into an exclusion.
+          if [ "$(jq -er '[.plugins[] | select((.migration.state // "") != "blocked")] | length' "$SNAPSHOT_PATH")" -eq 0 ]; then
+            echo "every snapshot plugin is excluded by migration preflight; nothing to promote" >&2
+            exit 1
+          fi
+          excluded=$(jq -r '[.plugins[] | select((.migration.state // "") == "blocked") | .logicalId] | join(", ")' "$SNAPSHOT_PATH")
+          if [ -n "$excluded" ]; then
+            echo "Migration preflight excluded from this promote batch: $excluded" >> "$GITHUB_STEP_SUMMARY"
+          fi
           while read -r entry; do
             ref=$(jq -r .ociRef <<<"$entry"); digest=$(jq -r .digest <<<"$entry"); candidate=$(jq -r .candidateRef <<<"$entry"); provenance=$(jq -r '.provenanceMode // (if .candidateRef == "" then "public" else "candidate" end)' <<<"$entry")
+            if [ "$(jq -r '.migration.state // empty' <<<"$entry")" = blocked ]; then
+              jq --arg ref "$ref" --arg digest "$digest" --arg candidate "$candidate" --arg provenance "$provenance" --argjson migration "$(jq -c .migration <<<"$entry")" '.entries += [{ref:$ref,digest:$digest,candidateRef:$candidate,provenanceMode:$provenance,preflight:"migration-excluded",migration:$migration}]' "/tmp/plugin-release-version-$SNAPSHOT_SHA256.json" > /tmp/journal.next && mv /tmp/journal.next "/tmp/plugin-release-version-$SNAPSHOT_SHA256.json"
+              continue
+            fi
             if existing_json=$(descriptor_or_absent "$ref"); then
               existing=$(jq -r .digest <<<"$existing_json")
               test "$existing" = "$digest" || { echo "immutable tag conflict: $ref" >&2; exit 1; }
@@ -160,10 +312,13 @@ jobs:
             jq --arg ref "$ref" --arg digest "$digest" --arg candidate "$candidate" --arg provenance "$provenance" --arg state "$state" '.entries += [{ref:$ref,digest:$digest,candidateRef:$candidate,provenanceMode:$provenance,preflight:$state}]' "/tmp/plugin-release-version-$SNAPSHOT_SHA256.json" > /tmp/journal.next && mv /tmp/journal.next "/tmp/plugin-release-version-$SNAPSHOT_SHA256.json"
           done < <(jq -c '.plugins[]' "$SNAPSHOT_PATH")
           # Only preflight-approved absent tags are copied; every version tag
-          # is then re-resolved before this phase is considered complete.
+          # this batch publishes is then re-resolved before this phase is
+          # considered complete. Migration-excluded entries publish nothing, so
+          # their known-divergent public tag is not part of that set.
           jq -c '.entries[] | select(.preflight == "absent" and .provenanceMode == "candidate")' "/tmp/plugin-release-version-$SNAPSHOT_SHA256.json" | while read -r entry; do oras cp "$(jq -r .candidateRef <<<"$entry")" "$(jq -r .ref <<<"$entry")"; done
-          jq -c '.entries[]' "/tmp/plugin-release-version-$SNAPSHOT_SHA256.json" | while read -r entry; do test "$(oras manifest fetch "$(jq -r .ref <<<"$entry")" --descriptor | jq -r .digest)" = "$(jq -r .digest <<<"$entry")"; done
+          jq -c '.entries[] | select(.preflight != "migration-excluded")' "/tmp/plugin-release-version-$SNAPSHOT_SHA256.json" | while read -r entry; do test "$(oras manifest fetch "$(jq -r .ref <<<"$entry")" --descriptor | jq -r .digest)" = "$(jq -r .digest <<<"$entry")"; done
           jq '.phase="version-complete"' "/tmp/plugin-release-version-$SNAPSHOT_SHA256.json" > /tmp/journal.next && mv /tmp/journal.next "/tmp/plugin-release-version-$SNAPSHOT_SHA256.json"
+          # END promotion-version-contract
       - name: Persist complete version batch journal
         if: ${{ !inputs.dry_run }}
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
@@ -272,8 +427,20 @@ jobs:
             bootstrap_latest_migration=true
           fi
           jq -n --arg sha "$SNAPSHOT_SHA256" '{snapshotSha256:$sha,phase:"latest-preflight",entries:[]}' > "/tmp/plugin-release-latest-$SNAPSHOT_SHA256.json"
+          # A migration-excluded plugin never joins the latest preflight: this
+          # batch did not publish its version tag, so requiring that tag to
+          # resolve to the snapshot digest would fail on the very conflict the
+          # exclusion records. Its latest alias is left exactly as it is, and
+          # the exclusion is documented on the journal instead.
+          if [ "$(jq -er '[.plugins[] | select((.migration.state // "") != "blocked")] | length' "$SNAPSHOT_PATH")" -eq 0 ]; then
+            echo "every snapshot plugin is excluded by migration preflight; no latest alias can move" >&2
+            exit 1
+          fi
           while read -r entry; do
             id=$(jq -r .logicalId <<<"$entry"); ref=$(jq -r .ociRef <<<"$entry"); digest=$(jq -r .digest <<<"$entry")
+            if [ "$(jq -r '.migration.state // empty' <<<"$entry")" = blocked ]; then
+              continue
+            fi
             test "$(oras manifest fetch "$ref" --descriptor | jq -r .digest)" = "$digest"
             version=$(jq -r .version <<<"$entry")
             image=${ref%:*}; latest="$image:latest"
@@ -327,7 +494,7 @@ jobs:
           # re-resolved before the phase is considered complete.
           jq -c '.entries[] | select(.preflight != "identical")' "/tmp/plugin-release-latest-$SNAPSHOT_SHA256.json" | while read -r entry; do ref=$(jq -r .ref <<<"$entry"); oras cp "${ref%:*}@$(jq -r .digest <<<"$entry")" "$(jq -r .latest <<<"$entry")"; done
           jq -c '.entries[]' "/tmp/plugin-release-latest-$SNAPSHOT_SHA256.json" | while read -r entry; do test "$(oras manifest fetch "$(jq -r .latest <<<"$entry")" --descriptor | jq -r .digest)" = "$(jq -r .digest <<<"$entry")"; done
-          jq '.phase="latest-complete"' "/tmp/plugin-release-latest-$SNAPSHOT_SHA256.json" > /tmp/journal.next && mv /tmp/journal.next "/tmp/plugin-release-latest-$SNAPSHOT_SHA256.json"
+          jq --argjson excluded "$(jq -c '[.plugins[] | select((.migration.state // "") == "blocked") | {logicalId, ociRef, version, existingDigest: .migration.existingDigest, recommendation: .migration.recommendation}]' "$SNAPSHOT_PATH")" '.phase="latest-complete" | .migrationExcluded = $excluded' "/tmp/plugin-release-latest-$SNAPSHOT_SHA256.json" > /tmp/journal.next && mv /tmp/journal.next "/tmp/plugin-release-latest-$SNAPSHOT_SHA256.json"
           # END promotion-latest-contract
           # The registry marker is the cross-workflow completion gate. Its
           # immutable content is the fully reverified version/latest batch.

--- a/docs/developers/immutable-plugin-releases.md
+++ b/docs/developers/immutable-plugin-releases.md
@@ -15,16 +15,25 @@ controls exist.
 - Make every public plugin tag other than `latest` immutable in the registry.
   Retain candidate artifacts only in a separate content-addressed namespace
   with an expiry policy.
-- Give the protected `plugin-release-production` environment the sole
-  credential able to write `plugins/<plugin>:<VERSION>` and `:latest`; remove
-  equivalent public-write access from legacy Wasm workflows and users.
+- Scope the credential able to write `plugins/<plugin>:<VERSION>` and `:latest`
+  as narrowly as GitHub still allows, and remove equivalent public-write access
+  from legacy Wasm workflows and users. Since SPEC-4634005 only the latest-move
+  job keeps the protected `plugin-release-production` environment, so the
+  version-tag phase reads that credential without an environment gate: it must
+  be a repository-scoped secret, which means every workflow in this repository
+  can read it. Review that exposure before each release, keep the credential
+  limited to the plugin namespaces, and never reference it from a
+  pull-request-triggered workflow.
 - Give the protected `plugin-server-production` environment the sole
   credential able to write `higress/plugin-server:<gateway-version>`. The
   plugin-server repository publisher may write only its development/candidate
   namespace.
 - Configure `PLUGIN_CANDIDATE_REGISTRY` and
-  `CANDIDATE_REGISTRY_USERNAME` / `CANDIDATE_REGISTRY_PASSWORD` on the
-  protected `plugin-release-candidate` environment. Bootstrap capture reuses
+  `CANDIDATE_REGISTRY_USERNAME` / `CANDIDATE_REGISTRY_PASSWORD` as
+  repository-scoped secrets/variables. The preparation job no longer uses the
+  `plugin-release-candidate` environment: candidate builds publish only into the
+  content-addressed `candidates/` namespace, which nothing public resolves, so
+  that phase requests no approval. Bootstrap capture reuses
   this existing ACR login, but its command path only resolves public manifests
   and never pushes, retags, or deletes. The uncredentialed ORAS preflight stays
   read-only and outside any protected environment. If that preflight receives
@@ -36,6 +45,11 @@ controls exist.
 - Create a scoped GitHub App for each downstream repository dispatch/PR
   receiver. It may update the deterministic dependency PR but may not merge,
   tag, or release.
+- Grant the release preparation App label write permission in addition to its
+  contents and pull-request permissions. It applies `release/<gateway-version>`
+  to the preparation PR it opens, and promote refuses to run without that label
+  on the merged PR; a missing label permission fails the preparation run rather
+  than publishing an unauthorized PR.
 - Protect `higress-release-manager` with human approval and a tag ruleset that
   permits only its release-manager App to create `vMAJOR.MINOR.PATCH` tags.
 - Record negative checks for every retained credential: a conflicting public
@@ -66,20 +80,36 @@ repository source alone.
    see "Bootstrap deferral and backfill" below.
 3. Build/test every plan entry through the protected candidate publisher. Each
    candidate is keyed by plan ID/input hash and reports its manifest digest,
-   source commit, and input hash. Render the snapshot only after every changed
+   source commit, and input hash. Before the snapshot is rendered, the workflow
+   sweeps the public registry for every planned version tag and compares each
+   occupied tag with the candidate digest just built; see "Onboarding migration
+   preflight" below. Render the snapshot only after every changed
    entry has matching evidence. A later source or `VERSION` edit invalidates
    that evidence.
 4. Review and merge the one preparation PR containing `VERSION` edits and
    `plugins/release/snapshots/<gateway-version>.json`. The snapshot carries all
    release-eligible plugins, including unchanged entries carried forward by
-   digest. It is the only downstream input.
+   digest. It is the only downstream input. Merging it is one of the two human
+   gates in a routine release: the preparation App labels the PR
+   `release/<gateway-version>`, and that label on the merged PR is what
+   authorizes the version-tag phase of promotion. A PR whose migration report
+   excludes plugins is still mergeable; the excluded plugins are simply not
+   published by this release.
 5. Run `promote-plugin-release` for that exact merged commit and snapshot
    hash, first with `dry_run=true`; the dry run resolves the exact committed
    plan, previous snapshot, and every candidate manifest without logging in or
-   mutating registry state. A production publisher may create a missing public version tag or
+   mutating registry state. The version-tag phase requests no environment
+   approval: it fails closed unless `source_commit` descends from the
+   code-freeze commit the snapshot records, is reachable from `main`, and
+   belongs to exactly one merged preparation PR from
+   `release/plugin-snapshot-<gateway-version>` carrying the
+   `release/<gateway-version>` label. A production publisher may create a missing public version tag or
    accept an identical existing digest only. It must fail before mutation on a
-   conflicting digest. Advance `latest` only after the full batch verifies and
-   only when its stable SemVer cannot move backwards. An existing `latest`
+   conflicting digest, and it skips every entry the migration preflight
+   excluded. Advance `latest` only after the full batch verifies and
+   only when its stable SemVer cannot move backwards; this move is the second
+   human gate and still waits for the protected `plugin-release-production`
+   environment approval. An existing `latest`
    already serving the desired digest is accepted before reading legacy
    version annotations and is never rewritten.
 6. Build `higress/plugin-server:<gateway-version>` from the exact approved
@@ -102,6 +132,65 @@ repository source alone.
    authorization. After the Higress release, dispatch Standalone with
    immutable release/chart/image identities. It derives a deterministic PR key
    and must not read a newer branch head.
+
+## Onboarding migration preflight
+
+A plugin that the pipeline starts managing can already have a manually published
+artifact at the exact version tag its plan selects. Promotion then hit an
+immutable tag conflict and a maintainer had to delete that tag in the registry by
+hand, one plugin at a time (three times during 2.2.5). Prepare now classifies
+every planned tag before the preparation PR is opened.
+
+- The sweep resolves each planned `plugins/<plugin>:<VERSION>` reference
+  read-only through the same registry path the rest of the pipeline uses. It
+  calibrates first: a known-good control tag from the reviewed previous snapshot
+  must resolve to exactly its recorded digest. If it does not, no classification
+  from that sweep is trusted and the run fails. An authorization failure, or any
+  lookup that is not explicit registry absence evidence, also fails the run and
+  is never treated as an absent tag.
+- A planned tag that is absent, or that already serves exactly the candidate
+  digest, is clear. With no conflicts the release is byte-identical to the
+  pre-preflight behaviour: no snapshot marker, no PR body section.
+- A tag occupied by a different digest puts that one plugin in migration mode.
+  The snapshot records `migration.state=blocked` on its entry together with the
+  existing digest, the planned digest, the occupant's annotations, a source
+  comparison, and exactly one recommended disposition:
+  - `delete-legacy` — the occupant carries no pipeline annotation at all, so it
+    is presumed a pre-pipeline manual artifact. This is a presumption, not
+    proof of origin: the disposition is conditional on a human confirming the
+    occupant's provenance (e.g. matching build history or maintainer records)
+    before a registry administrator deletes that tag. After deletion, a later
+    release plans and promotes the plugin normally.
+  - `bump-version` — a different managed build already occupies this exact
+    version. Re-run prepare with `version_overrides` for that plugin set to a
+    reviewed stable version greater than the occupied one.
+  - `adopt-public` — the occupant was built from the same source commit and the
+    same input hash as this plan, so the published tag already serves these
+    inputs and may be left alone. Until the published layouts are unified
+    (proposal #4634 S1/S2), this is how a tag previously patched by
+    `emergency-overwrite-plugin-tag` presents itself: same inputs, different
+    bytes, because that channel publishes the 2-layer variant.
+  Deleting a tag is only ever recommended for an unannotated occupant. An
+  artifact the pipeline cannot classify is never deleted automatically; the
+  disposition is re-derived from the recorded annotations during snapshot
+  rendering and again during verification, so a hand-edited recommendation does
+  not survive validation.
+- The exclusion is per plugin. Every other planned plugin promotes normally, the
+  excluded entry keeps its candidate and snapshot record, and both promotion
+  journals document the exclusion: `preflight: migration-excluded` in the version
+  batch and `migrationExcluded` in the latest batch. The excluded plugin's
+  version tag and `latest` alias are left exactly as they are. A batch in which
+  every plugin is excluded fails closed instead of publishing an empty marker.
+- The exclusion is durable. Later snapshots carry the marked entry forward
+  verbatim, so it stays out of every batch until a release re-plans that plugin
+  after its disposition completes. Verification tolerates the divergent public
+  tag the marker records and never resolves it; candidate resolution for the same
+  entry is unchanged.
+- The report is embedded in the preparation PR body and uploaded as the
+  `plugin-release-migration-report-<gateway-version>` artifact. A dry run builds
+  no candidates, so it lists occupied planned tags as suspected conflicts without
+  excluding anything; the non-dry-run sweep classifies them. A suspected report
+  can never be bound into a snapshot.
 
 ## Bootstrap deferral and backfill
 

--- a/tools/plugin-release/approval_chain_contract_test.go
+++ b/tools/plugin-release/approval_chain_contract_test.go
@@ -1,0 +1,710 @@
+// Copyright 2026 Higress Authors
+// Licensed under the Apache License, Version 2.0.
+
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// TestApprovalChainHasExactlyTwoHumanGates proves SPEC-4634005 in the checked-in
+// workflows: the candidate phase requests no environment approval, promote's
+// version phase is authorized by the merged labeled preparation PR instead of an
+// environment, and the latest move keeps the single independent production gate.
+func TestApprovalChainHasExactlyTwoHumanGates(t *testing.T) {
+	prepare := mustWorkflow(t, "prepare-plugin-release.yaml")
+	if strings.Contains(prepare, "plugin-release-candidate") {
+		t.Fatal("prepare still references the removed plugin-release-candidate environment")
+	}
+	prepareJob := workflowJobSection(t, prepare, "prepare")
+	if strings.Contains(prepareJob, "environment:") {
+		t.Fatal("the prepare job must not request an environment approval")
+	}
+
+	promote := mustWorkflow(t, "promote-plugin-release.yaml")
+	versionJob := workflowJobSection(t, promote, "verify-and-promote")
+	if strings.Contains(versionJob, "environment:") {
+		t.Fatal("promote's version phase must not request an environment approval; the merged labeled preparation PR authorizes it")
+	}
+	latestJob := workflowJobSection(t, promote, "latest")
+	if !strings.Contains(latestJob, "environment: plugin-release-production") {
+		t.Fatal("the latest move lost its independent plugin-release-production gate")
+	}
+	if strings.Count(promote, "environment: plugin-release-production") != 1 {
+		t.Fatal("promote must keep exactly one production environment gate, on the latest job")
+	}
+	if !strings.Contains(promote, "  pull-requests: read\n") {
+		t.Fatal("promote cannot resolve the authorizing preparation PR without read-only pull-requests permission")
+	}
+	for _, forbidden := range []string{"pull-requests: write", "contents: write", "issues: write"} {
+		if strings.Contains(promote, forbidden) {
+			t.Fatalf("promote grants more than read-only permission: %q", forbidden)
+		}
+	}
+
+	// The emergency channel is unchanged by this sub-item; its gate stays.
+	emergency := mustWorkflow(t, "emergency-overwrite-plugin-tag.yaml")
+	if !strings.Contains(emergency, "environment: plugin-release-production") {
+		t.Fatal("emergency overwrite lost its production gate")
+	}
+}
+
+const (
+	// releaseAppLogin is the automation identity the real preparation PRs carry;
+	// the workflow reads it from vars.RELEASE_PR_APP_LOGIN, never hard-codes it.
+	releaseAppLogin     = "higress-release-automation[bot]"
+	releasePRMaintainer = "maintainer-one"
+	releasePRNumber     = 4700
+)
+
+// prepPR describes the GitHub preparation-PR payload promote may authorize.
+// defaultPrepPR fills in the real automation's PR, so each case overrides
+// exactly the one property it exercises.
+type prepPR struct {
+	number              int
+	state               string
+	baseRef             string
+	headRef             string
+	headSHA             string
+	headRepo            string
+	headFork            bool
+	omitHeadRepo        bool
+	title               string
+	author              string
+	authorType          string
+	labels              []string
+	mergedAt            string
+	mergeCommit         string
+	maintainerCanModify bool
+}
+
+func defaultPrepPR(gateway, mergeCommit, headSHA string) prepPR {
+	return prepPR{
+		number:      releasePRNumber,
+		state:       "closed",
+		baseRef:     "main",
+		headRef:     "release/plugin-snapshot-" + gateway,
+		headSHA:     headSHA,
+		headRepo:    "higress-group/higress",
+		title:       "chore: prepare plugin snapshot " + gateway,
+		author:      releaseAppLogin,
+		authorType:  "Bot",
+		labels:      []string{"release/" + gateway},
+		mergedAt:    "2026-09-02T10:00:21Z",
+		mergeCommit: mergeCommit,
+	}
+}
+
+func (p prepPR) payload() map[string]any {
+	var mergedAt, mergeCommit any
+	if p.mergedAt != "" {
+		mergedAt = p.mergedAt
+	}
+	if p.mergeCommit != "" {
+		mergeCommit = p.mergeCommit
+	}
+	labels := make([]map[string]any, 0, len(p.labels))
+	for _, label := range p.labels {
+		labels = append(labels, map[string]any{"name": label})
+	}
+	head := map[string]any{"ref": p.headRef, "sha": p.headSHA}
+	if !p.omitHeadRepo {
+		head["repo"] = map[string]any{"full_name": p.headRepo, "fork": p.headFork}
+	}
+	return map[string]any{
+		"number":                p.number,
+		"state":                 p.state,
+		"merged_at":             mergedAt,
+		"merge_commit_sha":      mergeCommit,
+		"base":                  map[string]any{"ref": p.baseRef},
+		"head":                  head,
+		"title":                 p.title,
+		"user":                  map[string]any{"login": p.author, "type": p.authorType},
+		"labels":                labels,
+		"maintainer_can_modify": p.maintainerCanModify,
+	}
+}
+
+// prepReview describes one entry of the PR's review list.
+type prepReview struct {
+	user      string
+	userType  string
+	state     string
+	submitted string
+	commit    string
+}
+
+func (r prepReview) payload() map[string]any {
+	return map[string]any{
+		"user":         map[string]any{"login": r.user, "type": r.userType},
+		"state":        r.state,
+		"submitted_at": r.submitted,
+		"commit_id":    r.commit,
+	}
+}
+
+// approvedReviews is the review list of a properly reviewed preparation PR: one
+// human approval of the final head commit, submitted before the merge.
+func approvedReviews(headSHA string) []prepReview {
+	return []prepReview{{
+		user:      releasePRMaintainer,
+		userType:  "User",
+		state:     "APPROVED",
+		submitted: "2026-09-02T10:00:02Z",
+		commit:    headSHA,
+	}}
+}
+
+// TestPromotionAuthorizationRequiresTheReviewedAutomationPreparationPR executes
+// the workflow's authorization contract against a real Git repository whose
+// preparation branch was SQUASH-merged, and a stubbed GitHub API. Labels, titles
+// and branch names are mutable metadata any write-access collaborator can forge,
+// so authorization must additionally rest on the App author, the canonical
+// non-fork head, the merge commit, the frozen head content, and a human approval
+// of that content submitted before the merge.
+func TestPromotionAuthorizationRequiresTheReviewedAutomationPreparationPR(t *testing.T) {
+	const gateway = "2.2.6"
+	otherMerge := strings.Repeat("f", 40)
+	staleHead := strings.Repeat("1", 40)
+
+	for _, tc := range []struct {
+		name               string
+		mode               string
+		pr                 func(pr *prepPR)
+		pulls              func(payloads []map[string]any) []map[string]any
+		reviews            func(headSHA string) []prepReview
+		reviewerPermission string
+		noAppLogin         bool
+		apiFails           bool
+		want               string
+		wantError          bool
+	}{
+		{name: "squash-merged-reviewed-preparation-pr"},
+		{
+			// A collaborator with write access can create the branch, open a PR
+			// with the exact title, and add the release label. Only the author
+			// identity distinguishes this from the automation's PR.
+			name: "forged-label-by-collaborator",
+			pr:   func(pr *prepPR) { pr.author, pr.authorType = "write-collaborator", "User" },
+			want: "not the release automation App",
+		},
+		{
+			name: "other-app-author",
+			pr:   func(pr *prepPR) { pr.author = "some-other-automation[bot]" },
+			want: "not the release automation App",
+		},
+		{
+			name: "app-author-with-user-type",
+			pr:   func(pr *prepPR) { pr.authorType = "User" },
+			want: "not the release automation App",
+		},
+		{
+			name:    "approved-review-missing",
+			reviews: func(string) []prepReview { return nil },
+			want:    "has no review by someone other than its author",
+		},
+		{
+			name: "self-approval",
+			reviews: func(headSHA string) []prepReview {
+				reviews := approvedReviews(headSHA)
+				reviews[0].user = releaseAppLogin
+				reviews[0].userType = "Bot"
+				return reviews
+			},
+			want: "has no review by someone other than its author",
+		},
+		{
+			name: "comment-only-review",
+			reviews: func(headSHA string) []prepReview {
+				reviews := approvedReviews(headSHA)
+				reviews[0].state = "COMMENTED"
+				return reviews
+			},
+			want: "has no review by someone other than its author",
+		},
+		{
+			name: "changes-requested-review",
+			reviews: func(headSHA string) []prepReview {
+				reviews := approvedReviews(headSHA)
+				reviews[0].state = "CHANGES_REQUESTED"
+				return reviews
+			},
+			want: "has no review by someone other than its author",
+		},
+		{
+			name: "approval-after-merge",
+			reviews: func(headSHA string) []prepReview {
+				reviews := approvedReviews(headSHA)
+				reviews[0].submitted = "2026-09-02T10:05:00Z"
+				return reviews
+			},
+			want: "has no review by someone other than its author",
+		},
+		{
+			// The automation re-ran after the approval, so the approved content
+			// is not the content that was merged.
+			name: "approval-of-stale-head",
+			reviews: func(string) []prepReview {
+				reviews := approvedReviews(staleHead)
+				return reviews
+			},
+			want: "has no review by someone other than its author",
+		},
+		{
+			name: "fork-head",
+			pr:   func(pr *prepPR) { pr.headRepo, pr.headFork = "attacker/higress", true },
+			want: "is not the canonical higress-group/higress",
+		},
+		{
+			name: "head-repository-absent",
+			pr:   func(pr *prepPR) { pr.omitHeadRepo = true },
+			want: "is not the canonical higress-group/higress",
+		},
+		{
+			name: "maintainer-edits-allowed",
+			pr:   func(pr *prepPR) { pr.maintainerCanModify = true },
+			want: "still allows maintainer edits",
+		},
+		{
+			name: "merge-commit-differs",
+			pr:   func(pr *prepPR) { pr.mergeCommit = otherMerge },
+			want: "expected exactly one PR merged into main at",
+		},
+		{
+			name: "malformed-head-sha",
+			pr:   func(pr *prepPR) { pr.headSHA = "0f64f58" },
+			want: "reports no usable head commit",
+		},
+		{
+			name: "missing-label",
+			pr:   func(pr *prepPR) { pr.labels = nil },
+			want: "does not carry the label release/" + gateway,
+		},
+		{
+			name: "other-label",
+			pr:   func(pr *prepPR) { pr.labels = []string{"release/2.2.5"} },
+			want: "does not carry the label release/" + gateway,
+		},
+		{
+			name: "not-merged",
+			pr:   func(pr *prepPR) { pr.state, pr.mergedAt, pr.mergeCommit = "open", "", "" },
+			want: "expected exactly one PR merged into main at",
+		},
+		{
+			name: "other-branch",
+			pr:   func(pr *prepPR) { pr.headRef = "some-feature" },
+			want: "does not match the deterministic preparation branch",
+		},
+		{
+			name: "other-title",
+			pr:   func(pr *prepPR) { pr.title = "chore: prepare plugin snapshot 2.2.5" },
+			want: "does not match the deterministic preparation branch",
+		},
+		{
+			name: "other-release-preparation-pr",
+			pr: func(pr *prepPR) {
+				pr.headRef = "release/plugin-snapshot-2.2.5"
+				pr.title = "chore: prepare plugin snapshot 2.2.5"
+				pr.labels = []string{"release/2.2.5"}
+			},
+			want: "does not match the deterministic preparation branch",
+		},
+		{
+			name: "merged-into-another-branch",
+			pr:   func(pr *prepPR) { pr.baseRef = "release-2.2" },
+			want: "expected exactly one PR merged into main at",
+		},
+		{
+			name:  "no-associated-pr",
+			pulls: func([]map[string]any) []map[string]any { return []map[string]any{} },
+			want:  "expected exactly one PR merged into main at",
+		},
+		{
+			name:  "duplicate-match",
+			pulls: func(payloads []map[string]any) []map[string]any { return []map[string]any{payloads[0], payloads[0]} },
+			want:  "expected exactly one PR merged into main at",
+		},
+		{
+			// A write collaborator can approve the App-owned branch head
+			// themselves; only a maintainer/admin approval authorizes promotion.
+			name:               "write-collaborator-approval",
+			reviewerPermission: "write",
+			want:               "no pre-merge APPROVED review of head commit",
+		},
+		{
+			name:               "reviewer-permission-lookup-unknown",
+			reviewerPermission: "unknown",
+			want:               "no pre-merge APPROVED review of head commit",
+		},
+		{name: "api-refusal", apiFails: true, wantError: true},
+		{
+			name:       "app-login-not-configured",
+			noAppLogin: true,
+			want:       "vars.RELEASE_PR_APP_LOGIN is not configured",
+		},
+		{
+			name: "commit-not-on-main",
+			mode: "off-main",
+			want: "not reachable from main",
+		},
+		{
+			name: "snapshot-from-unrelated-freeze",
+			mode: "bogus-freeze",
+			want: "does not descend from the code-freeze commit",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			root, commit, headSHA := authorizationGitFixture(t, gateway, tc.mode)
+			bin := filepath.Join(root, "bin")
+			if err := os.MkdirAll(bin, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			spec := defaultPrepPR(gateway, commit, headSHA)
+			if tc.pr != nil {
+				tc.pr(&spec)
+			}
+			payloads := []map[string]any{spec.payload()}
+			if tc.pulls != nil {
+				payloads = tc.pulls(payloads)
+			}
+			reviews := approvedReviews(headSHA)
+			if tc.reviews != nil {
+				reviews = tc.reviews(headSHA)
+			}
+			reviewPayloads := make([]map[string]any, 0, len(reviews))
+			for _, review := range reviews {
+				reviewPayloads = append(reviewPayloads, review.payload())
+			}
+			status := "0"
+			if tc.apiFails {
+				status = "1"
+			}
+			writeExecutableFixture(t, filepath.Join(bin, "gh"), strings.ReplaceAll(`#!/usr/bin/env bash
+set -uo pipefail
+if [ "$1" != api ]; then echo "unexpected gh invocation: $*" >&2; exit 2; fi
+endpoint=""
+for arg in "$@"; do
+  case "$arg" in
+    repos/*) endpoint="$arg" ;;
+  esac
+done
+if [ -z "$endpoint" ]; then echo "no endpoint in gh api invocation: $*" >&2; exit 2; fi
+case "$endpoint" in
+  */pulls) cat "$PULLS_FIXTURE" ;;
+  */reviews) cat "$REVIEWS_FIXTURE" ;;
+  */collaborators/*/permission) user=$(basename "$(dirname "$endpoint")"); cat "$PERMISSIONS_FIXTURE/$user.json" ;;
+  *) echo "unexpected gh api endpoint: $endpoint" >&2; exit 2 ;;
+esac
+exit @@STATUS@@
+`, "@@STATUS@@", status))
+			pullsFixture := filepath.Join(root, "pulls.json")
+			if err := os.WriteFile(pullsFixture, mustJSON(t, payloads), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			reviewsFixture := filepath.Join(root, "reviews.json")
+			if err := os.WriteFile(reviewsFixture, mustJSON(t, reviewPayloads), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			permissionsDir := filepath.Join(root, "permissions")
+			if err := os.MkdirAll(permissionsDir, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			reviewerPermission := "maintain"
+			if tc.reviewerPermission != "" {
+				reviewerPermission = tc.reviewerPermission
+			}
+			if err := os.WriteFile(filepath.Join(permissionsDir, releasePRMaintainer+".json"), mustJSON(t, map[string]string{"permission": reviewerPermission}), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			os.Setenv("PERMISSIONS_FIXTURE", permissionsDir)
+			defer os.Unsetenv("PERMISSIONS_FIXTURE")
+			summary := filepath.Join(root, "summary.md")
+			contract := workflowShellContract(t, "promote-plugin-release.yaml", "promotion-authorization-contract")
+			cmd := exec.Command("bash", "-c", "set -euo pipefail\n"+contract)
+			cmd.Dir = root
+			appLogin := releaseAppLogin
+			if tc.noAppLogin {
+				appLogin = ""
+			}
+			cmd.Env = append(os.Environ(),
+				"PATH="+bin+":"+os.Getenv("PATH"),
+				"PULLS_FIXTURE="+pullsFixture,
+				"REVIEWS_FIXTURE="+reviewsFixture,
+				"GH_TOKEN=fixture-token",
+				"GITHUB_REPOSITORY=higress-group/higress",
+				"GITHUB_STEP_SUMMARY="+summary,
+				"RELEASE_PR_APP_LOGIN="+appLogin,
+				"SOURCE_COMMIT="+commit,
+				"SNAPSHOT_PATH=plugins/release/snapshots/"+gateway+".json",
+			)
+			output, err := cmd.CombinedOutput()
+			if strings.Contains(string(output), "fixture-token") {
+				t.Fatalf("authorization leaked its token:\n%s", output)
+			}
+			if tc.want != "" && !strings.Contains(string(output), tc.want) {
+				t.Fatalf("authorization output lacks %q:\n%s", tc.want, output)
+			}
+			if tc.wantError || tc.want != "" {
+				if err == nil {
+					t.Fatalf("unauthorized promotion was accepted:\n%s", output)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("authorized promotion was rejected: %v\n%s", err, output)
+			}
+			body, readErr := os.ReadFile(summary)
+			if readErr != nil {
+				t.Fatal(readErr)
+			}
+			for _, required := range []string{
+				"Promotion of " + gateway + " authorized by merged preparation PR #" + strconv.Itoa(releasePRNumber),
+				"author " + releaseAppLogin,
+				"label release/" + gateway,
+				"head " + headSHA,
+				"at " + commit,
+			} {
+				if !strings.Contains(string(body), required) {
+					t.Fatalf("step summary did not record %q: %s", required, body)
+				}
+			}
+		})
+	}
+}
+
+// TestPromotionAuthorizationReadsTheAppLoginFromRepositoryVariables keeps the
+// authorizing identity configuration rather than a guess: the workflow must take
+// it from vars.RELEASE_PR_APP_LOGIN, refuse to run without it, and never embed a
+// bot login that a rename would silently invalidate.
+func TestPromotionAuthorizationReadsTheAppLoginFromRepositoryVariables(t *testing.T) {
+	promote := mustWorkflow(t, "promote-plugin-release.yaml")
+	job := workflowJobSection(t, promote, "verify-and-promote")
+	for _, required := range []string{
+		"RELEASE_PR_APP_LOGIN: ${{ vars.RELEASE_PR_APP_LOGIN }}",
+		`if [ -z "${RELEASE_PR_APP_LOGIN:-}" ]; then`,
+		`if [ "$pr_author" != "$RELEASE_PR_APP_LOGIN" ] || [ "$pr_author_type" != Bot ]; then`,
+		`.merge_commit_sha == $commit`,
+		`if [ "$maintainer_can_modify" != false ]; then`,
+		`(.commit_id // "") == $head`,
+	} {
+		if !strings.Contains(job, required) {
+			t.Fatalf("promotion authorization lacks %q", required)
+		}
+	}
+	if strings.Contains(promote, releaseAppLogin) {
+		t.Fatalf("promote must not hard-code the App login %q; it is read from vars.RELEASE_PR_APP_LOGIN", releaseAppLogin)
+	}
+}
+
+// TestPromotionAuthorizationRunsBeforeAnyRegistryMutation keeps the
+// authorization decision ahead of the credential login and every write.
+func TestPromotionAuthorizationRunsBeforeAnyRegistryMutation(t *testing.T) {
+	promote := mustWorkflow(t, "promote-plugin-release.yaml")
+	job := workflowJobSection(t, promote, "verify-and-promote")
+	authorization := strings.Index(job, "# BEGIN promotion-authorization-contract")
+	login := strings.Index(job, "oras login")
+	verify := strings.Index(job, "      - name: Verify exact snapshot provenance\n")
+	copyStep := strings.Index(job, "oras cp")
+	if authorization < 0 || login < 0 || verify < 0 || copyStep < 0 {
+		t.Fatal("promote's version phase lost an expected step boundary")
+	}
+	if !(authorization < verify && verify < login && login < copyStep) {
+		t.Fatal("the merged preparation PR must authorize promotion before verification, registry login, and any copy")
+	}
+}
+
+// TestPreparationSweepsRegistryBeforeOpeningThePR proves SPEC-4634004 wiring in
+// the prepare workflow: the sweep runs after candidates exist and before the
+// snapshot is rendered, its report is bound into the snapshot and the PR body,
+// and the PR carries the release label promote requires.
+func TestPreparationSweepsRegistryBeforeOpeningThePR(t *testing.T) {
+	prepare := mustWorkflow(t, "prepare-plugin-release.yaml")
+	candidates := strings.Index(prepare, "      - name: Build and publish content-addressed candidates\n")
+	sweep := strings.Index(prepare, "      - name: Sweep public registry for planned tag conflicts\n")
+	render := strings.Index(prepare, "      - name: Render canonical snapshot\n")
+	prStep := strings.Index(prepare, "      - name: Create or update deterministic preparation PR\n")
+	if candidates < 0 || sweep < 0 || render < 0 || prStep < 0 {
+		t.Fatal("prepare lost an expected step")
+	}
+	if !(candidates < sweep && sweep < render && render < prStep) {
+		t.Fatal("the registry sweep must run after candidates are built and before the snapshot is rendered and the PR is opened")
+	}
+	for _, required := range []string{
+		"# BEGIN migration-preflight-contract",
+		"args=(migration-preflight --root ../.. --catalog ../../plugins/release/catalog.json --plan /tmp/plan.json --output /tmp/migration-report.json --markdown /tmp/migration-report.md)",
+		`if [ -n "$PREVIOUS" ]; then args+=(--previous "../../$PREVIOUS"); else args+=(--previous /tmp/bootstrap-snapshot.json); fi`,
+		`if [ -f /tmp/candidates.json ]; then args+=(--candidate-evidence /tmp/candidates.json); fi`,
+		"--migration-report /tmp/migration-report.json",
+		`name: plugin-release-migration-report-${{ inputs.gateway_version }}`,
+	} {
+		if !strings.Contains(prepare, required) {
+			t.Fatalf("prepare lacks migration preflight contract %q", required)
+		}
+	}
+	// The sweep must not write to any registry: it is a read-only classification.
+	sweepStep := prepare[sweep:render]
+	for _, mutation := range []string{"oras login", "oras cp", "oras push"} {
+		if strings.Contains(sweepStep, mutation) {
+			t.Fatalf("migration sweep contains registry mutation %q", mutation)
+		}
+	}
+
+	pr := prepare[prStep:]
+	for _, required := range []string{
+		"# BEGIN preparation-pr-contract",
+		`label="release/$GATEWAY_VERSION"`,
+		`label_ref=$(jq -rn --arg label "$label" '$label | @uri')`,
+		`if ! gh api "repos/$GITHUB_REPOSITORY/labels/$label_ref" >/dev/null 2>&1; then`,
+		`gh label create "$label"`,
+		`test "$(gh api "repos/$GITHUB_REPOSITORY/labels/$label_ref" --jq .name)" = "$label"`,
+		`gh pr create --base main --head "$branch" --title "$title" --body "$body" --label "$label" || gh pr edit "$branch" --title "$title" --body "$body" --add-label "$label"`,
+		`if [ "$(jq -er '[.entries[] | select(.state == "blocked")] | length' /tmp/migration-report.json)" -gt 0 ]; then`,
+		`$(cat /tmp/migration-report.md)`,
+	} {
+		if !strings.Contains(pr, required) {
+			t.Fatalf("preparation PR publication lacks contract %q", required)
+		}
+	}
+	labelCheck := strings.Index(pr, `gh api "repos/$GITHUB_REPOSITORY/labels/$label_ref"`)
+	create := strings.Index(pr, "gh pr create")
+	if labelCheck < 0 || create < 0 || labelCheck > create {
+		t.Fatal("the release label must exist before the preparation PR is opened")
+	}
+}
+
+func mustWorkflow(t *testing.T, name string) string {
+	t.Helper()
+	data, err := os.ReadFile("../../.github/workflows/" + name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(data)
+}
+
+// workflowJobSection returns one top-level job's YAML text so a gate assertion
+// cannot be satisfied by a different job in the same workflow.
+func workflowJobSection(t *testing.T, workflow, job string) string {
+	t.Helper()
+	start := strings.Index(workflow, "\n  "+job+":\n")
+	if start < 0 {
+		t.Fatalf("workflow has no %s job", job)
+	}
+	rest := workflow[start+1:]
+	end := len(rest)
+	for _, candidate := range []string{"\n  latest:\n", "\n  prepare:\n", "\n  publish:\n", "\n  preflight:\n"} {
+		if idx := strings.Index(rest, candidate); idx >= 0 && idx < end && candidate != "\n  "+job+":\n" {
+			end = idx
+		}
+	}
+	return rest[:end]
+}
+
+func mustJSON(t *testing.T, value any) []byte {
+	t.Helper()
+	data, err := json.Marshal(value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return data
+}
+
+func gitOutput(t *testing.T, root string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = root
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v: %v: %s", args, err, out)
+	}
+	return string(out)
+}
+
+func commitIsAncestor(t *testing.T, root, ancestor, descendant string) bool {
+	t.Helper()
+	cmd := exec.Command("git", "merge-base", "--is-ancestor", ancestor, descendant)
+	cmd.Dir = root
+	return cmd.Run() == nil
+}
+
+// authorizationGitFixture mirrors the real chain: a code-freeze commit on main, a
+// preparation branch forking that exact commit and carrying the snapshot whose
+// sourceCommit is the freeze, then that branch SQUASH-merged into main and
+// checked out detached, exactly as promote sees it. It returns the repository,
+// the merge commit handed to promote as source_commit, and the preparation
+// branch head the PR reports as head.sha and a review must have approved.
+func authorizationGitFixture(t *testing.T, gateway, mode string) (root, mergeCommit, headSHA string) {
+	t.Helper()
+	origin := t.TempDir()
+	mustRun(t, origin, "git", "init", "-q", "--bare", "-b", "main")
+	root = t.TempDir()
+	mustRun(t, root, "git", "init", "-q", "-b", "main")
+	mustRun(t, root, "git", "config", "user.name", "test")
+	mustRun(t, root, "git", "config", "user.email", "test@example.com")
+	mustRun(t, root, "git", "remote", "add", "origin", origin)
+	mustWrite(t, filepath.Join(root, "plugins/wasm-go/extensions/demo/VERSION"), "1.0.0\n")
+	mustRun(t, root, "git", "add", ".")
+	mustRun(t, root, "git", "commit", "-q", "-m", "code freeze")
+	mustRun(t, root, "git", "push", "-q", "origin", "HEAD:refs/heads/main")
+	freeze, err := resolveCommit(root, "HEAD")
+	if err != nil {
+		t.Fatal(err)
+	}
+	recorded := freeze
+	if mode == "bogus-freeze" {
+		recorded = strings.Repeat("0", 40)
+	}
+	mustRun(t, root, "git", "checkout", "-q", "-B", "release/plugin-snapshot-"+gateway)
+	snapshot := map[string]any{
+		"schemaVersion": 1, "gatewayVersion": gateway, "sourceCommit": recorded,
+		"provenanceMode": "candidate", "plugins": []any{},
+	}
+	snapshotPath := filepath.Join(root, "plugins", "release", "snapshots", gateway+".json")
+	if err := os.MkdirAll(filepath.Dir(snapshotPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	data, err := json.MarshalIndent(snapshot, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(snapshotPath, append(data, '\n'), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	mustRun(t, root, "git", "add", ".")
+	mustRun(t, root, "git", "commit", "-q", "-s", "-m", "chore: prepare plugin snapshot "+gateway)
+	headSHA, err = resolveCommit(root, "HEAD")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if mode == "off-main" {
+		// The preparation branch was never merged: the commit exists and carries
+		// the snapshot, but nothing on main authorizes it.
+		return root, headSHA, headSHA
+	}
+	mustRun(t, root, "git", "checkout", "-q", "main")
+	mustRun(t, root, "git", "merge", "-q", "--squash", headSHA)
+	mustRun(t, root, "git", "commit", "-q", "-m", "chore: prepare plugin snapshot "+gateway+" (#"+strconv.Itoa(releasePRNumber)+")")
+	mergeCommit, err = resolveCommit(root, "HEAD")
+	if err != nil {
+		t.Fatal(err)
+	}
+	mustRun(t, root, "git", "push", "-q", "origin", "HEAD:refs/heads/main")
+	mustRun(t, root, "git", "checkout", "-q", mergeCommit)
+	// The fixture must really have squash semantics: one parent (the code-freeze
+	// commit) and a preparation head that is not an ancestor of the merge, so no
+	// assertion below can be satisfied by a fast-forward shape production never
+	// produces.
+	parents := strings.Fields(gitOutput(t, root, "rev-list", "--parents", "-n", "1", mergeCommit))
+	if len(parents) != 2 || parents[1] != freeze {
+		t.Fatalf("fixture merge must be a squash of the preparation branch onto the code freeze %s, got parents %v", freeze, parents[1:])
+	}
+	if mergeCommit == headSHA || commitIsAncestor(t, root, headSHA, mergeCommit) {
+		t.Fatal("fixture must not fast-forward: the preparation head cannot be an ancestor of its squash merge commit")
+	}
+	return root, mergeCommit, headSHA
+}

--- a/tools/plugin-release/commands.go
+++ b/tools/plugin-release/commands.go
@@ -818,6 +818,9 @@ func verifySnapshotBindings(root, catalogPath, snapshotPath, planPath, previousP
 	if ociSource != "candidate" && ociSource != "public" {
 		return fmt.Errorf("OCI source must be candidate or public, got %q", ociSource)
 	}
+	if err := validateSnapshotMigration(snapshot); err != nil {
+		return err
+	}
 	if expectedSource != "" {
 		commit, err := resolveCommit(root, expectedSource)
 		if err != nil || commit != snapshot.SourceCommit {
@@ -919,6 +922,13 @@ func verifySnapshotBindings(root, catalogPath, snapshotPath, planPath, previousP
 		}
 		if resolve {
 			if ociSource == "candidate" && provenance == "public" {
+				continue
+			}
+			if ociSource == "public" && entry.Migration != nil {
+				// The prepare-time sweep already proved this public tag serves a
+				// different digest. That divergence is the recorded exclusion
+				// from this promote batch, not a verification failure; the
+				// candidate for the same entry is still resolved above.
 				continue
 			}
 			if err := verifyOCI(entry, provenance, snapshot.ProvenanceMode, ociSource); err != nil {
@@ -1051,11 +1061,15 @@ func verifySnapshotProvenanceBindings(root string, snapshot Snapshot, planPath, 
 					return fmt.Errorf("%s is neither planned nor carried by the previous snapshot", entry.LogicalID)
 				}
 				// Consumers are re-cloned from the catalog on carry, so the
-				// exact-field comparison excludes them deliberately.
+				// exact-field comparison excludes them deliberately. A carried
+				// migration exclusion is compared verbatim: the entry stays out
+				// of the promote batch until a later release re-plans the plugin
+				// after its disposition completes, and dropping the marker would
+				// re-expose the immutable tag conflict that created it.
 				if old.Version != entry.Version || old.OCIRef != entry.OCIRef || old.Digest != entry.Digest ||
 					old.InputHash != entry.InputHash || old.SourceCommit != entry.SourceCommit ||
 					old.CandidateRef != entry.CandidateRef || old.ProvenanceMode != entry.ProvenanceMode ||
-					old.Backfill != entry.Backfill {
+					old.Backfill != entry.Backfill || !reflect.DeepEqual(old.Migration, entry.Migration) {
 					return fmt.Errorf("%s carried snapshot entry differs from the previous snapshot", entry.LogicalID)
 				}
 				continue
@@ -1531,6 +1545,7 @@ func commandRender(args []string) error {
 	previous := fs.String("previous", "", "previous snapshot")
 	evidence := fs.String("candidate-evidence", "", "candidate evidence path")
 	bootstrapEvidence := fs.String("bootstrap-evidence", "", "bootstrap evidence path (first managed release only)")
+	migrationReport := fs.String("migration-report", "", "prepare-time public registry sweep bound into the snapshot")
 	output := fs.String("output", "-", "snapshot output")
 	if err := fs.Parse(args); err != nil {
 		return err
@@ -1540,6 +1555,14 @@ func commandRender(args []string) error {
 	}
 	snapshot, err := renderSnapshot(*catalog, *plan, *previous, *evidence, *bootstrapEvidence)
 	if err != nil {
+		return err
+	}
+	if *migrationReport != "" {
+		snapshot, err = applyMigrationReport(snapshot, *migrationReport)
+		if err != nil {
+			return err
+		}
+	} else if err := requireNoCarriedMigration(snapshot); err != nil {
 		return err
 	}
 	return writeCanonical(*output, snapshot)

--- a/tools/plugin-release/io.go
+++ b/tools/plugin-release/io.go
@@ -43,6 +43,17 @@ func writeCanonical(path string, value any) error {
 	return os.WriteFile(path, data, 0o644)
 }
 
+func writeText(path, text string) error {
+	if path == "-" {
+		_, err := os.Stdout.WriteString(text)
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(path, []byte(text), 0o644)
+}
+
 func sha256Hex(data []byte) string {
 	sum := sha256.Sum256(data)
 	return hex.EncodeToString(sum[:])

--- a/tools/plugin-release/main.go
+++ b/tools/plugin-release/main.go
@@ -10,7 +10,7 @@ import (
 
 func main() {
 	if len(os.Args) < 2 {
-		fatalf("usage: plugin-release <validate-catalog|validate-console-recovery|capture-bootstrap-evidence|bootstrap-snapshot|plan|apply-plan|render-snapshot|verify-snapshot|semver-compare> [flags]")
+		fatalf("usage: plugin-release <validate-catalog|validate-console-recovery|capture-bootstrap-evidence|bootstrap-snapshot|plan|apply-plan|render-snapshot|migration-preflight|verify-snapshot|semver-compare> [flags]")
 	}
 	var err error
 	switch os.Args[1] {
@@ -28,6 +28,8 @@ func main() {
 		err = commandApply(os.Args[2:])
 	case "render-snapshot":
 		err = commandRender(os.Args[2:])
+	case "migration-preflight":
+		err = commandMigrationPreflight(os.Args[2:])
 	case "verify-snapshot":
 		err = commandVerify(os.Args[2:])
 	case "semver-compare":

--- a/tools/plugin-release/migration.go
+++ b/tools/plugin-release/migration.go
@@ -1,0 +1,567 @@
+// Copyright 2026 Higress Authors
+// Licensed under the Apache License, Version 2.0.
+
+package main
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"sort"
+	"strings"
+)
+
+// migrationPreflight sweeps the public registry for every planned plugin tag
+// before the preparation PR is created (SPEC-4634004). A planned tag that is
+// already occupied by a different artifact becomes a migration-mode entry with
+// a recommended disposition, so promote skips that one plugin instead of
+// hard-failing the whole batch on an immutable tag conflict.
+//
+// The probe method is calibrated first: a known-good control tag from the
+// reviewed previous snapshot must resolve to exactly its recorded digest. If it
+// does not, no present/absent classification from this sweep is trustworthy and
+// the preflight fails closed rather than reporting a clean registry.
+//
+// candidateEvidencePath may be empty for a dry-run rehearsal. Without candidate
+// digests there is nothing to compare, so an occupied planned tag is reported as
+// suspected and can never block a plugin or enter a snapshot.
+func migrationPreflight(catalogPath, planPath, previousPath, candidateEvidencePath string) (MigrationReportFile, error) {
+	c, catalogData, err := loadCatalog(catalogPath)
+	if err != nil {
+		return MigrationReportFile{}, err
+	}
+	var plan Plan
+	if _, err := readJSON(planPath, &plan); err != nil {
+		return MigrationReportFile{}, err
+	}
+	if err := validatePlanProvenance(plan, catalogData); err != nil {
+		return MigrationReportFile{}, err
+	}
+	controlRef, controlDigest, err := migrationControlTag(previousPath)
+	if err != nil {
+		return MigrationReportFile{}, err
+	}
+	control, err := ociManifestResolver(controlRef)
+	if err != nil {
+		switch classifyOCIFailure(err, controlRef) {
+		case ociFailureUnauthorized:
+			return MigrationReportFile{}, fmt.Errorf("migration preflight control tag %s: registry authorization failed; authorization failure is never absence: %w", controlRef, err)
+		default:
+			return MigrationReportFile{}, fmt.Errorf("migration preflight cannot calibrate its probe against control tag %s: %w", controlRef, err)
+		}
+	}
+	if control.Digest != controlDigest {
+		return MigrationReportFile{}, fmt.Errorf("migration preflight probe is not trustworthy: control tag %s resolved to %s, expected the reviewed %s", controlRef, control.Digest, controlDigest)
+	}
+	probeMode := migrationProbeExistenceOnly
+	var evidence CandidateEvidenceFile
+	if candidateEvidencePath != "" {
+		if _, err := readJSON(candidateEvidencePath, &evidence); err != nil {
+			return MigrationReportFile{}, err
+		}
+		probeMode = migrationProbeCandidateDigest
+	}
+	report := MigrationReportFile{
+		SchemaVersion:  migrationReportSchemaVersion,
+		GatewayVersion: plan.GatewayVersion,
+		SourceCommit:   plan.SourceCommit,
+		PlanID:         plan.PlanID,
+		Registry:       c.Registry,
+		ProbeMode:      probeMode,
+		ControlRef:     controlRef,
+		ControlDigest:  controlDigest,
+		Entries:        []MigrationReportEntry{},
+	}
+	for _, entry := range plan.Plugins {
+		ociRef := c.Registry + "/" + entry.Image + ":" + entry.Version
+		planned := ""
+		if probeMode == migrationProbeCandidateDigest {
+			proof, ok := evidence.Plugins[entry.LogicalID]
+			if !ok || !digestPattern.MatchString(proof.Digest) || proof.InputHash != entry.InputHash {
+				return MigrationReportFile{}, fmt.Errorf("migration preflight needs candidate evidence for every planned plugin; %s has no matching candidate digest", entry.LogicalID)
+			}
+			planned = proof.Digest
+		}
+		manifest, err := ociManifestResolver(ociRef)
+		if err != nil {
+			switch classifyOCIFailure(err, ociRef) {
+			case ociFailureNotFound:
+				continue
+			case ociFailureUnauthorized:
+				return MigrationReportFile{}, fmt.Errorf("migration preflight %s: registry authorization failed; authorization failure is never absence: %w", entry.LogicalID, err)
+			default:
+				return MigrationReportFile{}, fmt.Errorf("migration preflight cannot classify the planned public tag %s: %w", ociRef, err)
+			}
+		}
+		if !digestPattern.MatchString(manifest.Digest) {
+			return MigrationReportFile{}, fmt.Errorf("migration preflight %s returned invalid digest %q", entry.LogicalID, manifest.Digest)
+		}
+		if planned != "" && manifest.Digest == planned {
+			continue
+		}
+		report.Entries = append(report.Entries, MigrationReportEntry{
+			LogicalID:         entry.LogicalID,
+			Version:           entry.Version,
+			OCIRef:            ociRef,
+			ExistingDigest:    manifest.Digest,
+			PlannedDigest:     planned,
+			InputHash:         entry.InputHash,
+			ExistingVersion:   manifest.Annotations["org.opencontainers.image.version"],
+			ExistingRevision:  manifest.Annotations["org.opencontainers.image.revision"],
+			ExistingInputHash: manifest.Annotations["io.higress.plugin.input-hash"],
+			SourceComparison:  migrationSourceComparison(manifest, plan.SourceCommit),
+			State:             migrationEntryState(planned),
+			Recommendation:    migrationEntryRecommendation(manifest, entry, plan.SourceCommit, planned),
+		})
+	}
+	return report, nil
+}
+
+func migrationEntryState(plannedDigest string) string {
+	if plannedDigest == "" {
+		return migrationStateSuspected
+	}
+	return migrationStateBlocked
+}
+
+func migrationEntryRecommendation(manifest ociManifest, planned PlanEntry, sourceCommit, plannedDigest string) string {
+	if plannedDigest == "" {
+		return ""
+	}
+	return migrationRecommendation(manifest, planned, sourceCommit)
+}
+
+// migrationControlTag selects the known-good public artifact the probe is
+// validated against: a pipeline-published tag of the previous snapshot that this
+// release's batch is not excluding, preferring an entry this pipeline built over
+// one adopted from a pre-existing public artifact. Those tags are immutable
+// published artifacts, so a probe that cannot reproduce the reviewed digest is
+// measuring the registry incorrectly.
+//
+// An entry carrying a migration exclusion is never eligible: its public tag
+// still serves the legacy artifact that caused the exclusion, not the digest its
+// snapshot records, so calibrating against it would fail every later prepare.
+func migrationControlTag(previousPath string) (string, string, error) {
+	if previousPath == "" {
+		return "", "", errors.New("migration preflight requires the reviewed previous snapshot to calibrate its registry probe")
+	}
+	var previous Snapshot
+	if _, err := readJSON(previousPath, &previous); err != nil {
+		return "", "", err
+	}
+	adoptedRef, adoptedDigest := "", ""
+	for _, entry := range previous.Plugins {
+		if entry.Migration != nil {
+			continue
+		}
+		if entry.OCIRef == "" || !digestPattern.MatchString(entry.Digest) {
+			continue
+		}
+		switch entryProvenance(entry) {
+		case "candidate":
+			return entry.OCIRef, entry.Digest, nil
+		case "public":
+			if adoptedRef == "" {
+				adoptedRef, adoptedDigest = entry.OCIRef, entry.Digest
+			}
+		}
+	}
+	if adoptedRef != "" {
+		return adoptedRef, adoptedDigest, nil
+	}
+	return "", "", errors.New("previous snapshot carries no published, non-excluded public control tag; migration preflight cannot calibrate its probe")
+}
+
+// validatePlanProvenance re-checks the immutable plan identity the sweep binds
+// its report to, so a report can never be attached to a plan that was edited
+// after it was hashed.
+func validatePlanProvenance(plan Plan, catalogData []byte) error {
+	if plan.SchemaVersion != planSchemaVersion || !commitPattern.MatchString(plan.SourceCommit) || !digestPattern.MatchString(plan.PlanID) {
+		return errors.New("plan has an unsupported schema or invalid immutable provenance")
+	}
+	if plan.CatalogSHA256 != sha256Hex(catalogData) {
+		return errors.New("plan catalogSha256 does not match catalog")
+	}
+	if want := "sha256:" + canonicalObjectHash(plan, true); plan.PlanID != want {
+		return fmt.Errorf("planId does not match canonical plan content: got %s, want %s", plan.PlanID, want)
+	}
+	gatewayVersion, err := parseSemver(plan.GatewayVersion)
+	if err != nil || gatewayVersion.prerelease != "" {
+		return errors.New("plan gatewayVersion must be stable SemVer")
+	}
+	return nil
+}
+
+func migrationSourceComparison(manifest ociManifest, sourceCommit string) string {
+	revision := manifest.Annotations["org.opencontainers.image.revision"]
+	if revision == "" &&
+		manifest.Annotations["io.higress.plugin.input-hash"] == "" &&
+		manifest.Annotations["org.opencontainers.image.version"] == "" {
+		return migrationSourceUnannotated
+	}
+	if revision == sourceCommit {
+		return migrationSourceMatch
+	}
+	return migrationSourceMismatch
+}
+
+// migrationRecommendation is a deterministic, mutually exclusive disposition.
+// Deleting a public tag is recommended only for an artifact carrying no
+// pipeline annotation at all, which is how a pre-pipeline manual artifact
+// presents itself. Anything the pipeline published but that cannot be matched
+// to this plan must be resolved by bumping the planned version: an unproven
+// artifact is never deleted automatically.
+func migrationRecommendation(manifest ociManifest, planned PlanEntry, sourceCommit string) string {
+	version := manifest.Annotations["org.opencontainers.image.version"]
+	revision := manifest.Annotations["org.opencontainers.image.revision"]
+	inputHash := manifest.Annotations["io.higress.plugin.input-hash"]
+	if version == "" && revision == "" && inputHash == "" {
+		return migrationRecommendDeleteLegacy
+	}
+	if inputHash == planned.InputHash && revision == sourceCommit && version == planned.Version {
+		return migrationRecommendAdoptPublic
+	}
+	return migrationRecommendBumpVersion
+}
+
+// migrationRecommendationFromRecord re-derives the disposition from the fields
+// recorded in a report or snapshot marker. Binding and verification both use it,
+// so a hand-edited recommendation can never survive validation.
+func migrationRecommendationFromRecord(existingVersion, existingRevision, existingInputHash, plannedInputHash, plannedVersion, sourceCommit string) string {
+	manifest := ociManifest{Annotations: map[string]string{
+		"org.opencontainers.image.version":  existingVersion,
+		"org.opencontainers.image.revision": existingRevision,
+		"io.higress.plugin.input-hash":      existingInputHash,
+	}}
+	return migrationRecommendation(manifest, PlanEntry{InputHash: plannedInputHash, Version: plannedVersion}, sourceCommit)
+}
+
+func migrationSourceComparisonFromRecord(existingVersion, existingRevision, existingInputHash, sourceCommit string) string {
+	manifest := ociManifest{Annotations: map[string]string{
+		"org.opencontainers.image.version":  existingVersion,
+		"org.opencontainers.image.revision": existingRevision,
+		"io.higress.plugin.input-hash":      existingInputHash,
+	}}
+	return migrationSourceComparison(manifest, sourceCommit)
+}
+
+// applyMigrationReport binds a definitive sweep into a rendered snapshot. A
+// snapshot that excludes nothing — neither newly blocked by this sweep nor
+// carried from an earlier release — is left byte-identical to the no-conflict
+// path.
+func applyMigrationReport(snapshot Snapshot, reportPath string) (Snapshot, error) {
+	var report MigrationReportFile
+	if _, err := readJSON(reportPath, &report); err != nil {
+		return Snapshot{}, err
+	}
+	if err := validateMigrationReport(report, snapshot); err != nil {
+		return Snapshot{}, err
+	}
+	// renderSnapshot carries an earlier release's exclusion forward verbatim, so
+	// the marker that binds those entries has to be rebuilt here even when this
+	// sweep found nothing: dropping it would make an unrelated later release fail
+	// verification wholesale instead of excluding only the still-blocked plugin.
+	carried := make([]string, 0)
+	for _, entry := range snapshot.Plugins {
+		if entry.Migration == nil {
+			continue
+		}
+		if entry.Migration.State != migrationStateBlocked {
+			return Snapshot{}, fmt.Errorf("%s carries migration state %q from the previous snapshot; only %q exclusions are carried forward", entry.LogicalID, entry.Migration.State, migrationStateBlocked)
+		}
+		carried = append(carried, entry.LogicalID)
+	}
+	if len(report.Entries) == 0 && len(carried) == 0 {
+		return snapshot, nil
+	}
+	// Copy on write: the caller's snapshot must not change through a shared
+	// backing array when markers are attached.
+	snapshot.Plugins = append([]SnapshotEntry(nil), snapshot.Plugins...)
+	excluded := append([]string(nil), carried...)
+	if len(report.Entries) > 0 {
+		entries := make(map[string]MigrationReportEntry, len(report.Entries))
+		for _, entry := range report.Entries {
+			entries[entry.LogicalID] = entry
+		}
+		for i := range snapshot.Plugins {
+			reported, ok := entries[snapshot.Plugins[i].LogicalID]
+			if !ok {
+				continue
+			}
+			if snapshot.Plugins[i].Migration != nil {
+				return Snapshot{}, fmt.Errorf("%s is carried as an existing migration exclusion and cannot be blocked again by this sweep; re-plan it after its disposition completes", reported.LogicalID)
+			}
+			snapshot.Plugins[i].Migration = &SnapshotMigration{
+				State:             reported.State,
+				SourceCommit:      report.SourceCommit,
+				ExistingDigest:    reported.ExistingDigest,
+				PlannedDigest:     reported.PlannedDigest,
+				ExistingVersion:   reported.ExistingVersion,
+				ExistingRevision:  reported.ExistingRevision,
+				ExistingInputHash: reported.ExistingInputHash,
+				SourceComparison:  reported.SourceComparison,
+				Recommendation:    reported.Recommendation,
+			}
+			excluded = append(excluded, reported.LogicalID)
+			delete(entries, reported.LogicalID)
+		}
+		if len(entries) > 0 {
+			missing := make([]string, 0, len(entries))
+			for id := range entries {
+				missing = append(missing, id)
+			}
+			sort.Strings(missing)
+			return Snapshot{}, fmt.Errorf("migration report names %s, which the snapshot does not carry", strings.Join(missing, ", "))
+		}
+	}
+	sort.Strings(excluded)
+	snapshot.MigrationPreflight = &SnapshotMigrationPreflight{
+		ControlRef:    report.ControlRef,
+		ControlDigest: report.ControlDigest,
+		Excluded:      excluded,
+	}
+	if err := validateSnapshotMigration(snapshot); err != nil {
+		return Snapshot{}, err
+	}
+	return snapshot, nil
+}
+
+// requireNoCarriedMigration keeps `render-snapshot` from silently writing a
+// snapshot that carries earlier exclusions but no sweep to rebind their marker.
+func requireNoCarriedMigration(snapshot Snapshot) error {
+	carried := make([]string, 0)
+	for _, entry := range snapshot.Plugins {
+		if entry.Migration != nil {
+			carried = append(carried, entry.LogicalID)
+		}
+	}
+	if len(carried) == 0 {
+		return nil
+	}
+	return fmt.Errorf("the previous snapshot carries migration exclusions for %s, so --migration-report is required to rebind them", strings.Join(carried, ", "))
+}
+
+// validateMigrationReport binds the sweep to the exact snapshot it qualifies.
+// Only a definitive candidate-digest comparison may block a plugin, and every
+// recorded disposition must be re-derivable from the recorded annotations.
+func validateMigrationReport(report MigrationReportFile, snapshot Snapshot) error {
+	if report.SchemaVersion != migrationReportSchemaVersion {
+		return fmt.Errorf("migration report schemaVersion must be %d", migrationReportSchemaVersion)
+	}
+	if report.ProbeMode != migrationProbeCandidateDigest {
+		return fmt.Errorf("a snapshot binds only a %s migration sweep, got %q", migrationProbeCandidateDigest, report.ProbeMode)
+	}
+	if report.GatewayVersion != snapshot.GatewayVersion || report.SourceCommit != snapshot.SourceCommit || report.PlanID != snapshot.PlanID {
+		return errors.New("migration report and snapshot immutable provenance differ")
+	}
+	if report.ControlRef == "" || !digestPattern.MatchString(report.ControlDigest) {
+		return errors.New("migration report lacks a calibrated control tag")
+	}
+	if report.Registry == "" || strings.Contains(report.Registry, "://") {
+		return errors.New("migration report registry must be a host without a URL scheme")
+	}
+	snapshotEntries := make(map[string]SnapshotEntry, len(snapshot.Plugins))
+	for _, entry := range snapshot.Plugins {
+		snapshotEntries[entry.LogicalID] = entry
+	}
+	last := ""
+	for _, entry := range report.Entries {
+		if last != "" && entry.LogicalID <= last {
+			return fmt.Errorf("migration report entries are not sorted and unique by logicalId at %q", entry.LogicalID)
+		}
+		last = entry.LogicalID
+		if entry.State != migrationStateBlocked {
+			return fmt.Errorf("migration report entry %s has state %q; only %s entries may be bound into a snapshot", entry.LogicalID, entry.State, migrationStateBlocked)
+		}
+		if err := validateMigrationFields(entry.LogicalID, entry.ExistingDigest, entry.PlannedDigest, entry.SourceComparison, entry.Recommendation); err != nil {
+			return err
+		}
+		snapshotEntry, ok := snapshotEntries[entry.LogicalID]
+		if !ok {
+			return fmt.Errorf("migration report names %s, which the snapshot does not carry", entry.LogicalID)
+		}
+		if entry.OCIRef != snapshotEntry.OCIRef || entry.OCIRef != report.Registry+"/"+snapshotEntry.Image+":"+entry.Version {
+			return fmt.Errorf("migration report reference for %s does not match its planned snapshot reference", entry.LogicalID)
+		}
+		if entry.Version != snapshotEntry.Version || entry.InputHash != snapshotEntry.InputHash || entry.PlannedDigest != snapshotEntry.Digest {
+			return fmt.Errorf("migration report for %s does not match the planned snapshot digest and inputs", entry.LogicalID)
+		}
+		if entry.ExistingDigest == entry.PlannedDigest {
+			return fmt.Errorf("migration report blocks %s although the public tag already serves the planned digest", entry.LogicalID)
+		}
+		if want := migrationRecommendationFromRecord(entry.ExistingVersion, entry.ExistingRevision, entry.ExistingInputHash, entry.InputHash, entry.Version, report.SourceCommit); entry.Recommendation != want {
+			return fmt.Errorf("migration report recommendation for %s is %q, but its recorded annotations require %q", entry.LogicalID, entry.Recommendation, want)
+		}
+		if want := migrationSourceComparisonFromRecord(entry.ExistingVersion, entry.ExistingRevision, entry.ExistingInputHash, report.SourceCommit); entry.SourceComparison != want {
+			return fmt.Errorf("migration report source comparison for %s is %q, but its recorded annotations require %q", entry.LogicalID, entry.SourceComparison, want)
+		}
+	}
+	return nil
+}
+
+func validateMigrationFields(logicalID, existingDigest, plannedDigest, sourceComparison, recommendation string) error {
+	if !digestPattern.MatchString(existingDigest) || !digestPattern.MatchString(plannedDigest) {
+		return fmt.Errorf("%s migration state must record the existing and planned digests", logicalID)
+	}
+	if existingDigest == plannedDigest {
+		return fmt.Errorf("%s migration state records an identical existing and planned digest", logicalID)
+	}
+	switch sourceComparison {
+	case migrationSourceMatch, migrationSourceMismatch, migrationSourceUnannotated:
+	default:
+		return fmt.Errorf("%s migration state has unsupported source comparison %q", logicalID, sourceComparison)
+	}
+	switch recommendation {
+	case migrationRecommendDeleteLegacy, migrationRecommendBumpVersion, migrationRecommendAdoptPublic:
+	default:
+		return fmt.Errorf("%s migration state has unsupported recommendation %q", logicalID, recommendation)
+	}
+	return nil
+}
+
+// validateSnapshotMigration checks the snapshot-internal migration binding: the
+// markers and the preflight marker must exist together, the excluded set must be
+// exactly the marked entries, and every recorded disposition must still be
+// re-derivable from the recorded annotations.
+func validateSnapshotMigration(snapshot Snapshot) error {
+	excluded := make([]string, 0)
+	for _, entry := range snapshot.Plugins {
+		if entry.Migration == nil {
+			continue
+		}
+		migration := *entry.Migration
+		if migration.State != migrationStateBlocked {
+			return fmt.Errorf("%s has unsupported migration state %q", entry.LogicalID, migration.State)
+		}
+		if err := validateMigrationFields(entry.LogicalID, migration.ExistingDigest, migration.PlannedDigest, migration.SourceComparison, migration.Recommendation); err != nil {
+			return err
+		}
+		if migration.PlannedDigest != entry.Digest {
+			return fmt.Errorf("%s migration state does not record its own snapshot digest as the planned digest", entry.LogicalID)
+		}
+		if !commitPattern.MatchString(migration.SourceCommit) {
+			return fmt.Errorf("%s migration state does not record the source commit of the sweep that decided it", entry.LogicalID)
+		}
+		// The disposition is re-derived against the commit of the sweep that
+		// decided it, which for a carried exclusion belongs to an earlier
+		// release. Deriving it against this snapshot's source commit instead
+		// would invalidate every carried exclusion.
+		if want := migrationRecommendationFromRecord(migration.ExistingVersion, migration.ExistingRevision, migration.ExistingInputHash, entry.InputHash, entry.Version, migration.SourceCommit); migration.Recommendation != want {
+			return fmt.Errorf("%s migration recommendation %q is not re-derivable from its recorded annotations, want %q", entry.LogicalID, migration.Recommendation, want)
+		}
+		if want := migrationSourceComparisonFromRecord(migration.ExistingVersion, migration.ExistingRevision, migration.ExistingInputHash, migration.SourceCommit); migration.SourceComparison != want {
+			return fmt.Errorf("%s migration source comparison %q is not re-derivable from its recorded annotations, want %q", entry.LogicalID, migration.SourceComparison, want)
+		}
+		excluded = append(excluded, entry.LogicalID)
+	}
+	sort.Strings(excluded)
+	if snapshot.MigrationPreflight == nil {
+		if len(excluded) > 0 {
+			return fmt.Errorf("snapshot excludes %s by migration state but carries no migrationPreflight marker", strings.Join(excluded, ", "))
+		}
+		return nil
+	}
+	preflight := *snapshot.MigrationPreflight
+	if len(excluded) == 0 {
+		return errors.New("snapshot carries a migrationPreflight marker but excludes no plugin")
+	}
+	if preflight.ControlRef == "" || !digestPattern.MatchString(preflight.ControlDigest) {
+		return errors.New("snapshot migrationPreflight marker lacks a calibrated control tag")
+	}
+	if !reflect.DeepEqual(preflight.Excluded, excluded) {
+		return fmt.Errorf("snapshot migrationPreflight excludes %v, but the marked entries are %v", preflight.Excluded, excluded)
+	}
+	return nil
+}
+
+// renderMigrationMarkdown renders the reviewer-facing section embedded in the
+// preparation PR body. It is deterministic: no timestamps, no run identifiers.
+func renderMigrationMarkdown(report MigrationReportFile) string {
+	var out strings.Builder
+	fmt.Fprintf(&out, "## Plugin migration preflight\n\n")
+	fmt.Fprintf(&out, "Read-only public registry sweep of every planned version tag, calibrated against control tag `%s` = `%s` (probe mode `%s`).\n\n", report.ControlRef, report.ControlDigest, report.ProbeMode)
+	blocked := make([]MigrationReportEntry, 0, len(report.Entries))
+	for _, entry := range report.Entries {
+		if entry.State == migrationStateBlocked {
+			blocked = append(blocked, entry)
+		}
+	}
+	if len(report.Entries) == 0 {
+		out.WriteString("No planned version tag is occupied by a different artifact: the promote batch includes every planned plugin.\n")
+		return out.String()
+	}
+	if len(blocked) == 0 {
+		out.WriteString("Dry-run existence sweep: the following planned version tags already exist publicly. Their digests cannot be compared before candidates are built, so no plugin is excluded yet; the non-dry-run sweep classifies each one.\n\n")
+	} else {
+		fmt.Fprintf(&out, "%d planned plugin(s) are in migration mode and are **excluded from this promote batch** (`migration.state=blocked`) until their disposition completes. Every other planned plugin promotes normally.\n\n", len(blocked))
+	}
+	out.WriteString("| Plugin | Planned tag | Existing digest | Planned digest | Source | Recommendation |\n")
+	out.WriteString("| --- | --- | --- | --- | --- | --- |\n")
+	for _, entry := range report.Entries {
+		planned := entry.PlannedDigest
+		if planned == "" {
+			planned = "_(no candidate digest in dry run)_"
+		}
+		recommendation := entry.Recommendation
+		if recommendation == "" {
+			recommendation = "_(classified by the non-dry-run sweep)_"
+		}
+		fmt.Fprintf(&out, "| `%s` | `%s` | `%s` | `%s` | %s | %s |\n", entry.LogicalID, entry.OCIRef, entry.ExistingDigest, planned, entry.SourceComparison, recommendation)
+	}
+	for _, entry := range blocked {
+		fmt.Fprintf(&out, "\n### %s\n\n", entry.LogicalID)
+		fmt.Fprintf(&out, "- existing digest: `%s`\n", entry.ExistingDigest)
+		fmt.Fprintf(&out, "- planned digest: `%s`\n", entry.PlannedDigest)
+		fmt.Fprintf(&out, "- planned input hash: `%s`\n", entry.InputHash)
+		fmt.Fprintf(&out, "- existing annotations: version=%s revision=%s input-hash=%s\n",
+			migrationMarkdownValue(entry.ExistingVersion), migrationMarkdownValue(entry.ExistingRevision), migrationMarkdownValue(entry.ExistingInputHash))
+		fmt.Fprintf(&out, "- source comparison: %s\n", entry.SourceComparison)
+		fmt.Fprintf(&out, "- recommendation: **%s** — %s\n", entry.Recommendation, migrationRemediation(entry))
+	}
+	return out.String()
+}
+
+func migrationMarkdownValue(value string) string {
+	if value == "" {
+		return "_(none)_"
+	}
+	return "`" + value + "`"
+}
+
+func migrationRemediation(entry MigrationReportEntry) string {
+	switch entry.Recommendation {
+	case migrationRecommendDeleteLegacy:
+		return fmt.Sprintf("the public tag carries no pipeline annotation, which is how a pre-pipeline manual artifact presents itself. Missing annotations are evidence, not proof of provenance: a maintainer must first confirm by hand that nothing still depends on the artifact behind `%s`. Only after that confirmation may a registry administrator delete the tag, and the next `prepare-plugin-release` run then plans and promotes this plugin normally.", entry.OCIRef)
+	case migrationRecommendBumpVersion:
+		return fmt.Sprintf("a different managed build already occupies this exact version. Re-run prepare with `version_overrides` setting `%s` to a reviewed stable version greater than `%s`.", entry.LogicalID, entry.Version)
+	case migrationRecommendAdoptPublic:
+		return fmt.Sprintf("the public artifact was built from the same source commit and input hash as this plan, so the published tag already serves these inputs. Leave it published; the next release re-plans `%s` from its input hash.", entry.LogicalID)
+	default:
+		return "unclassified conflict; a maintainer must review the existing artifact before this plugin promotes."
+	}
+}
+
+func commandMigrationPreflight(args []string) error {
+	fs, _, catalog := parseCommon("migration-preflight", args)
+	plan := fs.String("plan", "", "plan path")
+	previous := fs.String("previous", "", "reviewed previous snapshot supplying the control tag")
+	candidateEvidence := fs.String("candidate-evidence", "", "candidate evidence path (omit for a dry-run existence sweep)")
+	output := fs.String("output", "-", "canonical migration report output")
+	markdown := fs.String("markdown", "", "reviewer-facing Markdown report output")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if *plan == "" {
+		return errors.New("--plan is required")
+	}
+	report, err := migrationPreflight(*catalog, *plan, *previous, *candidateEvidence)
+	if err != nil {
+		return err
+	}
+	if *markdown != "" {
+		if err := writeText(*markdown, renderMigrationMarkdown(report)); err != nil {
+			return err
+		}
+	}
+	return writeCanonical(*output, report)
+}

--- a/tools/plugin-release/migration_carry_test.go
+++ b/tools/plugin-release/migration_carry_test.go
@@ -1,0 +1,314 @@
+// Copyright 2026 Higress Authors
+// Licensed under the Apache License, Version 2.0.
+
+package main
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// TestMigrationExclusionSurvivesAnUnrelatedLaterRelease proves a blocked plugin
+// stays excluded, verifiable, and re-derivable in a later release that does not
+// plan it. Release 2.0.1 blocks two of three plugins at commit A; release 2.0.2
+// plans only the third plugin at commit B. The carried exclusions must survive
+// verbatim, the top-level preflight marker must be rebound to the new sweep,
+// verification must still pass at the new commit, and promote must still skip
+// both blocked plugins while promoting the third.
+func TestMigrationExclusionSurvivesAnUnrelatedLaterRelease(t *testing.T) {
+	root, catalogPath, commitA := backfillRepo(t, map[string]string{"demo": "1.0.1", "other": "2.0.0", "third": "1.5.0"})
+	c, _, err := loadCatalog(catalogPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	byID := map[string]Plugin{}
+	for _, p := range c.Plugins {
+		byID[p.LogicalID] = p
+	}
+	catalogSHA := sha256Hex(mustRead(t, catalogPath))
+	digest := func(fill string) string { return "sha256:" + strings.Repeat(fill, 64) }
+	hash := func(commit, version, id string) string {
+		t.Helper()
+		out, err := inputHash(root, commit, version, c, byID[id])
+		if err != nil {
+			t.Fatal(err)
+		}
+		return out
+	}
+	demoHash := hash(commitA, "1.0.1", "demo")
+	otherHash := hash(commitA, "2.0.0", "other")
+	thirdHashA := hash(commitA, "1.5.0", "third")
+
+	// Release 2.0.2 touches only third, so the two excluded plugins keep the
+	// exact inputs their carried entries record.
+	mustWrite(t, filepath.Join(root, byID["third"].SourceDir, "VERSION"), "1.5.1\n")
+	mustRun(t, root, "git", "add", ".")
+	mustRun(t, root, "git", "commit", "-q", "-m", "release third 1.5.1")
+	commitB, err := resolveCommit(root, "HEAD")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if demoHash != hash(commitB, "1.0.1", "demo") || otherHash != hash(commitB, "2.0.0", "other") {
+		t.Fatal("fixture changed an excluded plugin's inputs between the two releases")
+	}
+	thirdHashB := hash(commitB, "1.5.1", "third")
+	if thirdHashA == thirdHashB {
+		t.Fatal("fixture did not change the planned plugin's inputs between the two releases")
+	}
+
+	baseDigest := digest("0")
+	demoDigest := digest("5")
+	otherDigest := digest("6")
+	thirdDigestA := digest("7")
+	thirdDigestB := digest("8")
+	demoLegacy := digest("d")
+	otherLegacy := digest("e")
+	publicRef := func(id, version string) string { return c.Registry + "/" + byID[id].Image + ":" + version }
+	candidateRef := func(id, dgst string) string { return c.Registry + "/candidates/" + id + "@" + dgst }
+	annotated := func(dgst, commit, inputHashValue, version string) ociManifest {
+		return ociManifest{Digest: dgst, Annotations: map[string]string{
+			"org.opencontainers.image.revision": commit,
+			"io.higress.plugin.input-hash":      inputHashValue,
+			"org.opencontainers.image.version":  version,
+		}}
+	}
+	entry := func(id, version, inputHashValue, dgst, commit string) SnapshotEntry {
+		p := byID[id]
+		return SnapshotEntry{LogicalID: id, Implementation: p.Implementation, SourceDir: p.SourceDir, Image: p.Image,
+			Version: version, OCIRef: publicRef(id, version), Digest: dgst, InputHash: inputHashValue, SourceCommit: commit,
+			CandidateRef: candidateRef(id, dgst), ProvenanceMode: "candidate", Consumers: catalogConsumers(c, p)}
+	}
+	planEntry := func(id, previousVersion, version, inputHashValue string) PlanEntry {
+		p := byID[id]
+		return PlanEntry{LogicalID: id, Implementation: p.Implementation, SourceDir: p.SourceDir, Image: p.Image,
+			PreviousVersion: previousVersion, Version: version, InputHash: inputHashValue, ChangedPaths: []string{}}
+	}
+	write := func(name string, value any) string {
+		path := filepath.Join(root, name)
+		if err := writeCanonical(path, value); err != nil {
+			t.Fatal(err)
+		}
+		return path
+	}
+
+	// The reviewed 2.0.0 baseline supplies release A's control tag.
+	baselinePath := write("2.0.0.json", Snapshot{SchemaVersion: snapshotSchemaVersion, GatewayVersion: "2.0.0",
+		SourceCommit: commitA, CatalogSHA256: catalogSHA, PlanID: digest("b"), ProvenanceMode: "candidate",
+		Plugins: []SnapshotEntry{entry("third", "1.4.9", hash(commitA, "1.4.9", "third"), baseDigest, commitA)}})
+
+	// Release 2.0.1: demo's planned tag holds an unannotated legacy artifact and
+	// other's holds a differently built artifact of the very same source, so both
+	// are blocked with different dispositions.
+	planA := Plan{SchemaVersion: planSchemaVersion, GatewayVersion: "2.0.1", SourceCommit: commitA, PreviousRelease: "2.0.0",
+		CatalogSHA256: catalogSHA, Plugins: []PlanEntry{
+			planEntry("demo", "", "1.0.1", demoHash),
+			planEntry("other", "", "2.0.0", otherHash),
+			planEntry("third", "1.4.9", "1.5.0", thirdHashA),
+		}}
+	planA.PlanID = "sha256:" + canonicalObjectHash(planA, true)
+	planAPath := write("plan-2.0.1.json", planA)
+	evidenceAPath := write("evidence-2.0.1.json", CandidateEvidenceFile{Plugins: map[string]CandidateEvidence{
+		"demo":  {CandidateRef: candidateRef("demo", demoDigest), Digest: demoDigest, SourceCommit: commitA, InputHash: demoHash},
+		"other": {CandidateRef: candidateRef("other", otherDigest), Digest: otherDigest, SourceCommit: commitA, InputHash: otherHash},
+		"third": {CandidateRef: candidateRef("third", thirdDigestA), Digest: thirdDigestA, SourceCommit: commitA, InputHash: thirdHashA},
+	}})
+	withManifestResolver(t, migrationResolver(t, map[string]ociManifest{
+		publicRef("third", "1.4.9"): {Digest: baseDigest},
+		publicRef("demo", "1.0.1"):  {Digest: demoLegacy},
+		publicRef("other", "2.0.0"): annotated(otherLegacy, commitA, otherHash, "2.0.0"),
+	}))
+	reportA, err := migrationPreflight(catalogPath, planAPath, baselinePath, evidenceAPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(reportA.Entries) != 2 || reportA.Entries[0].LogicalID != "demo" || reportA.Entries[1].LogicalID != "other" {
+		t.Fatalf("release A did not block both conflicting plugins: %#v", reportA.Entries)
+	}
+	if reportA.Entries[0].Recommendation != migrationRecommendDeleteLegacy || reportA.Entries[1].Recommendation != migrationRecommendAdoptPublic {
+		t.Fatalf("release A recorded unexpected dispositions: %#v", reportA.Entries)
+	}
+	if reportA.Entries[1].SourceComparison != migrationSourceMatch {
+		t.Fatalf("release A mis-compared the annotated artifact's source: %#v", reportA.Entries[1])
+	}
+	reportAPath := write("report-2.0.1.json", reportA)
+	renderedA, err := renderSnapshot(catalogPath, planAPath, baselinePath, evidenceAPath, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	snapshotA, err := applyMigrationReport(renderedA, reportAPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	snapshotAPath := write("2.0.1.json", snapshotA)
+	if snapshotA.MigrationPreflight == nil || snapshotA.MigrationPreflight.ControlRef != publicRef("third", "1.4.9") ||
+		snapshotA.MigrationPreflight.ControlDigest != baseDigest || strings.Join(snapshotA.MigrationPreflight.Excluded, ",") != "demo,other" {
+		t.Fatalf("release A lost its preflight marker: %#v", snapshotA.MigrationPreflight)
+	}
+
+	// Release 2.0.2 plans only third, at a different source commit.
+	planB := Plan{SchemaVersion: planSchemaVersion, GatewayVersion: "2.0.2", SourceCommit: commitB, PreviousRelease: "2.0.1",
+		CatalogSHA256: catalogSHA, Plugins: []PlanEntry{planEntry("third", "1.5.0", "1.5.1", thirdHashB)}}
+	planB.PlanID = "sha256:" + canonicalObjectHash(planB, true)
+	planBPath := write("plan-2.0.2.json", planB)
+	evidenceBPath := write("evidence-2.0.2.json", CandidateEvidenceFile{Plugins: map[string]CandidateEvidence{
+		"third": {CandidateRef: candidateRef("third", thirdDigestB), Digest: thirdDigestB, SourceCommit: commitB, InputHash: thirdHashB},
+	}})
+
+	// The sweep calibrates against third's 2.0.1 tag: the two excluded entries
+	// sort ahead of it and their public tags still serve the legacy artifacts.
+	withManifestResolver(t, migrationResolver(t, map[string]ociManifest{
+		publicRef("third", "1.5.0"): {Digest: thirdDigestA},
+	}))
+	reportB, err := migrationPreflight(catalogPath, planBPath, snapshotAPath, evidenceBPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(reportB.Entries) != 0 {
+		t.Fatalf("release B unexpectedly found a conflict: %#v", reportB.Entries)
+	}
+	if reportB.ControlRef != publicRef("third", "1.5.0") || reportB.ControlDigest != thirdDigestA {
+		t.Fatalf("release B calibrated against an excluded tag: %#v", reportB)
+	}
+	reportBPath := write("report-2.0.2.json", reportB)
+
+	renderedB, err := renderSnapshot(catalogPath, planBPath, snapshotAPath, evidenceBPath, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if renderedB.MigrationPreflight != nil {
+		t.Fatalf("rendering alone must not invent a preflight marker: %#v", renderedB.MigrationPreflight)
+	}
+	if err := requireNoCarriedMigration(renderedB); err == nil || !strings.Contains(err.Error(), "--migration-report is required to rebind them") {
+		t.Fatalf("rendering carried exclusions without a sweep must fail closed: %v", err)
+	}
+	snapshotB, err := applyMigrationReport(renderedB, reportBPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	snapshotBPath := write("2.0.2.json", snapshotB)
+	carried := map[string]SnapshotEntry{}
+	for _, snapshotEntry := range snapshotB.Plugins {
+		carried[snapshotEntry.LogicalID] = snapshotEntry
+	}
+	previous := map[string]SnapshotEntry{}
+	for _, snapshotEntry := range snapshotA.Plugins {
+		previous[snapshotEntry.LogicalID] = snapshotEntry
+	}
+	for _, id := range []string{"demo", "other"} {
+		if !reflect.DeepEqual(previous[id], carried[id]) {
+			t.Fatalf("%s was not carried forward verbatim:\n previous %#v\n carried  %#v", id, previous[id], carried[id])
+		}
+		if carried[id].Migration.SourceCommit != commitA {
+			t.Fatalf("%s lost the source commit of the sweep that decided its disposition: %#v", id, carried[id].Migration)
+		}
+	}
+	// The carried adopt-public disposition is only re-derivable from the commit
+	// that decided it: release B was computed at a different source commit.
+	if carried["other"].Migration.Recommendation != migrationRecommendAdoptPublic || carried["other"].Migration.SourceComparison != migrationSourceMatch {
+		t.Fatalf("carried adopt-public disposition did not survive the later release: %#v", carried["other"].Migration)
+	}
+	if carried["third"].Migration != nil || carried["third"].Version != "1.5.1" || carried["third"].Digest != thirdDigestB {
+		t.Fatalf("the planned plugin was not re-planned by release B: %#v", carried["third"])
+	}
+	if snapshotB.MigrationPreflight == nil || snapshotB.MigrationPreflight.ControlRef != publicRef("third", "1.5.0") ||
+		snapshotB.MigrationPreflight.ControlDigest != thirdDigestA || strings.Join(snapshotB.MigrationPreflight.Excluded, ",") != "demo,other" {
+		t.Fatalf("release B did not rebind the preflight marker to its own sweep: %#v", snapshotB.MigrationPreflight)
+	}
+	if err := validateSnapshotMigration(snapshotB); err != nil {
+		t.Fatalf("carried exclusions did not validate in the later release: %v", err)
+	}
+
+	// Verification of the later release must tolerate both carried exclusions at
+	// the new source commit, in either OCI source mode.
+	untouched := map[string]string{publicRef("demo", "1.0.1"): demoLegacy, publicRef("other", "2.0.0"): otherLegacy}
+	forbidden := make([]string, 0, len(untouched))
+	for ref := range untouched {
+		forbidden = append(forbidden, ref)
+	}
+	sort.Strings(forbidden)
+	candidatesB := map[string]ociManifest{
+		candidateRef("demo", demoDigest):    annotated(demoDigest, commitA, demoHash, "1.0.1"),
+		candidateRef("other", otherDigest):  annotated(otherDigest, commitA, otherHash, "2.0.0"),
+		candidateRef("third", thirdDigestB): annotated(thirdDigestB, commitB, thirdHashB, "1.5.1"),
+	}
+	withManifestResolver(t, neverResolve(t, forbidden, candidatesB))
+	if err := verifySnapshotBindings(root, catalogPath, snapshotBPath, planBPath, snapshotAPath, commitB, commitB, true, "candidate"); err != nil {
+		t.Fatalf("release B verification rejected the carried exclusions: %v", err)
+	}
+	publicB := map[string]ociManifest{publicRef("third", "1.5.1"): annotated(thirdDigestB, commitB, thirdHashB, "1.5.1")}
+	withManifestResolver(t, neverResolve(t, forbidden, publicB))
+	if err := verifySnapshotBindings(root, catalogPath, snapshotBPath, planBPath, snapshotAPath, commitB, commitB, true, "public"); err != nil {
+		t.Fatalf("public verification of release B rejected the carried exclusions: %v", err)
+	}
+
+	// Promote of the later release still skips both blocked plugins and leaves
+	// their divergent public tags untouched.
+	result := runPromotionVersionContractState(t, snapshotDocument(t, snapshotB), map[string]any{
+		publicRef("demo", "1.0.1"):  map[string]any{"digest": demoLegacy, "version": ""},
+		publicRef("other", "2.0.0"): map[string]any{"digest": otherLegacy, "version": ""},
+		publicRef("third", "1.5.0"): map[string]any{"digest": thirdDigestA, "version": ""},
+	})
+	if result.err != nil {
+		t.Fatalf("release B promote failed on carried exclusions: %v\n%s", result.err, result.output)
+	}
+	entries := versionJournalEntries(t, result.journal)
+	if len(entries) != 3 {
+		t.Fatalf("release B journal lost an entry: %#v", entries)
+	}
+	if entries[0]["preflight"] != "migration-excluded" || entries[1]["preflight"] != "migration-excluded" || entries[2]["preflight"] != "absent" {
+		t.Fatalf("release B journal has unexpected states: %#v", entries)
+	}
+	if migration, ok := entries[1]["migration"].(map[string]any); !ok || migration["recommendation"] != migrationRecommendAdoptPublic {
+		t.Fatalf("release B journal did not document the carried disposition: %#v", entries[1])
+	}
+	if !strings.Contains(result.log, "cp "+candidateRef("third", thirdDigestB)+" "+publicRef("third", "1.5.1")) {
+		t.Fatalf("release B did not promote the planned plugin:\n%s", result.log)
+	}
+	for _, ref := range forbidden {
+		if strings.Contains(result.log, ref) {
+			t.Fatalf("release B touched an excluded plugin's public tag %s:\n%s", ref, result.log)
+		}
+		if got := digestOf(t, result.state[ref]); got != untouched[ref] {
+			t.Fatalf("excluded tag %s was mutated from %s to %s", ref, untouched[ref], got)
+		}
+	}
+	if got := digestOf(t, result.state[publicRef("third", "1.5.1")]); got != thirdDigestB {
+		t.Fatalf("release B published the wrong digest for third: %s", got)
+	}
+	if !strings.Contains(result.summary, "Migration preflight excluded from this promote batch: demo, other") {
+		t.Fatalf("release B step summary did not document the carried exclusions: %q", result.summary)
+	}
+}
+
+// neverResolve serves present references and fails the test on any reference an
+// excluded plugin's divergent public tag would require, so a verification that
+// resolves too much cannot pass silently.
+func neverResolve(t *testing.T, forbidden []string, present map[string]ociManifest) func(string) (ociManifest, error) {
+	t.Helper()
+	return func(ref string) (ociManifest, error) {
+		for _, banned := range forbidden {
+			if ref == banned {
+				t.Fatalf("verification resolved an excluded plugin's divergent public tag: %s", ref)
+			}
+		}
+		if manifest, ok := present[ref]; ok {
+			return manifest, nil
+		}
+		return ociManifest{}, notFoundError(ref)
+	}
+}
+
+// snapshotDocument converts a rendered snapshot into the JSON document the
+// workflow shell contracts consume.
+func snapshotDocument(t *testing.T, snapshot Snapshot) map[string]any {
+	t.Helper()
+	var document map[string]any
+	if err := json.Unmarshal(mustJSON(t, snapshot), &document); err != nil {
+		t.Fatal(err)
+	}
+	return document
+}

--- a/tools/plugin-release/migration_promotion_contract_test.go
+++ b/tools/plugin-release/migration_promotion_contract_test.go
@@ -1,0 +1,308 @@
+// Copyright 2026 Higress Authors
+// Licensed under the Apache License, Version 2.0.
+
+package main
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+type versionContractPlugin struct {
+	ID             string
+	Version        string
+	Digest         string
+	CandidateRef   string
+	Provenance     string
+	Blocked        bool
+	ExistingDigest string
+}
+
+type versionContractResult struct {
+	err     error
+	output  string
+	log     string
+	summary string
+	journal map[string]any
+	state   map[string]any
+}
+
+// TestPromotionVersionContractSkipsMigrationExcludedPlugins proves the prepare
+// time exclusion is what keeps a legacy occupied tag from failing the batch: the
+// excluded plugin is neither probed nor copied, its divergent public tag is left
+// untouched, and the remaining plugins promote normally.
+func TestPromotionVersionContractSkipsMigrationExcludedPlugins(t *testing.T) {
+	excluded := versionContractPlugin{
+		ID: "ai-context-limit", Version: "1.0.0", Digest: testDigest("planned"),
+		CandidateRef: "registry.example.invalid/candidates/ai-context-limit@" + testDigest("planned"),
+		Provenance:   "candidate", Blocked: true, ExistingDigest: testDigest("legacy-manual"),
+	}
+	promoted := versionContractPlugin{
+		ID: "ai-agent", Version: "2.0.2", Digest: testDigest("agent"),
+		CandidateRef: "registry.example.invalid/candidates/ai-agent@" + testDigest("agent"),
+		Provenance:   "candidate",
+	}
+	result := runPromotionVersionContract(t, []versionContractPlugin{excluded, promoted})
+	if result.err != nil {
+		t.Fatalf("migration exclusion failed the promote batch: %v\n%s", result.err, result.output)
+	}
+	if strings.Contains(result.output, "immutable tag conflict") {
+		t.Fatalf("excluded plugin still triggered the immutable tag conflict:\n%s", result.output)
+	}
+	if !strings.Contains(result.log, "cp registry.example.invalid/candidates/ai-agent@") {
+		t.Fatalf("the non-excluded plugin was not promoted:\n%s", result.log)
+	}
+	if strings.Contains(result.log, "ai-context-limit") {
+		t.Fatalf("the excluded plugin was probed or copied:\n%s", result.log)
+	}
+	entries := versionJournalEntries(t, result.journal)
+	if len(entries) != 2 {
+		t.Fatalf("version journal lost an entry: %#v", entries)
+	}
+	if entries[0]["preflight"] != "migration-excluded" || entries[1]["preflight"] != "absent" {
+		t.Fatalf("unexpected version journal states: %#v", entries)
+	}
+	migration, ok := entries[0]["migration"].(map[string]any)
+	if !ok || migration["state"] != "blocked" || migration["recommendation"] != "delete-legacy" || migration["existingDigest"] != excluded.ExistingDigest {
+		t.Fatalf("version journal did not document the exclusion: %#v", entries[0])
+	}
+	if !strings.Contains(result.summary, "Migration preflight excluded from this promote batch: ai-context-limit") {
+		t.Fatalf("step summary did not document the exclusion: %q", result.summary)
+	}
+	if got := result.state[excludedRef(excluded)]; digestOf(t, got) != excluded.ExistingDigest {
+		t.Fatalf("the excluded legacy tag was mutated: %#v", got)
+	}
+}
+
+// TestPromotionVersionContractFailsClosedWhenEverythingIsExcluded keeps an empty
+// batch from publishing a degenerate completion marker.
+func TestPromotionVersionContractFailsClosedWhenEverythingIsExcluded(t *testing.T) {
+	result := runPromotionVersionContract(t, []versionContractPlugin{{
+		ID: "only", Version: "1.0.0", Digest: testDigest("planned"),
+		CandidateRef: "registry.example.invalid/candidates/only@" + testDigest("planned"),
+		Provenance:   "candidate", Blocked: true, ExistingDigest: testDigest("legacy"),
+	}})
+	if result.err == nil || !strings.Contains(result.output, "every snapshot plugin is excluded by migration preflight") {
+		t.Fatalf("an entirely excluded batch was promoted: err=%v\n%s", result.err, result.output)
+	}
+	assertNoLatestMutation(t, result.log)
+}
+
+// TestPromotionLatestContractSkipsMigrationExcludedPlugins proves the latest
+// alias of an excluded plugin never moves and that the exclusion is documented
+// on the completion marker journal.
+func TestPromotionLatestContractSkipsMigrationExcludedPlugins(t *testing.T) {
+	result := runPromotionLatestContract(t, false, []latestContractPlugin{
+		{
+			ID: "excluded", Version: "1.0.0", Digest: testDigest("planned"),
+			CurrentDigest: testDigest("legacy-latest"),
+			Blocked:       true, BlockedExistingDigest: testDigest("legacy-manual"),
+		},
+		{ID: "promoted", Version: "2.0.2", Digest: testDigest("agent")},
+	})
+	if result.err != nil {
+		t.Fatalf("latest phase rejected a migration exclusion: %v\n%s", result.err, result.output)
+	}
+	if strings.Contains(result.log, "plugins/excluded") {
+		t.Fatalf("excluded plugin was probed or its latest alias moved:\n%s", result.log)
+	}
+	if strings.Count(result.log, "cp ") != 1 || !strings.Contains(result.log, "plugins/promoted:latest") {
+		t.Fatalf("only the promoted plugin's alias should move:\n%s", result.log)
+	}
+	entries := latestJournalEntries(t, result.journal)
+	if len(entries) != 1 || entries[0]["ref"] != "registry.example.invalid/plugins/promoted:2.0.2" {
+		t.Fatalf("excluded plugin joined the latest preflight entries: %#v", entries)
+	}
+	excludedList, ok := result.journal["migrationExcluded"].([]any)
+	if !ok || len(excludedList) != 1 {
+		t.Fatalf("latest journal did not document the exclusion: %#v", result.journal["migrationExcluded"])
+	}
+	documented, ok := excludedList[0].(map[string]any)
+	if !ok || documented["logicalId"] != "excluded" || documented["recommendation"] != "delete-legacy" || documented["existingDigest"] != testDigest("legacy-manual") {
+		t.Fatalf("latest journal exclusion record is incomplete: %#v", excludedList[0])
+	}
+}
+
+// TestPromotionLatestContractFailsClosedWhenEverythingIsExcluded keeps an empty
+// latest batch from pushing a marker with no entries.
+func TestPromotionLatestContractFailsClosedWhenEverythingIsExcluded(t *testing.T) {
+	result := runPromotionLatestContract(t, false, []latestContractPlugin{{
+		ID: "only", Version: "1.0.0", Digest: testDigest("planned"),
+		Blocked: true, BlockedExistingDigest: testDigest("legacy"),
+	}})
+	if result.err == nil || !strings.Contains(result.output, "no latest alias can move") {
+		t.Fatalf("an entirely excluded batch moved latest: err=%v\n%s", result.err, result.output)
+	}
+	assertNoLatestMutation(t, result.log)
+}
+
+func excludedRef(plugin versionContractPlugin) string {
+	return "registry.example.invalid/plugins/" + plugin.ID + ":" + plugin.Version
+}
+
+func digestOf(t *testing.T, value any) string {
+	t.Helper()
+	record, ok := value.(map[string]any)
+	if !ok {
+		t.Fatalf("registry state entry has unexpected type: %#v", value)
+	}
+	digest, _ := record["digest"].(string)
+	return digest
+}
+
+func versionJournalEntries(t *testing.T, journal map[string]any) []map[string]any {
+	t.Helper()
+	if journal["phase"] != "version-complete" {
+		t.Fatalf("version journal is not complete: %#v", journal)
+	}
+	raw, ok := journal["entries"].([]any)
+	if !ok {
+		t.Fatalf("version journal entries have unexpected type: %#v", journal)
+	}
+	entries := make([]map[string]any, 0, len(raw))
+	for _, entry := range raw {
+		entries = append(entries, entry.(map[string]any))
+	}
+	return entries
+}
+
+// runPromotionVersionContract executes the workflow's version-phase shell
+// contract against a fake ORAS CLI and a file-backed registry, the same way the
+// latest-phase contract is exercised.
+func runPromotionVersionContract(t *testing.T, plugins []versionContractPlugin) versionContractResult {
+	t.Helper()
+	const gateway = "2.2.6"
+	snapshot := map[string]any{"gatewayVersion": gateway, "plugins": []any{}}
+	registry := map[string]any{}
+	for _, plugin := range plugins {
+		ref := excludedRef(plugin)
+		entry := map[string]any{
+			"logicalId": plugin.ID, "ociRef": ref, "digest": plugin.Digest, "version": plugin.Version,
+			"candidateRef": plugin.CandidateRef, "provenanceMode": plugin.Provenance,
+		}
+		if plugin.Blocked {
+			entry["migration"] = map[string]any{
+				"state": "blocked", "existingDigest": plugin.ExistingDigest, "plannedDigest": plugin.Digest,
+				"sourceComparison": "unannotated", "recommendation": "delete-legacy",
+			}
+			registry[ref] = map[string]any{"digest": plugin.ExistingDigest, "version": ""}
+		}
+		snapshot["plugins"] = append(snapshot["plugins"].([]any), entry)
+	}
+	return runPromotionVersionContractState(t, snapshot, registry)
+}
+
+// runPromotionVersionContractState executes the same contract against an
+// arbitrary snapshot document, so a snapshot the real render pipeline produced
+// can be promoted without re-describing it by hand.
+func runPromotionVersionContractState(t *testing.T, snapshot, registry map[string]any) versionContractResult {
+	t.Helper()
+	root := t.TempDir()
+	bin := filepath.Join(root, "bin")
+	if err := os.MkdirAll(bin, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	logPath := filepath.Join(root, "oras.log")
+	statePath := filepath.Join(root, "registry.json")
+	summaryPath := filepath.Join(root, "summary.md")
+
+	gateway, _ := snapshot["gatewayVersion"].(string)
+	if gateway == "" {
+		t.Fatal("snapshot fixture has no gatewayVersion")
+	}
+	snapshotPath := filepath.Join(root, "plugins", "release", "snapshots", gateway+".json")
+	if err := os.MkdirAll(filepath.Dir(snapshotPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(snapshotPath, marshalLatestFixture(t, snapshot), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(statePath, marshalLatestFixture(t, registry), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	writeExecutableFixture(t, filepath.Join(bin, "oras"), `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "$ORAS_LOG"
+if [ "$1 $2" = "manifest fetch" ]; then
+  ref=$3
+  if ! record=$(jq -cer --arg ref "$ref" '.[$ref]' "$ORAS_STATE" 2>/dev/null); then
+    echo "response status code 404: Not Found" >&2
+    exit 1
+  fi
+  if [ "${4:-}" = "--descriptor" ]; then
+    jq -cn --arg digest "$(jq -er .digest <<<"$record")" '{digest:$digest}'
+    exit 0
+  fi
+  jq -cn --arg version "$(jq -r '.version // empty' <<<"$record")" '{annotations:{"org.opencontainers.image.version":$version}}'
+  exit 0
+fi
+if [ "$1" = cp ]; then
+  source=$2
+  destination=$3
+  digest=${source##*@}
+  jq --arg ref "$destination" --arg digest "$digest" '.[$ref]={digest:$digest,version:""}' "$ORAS_STATE" > "$ORAS_STATE.next"
+  mv "$ORAS_STATE.next" "$ORAS_STATE"
+  exit 0
+fi
+echo "unsupported fake oras invocation: $*" >&2
+exit 2
+`)
+
+	descriptorContracts := workflowShellContracts(t, "promote-plugin-release.yaml", "promotion-descriptor-contract")
+	if len(descriptorContracts) != 2 {
+		t.Fatalf("promotion workflow has %d descriptor contracts, want 2", len(descriptorContracts))
+	}
+	versionContract := workflowShellContract(t, "promote-plugin-release.yaml", "promotion-version-contract")
+	script := "set -euo pipefail\n" + descriptorContracts[0] + "\n" + versionContract
+	snapshotSHA := sha256.Sum256([]byte("version-" + root))
+	snapshotSHAHex := hex.EncodeToString(snapshotSHA[:])
+	journalPath := filepath.Join("/tmp", "plugin-release-version-"+snapshotSHAHex+".json")
+	t.Cleanup(func() {
+		_ = os.Remove(journalPath)
+		_ = os.Remove("/tmp/journal.next")
+	})
+	cmd := exec.Command("bash", "-c", script)
+	cmd.Dir = root
+	cmd.Env = append(os.Environ(),
+		"PATH="+bin+":"+os.Getenv("PATH"),
+		"ORAS_LOG="+logPath,
+		"ORAS_STATE="+statePath,
+		"REGISTRY=registry.example.invalid",
+		"SNAPSHOT_PATH="+snapshotPath,
+		"SNAPSHOT_SHA256="+snapshotSHAHex,
+		"GITHUB_STEP_SUMMARY="+summaryPath,
+	)
+	output, runErr := cmd.CombinedOutput()
+	result := versionContractResult{err: runErr, output: string(output)}
+	if logBytes, err := os.ReadFile(logPath); err == nil {
+		result.log = string(logBytes)
+	} else if !os.IsNotExist(err) {
+		t.Fatal(err)
+	}
+	if summary, err := os.ReadFile(summaryPath); err == nil {
+		result.summary = string(summary)
+	} else if !os.IsNotExist(err) {
+		t.Fatal(err)
+	}
+	if journalBytes, err := os.ReadFile(journalPath); err == nil {
+		if err := json.Unmarshal(journalBytes, &result.journal); err != nil {
+			t.Fatalf("decode version journal: %v", err)
+		}
+	} else if runErr == nil {
+		t.Fatalf("successful version contract did not write its journal: %v", err)
+	}
+	if stateBytes, err := os.ReadFile(statePath); err == nil {
+		if err := json.Unmarshal(stateBytes, &result.state); err != nil {
+			t.Fatalf("decode registry state: %v", err)
+		}
+	} else if !os.IsNotExist(err) {
+		t.Fatal(err)
+	}
+	return result
+}

--- a/tools/plugin-release/migration_test.go
+++ b/tools/plugin-release/migration_test.go
@@ -1,0 +1,734 @@
+// Copyright 2026 Higress Authors
+// Licensed under the Apache License, Version 2.0.
+
+package main
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+type migrationFixture struct {
+	root          string
+	catalog       string
+	plan          string
+	previous      string
+	evidence      string
+	planValue     Plan
+	snapshot      Snapshot
+	controlRef    string
+	controlDigest string
+	demoRef       string
+	otherRef      string
+	demoDigest    string
+	otherDigest   string
+	demoInputHash string
+	otherHash     string
+	sourceCommit  string
+}
+
+// migrationFixture builds the pure-JSON inputs the sweep consumes: a catalog, a
+// hashed plan for two plugins, candidate evidence for both, and a reviewed
+// previous snapshot that supplies the known-good control tag. No Git tree is
+// needed because the sweep classifies registry state, not source state.
+func newMigrationFixture(t *testing.T) migrationFixture {
+	t.Helper()
+	root := t.TempDir()
+	sourceCommit := strings.Repeat("a", 40)
+	demoInputHash := "sha256:" + strings.Repeat("b", 64)
+	otherHash := "sha256:" + strings.Repeat("c", 64)
+	demoDigest := "sha256:" + strings.Repeat("d", 64)
+	otherDigest := "sha256:" + strings.Repeat("e", 64)
+	controlDigest := "sha256:" + strings.Repeat("f", 64)
+	c := Catalog{SchemaVersion: 1, Registry: "registry.example", Plugins: []Plugin{
+		{LogicalID: "demo", Implementation: "go", SourceDir: "plugins/wasm-go/extensions/demo", Image: "plugins/demo", ReleaseEligible: true, ArtifactInputs: []string{"plugins/wasm-go/extensions/demo/**"}},
+		{LogicalID: "other", Implementation: "go", SourceDir: "plugins/wasm-go/extensions/other", Image: "plugins/other", ReleaseEligible: true, ArtifactInputs: []string{"plugins/wasm-go/extensions/other/**"}},
+	}}
+	catalogPath := filepath.Join(root, "catalog.json")
+	if err := writeCanonical(catalogPath, c); err != nil {
+		t.Fatal(err)
+	}
+	plan := Plan{SchemaVersion: planSchemaVersion, GatewayVersion: "2.0.1", SourceCommit: sourceCommit,
+		PreviousRelease: "2.0.0", CatalogSHA256: sha256Hex(mustRead(t, catalogPath)), Plugins: []PlanEntry{
+			{LogicalID: "demo", Implementation: "go", SourceDir: "plugins/wasm-go/extensions/demo", Image: "plugins/demo", PreviousVersion: "1.0.0", Version: "1.0.1", InputHash: demoInputHash, ChangedPaths: []string{}},
+			{LogicalID: "other", Implementation: "go", SourceDir: "plugins/wasm-go/extensions/other", Image: "plugins/other", PreviousVersion: "1.9.9", Version: "2.0.0", InputHash: otherHash, ChangedPaths: []string{}},
+		}}
+	plan.PlanID = "sha256:" + canonicalObjectHash(plan, true)
+	planPath := filepath.Join(root, "plan.json")
+	if err := writeCanonical(planPath, plan); err != nil {
+		t.Fatal(err)
+	}
+	previous := Snapshot{SchemaVersion: snapshotSchemaVersion, GatewayVersion: "2.0.0", SourceCommit: sourceCommit,
+		CatalogSHA256: plan.CatalogSHA256, PlanID: plan.PlanID, ProvenanceMode: "candidate", Plugins: []SnapshotEntry{
+			{LogicalID: "demo", Implementation: "go", SourceDir: "plugins/wasm-go/extensions/demo", Image: "plugins/demo", Version: "1.0.0", OCIRef: "registry.example/plugins/demo:1.0.0", Digest: controlDigest, InputHash: demoInputHash, SourceCommit: sourceCommit, CandidateRef: "registry.example/candidates/demo@" + controlDigest, ProvenanceMode: "candidate"},
+		}}
+	previousPath := filepath.Join(root, "previous.json")
+	if err := writeCanonical(previousPath, previous); err != nil {
+		t.Fatal(err)
+	}
+	evidence := CandidateEvidenceFile{Plugins: map[string]CandidateEvidence{
+		"demo":  {CandidateRef: "registry.example/candidates/demo@" + demoDigest, Digest: demoDigest, SourceCommit: sourceCommit, InputHash: demoInputHash},
+		"other": {CandidateRef: "registry.example/candidates/other@" + otherDigest, Digest: otherDigest, SourceCommit: sourceCommit, InputHash: otherHash},
+	}}
+	evidencePath := filepath.Join(root, "evidence.json")
+	if err := writeCanonical(evidencePath, evidence); err != nil {
+		t.Fatal(err)
+	}
+	snapshot, err := renderSnapshot(catalogPath, planPath, "", evidencePath, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return migrationFixture{
+		root: root, catalog: catalogPath, plan: planPath, previous: previousPath, evidence: evidencePath,
+		planValue: plan, snapshot: snapshot,
+		controlRef: "registry.example/plugins/demo:1.0.0", controlDigest: controlDigest,
+		demoRef: "registry.example/plugins/demo:1.0.1", otherRef: "registry.example/plugins/other:2.0.0",
+		demoDigest: demoDigest, otherDigest: otherDigest,
+		demoInputHash: demoInputHash, otherHash: otherHash, sourceCommit: sourceCommit,
+	}
+}
+
+func notFoundError(ref string) error {
+	return &migrationProbeError{message: "Error response from registry: " + ref + ": not found"}
+}
+
+type migrationProbeError struct {
+	message string
+}
+
+func (e *migrationProbeError) Error() string { return e.message }
+
+// migrationResolver serves a fixed registry view: every reference in present is
+// resolved from the map, and every other reference is reported absent with the
+// provider-structured registry error the classifier requires.
+func migrationResolver(t *testing.T, present map[string]ociManifest) func(string) (ociManifest, error) {
+	t.Helper()
+	return func(ref string) (ociManifest, error) {
+		if manifest, ok := present[ref]; ok {
+			return manifest, nil
+		}
+		return ociManifest{}, notFoundError(ref)
+	}
+}
+
+func TestMigrationPreflightBlocksOnlyOccupiedPlannedTags(t *testing.T) {
+	f := newMigrationFixture(t)
+	legacy := "sha256:" + strings.Repeat("1", 64)
+	withManifestResolver(t, migrationResolver(t, map[string]ociManifest{
+		f.controlRef: {Digest: f.controlDigest},
+		f.demoRef:    {Digest: legacy},
+	}))
+	report, err := migrationPreflight(f.catalog, f.plan, f.previous, f.evidence)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if report.ProbeMode != migrationProbeCandidateDigest || report.ControlRef != f.controlRef || report.ControlDigest != f.controlDigest {
+		t.Fatalf("report lost its probe calibration: %#v", report)
+	}
+	if report.GatewayVersion != "2.0.1" || report.SourceCommit != f.sourceCommit || report.PlanID != f.planValue.PlanID || report.Registry != "registry.example" {
+		t.Fatalf("report is not bound to the exact plan: %#v", report)
+	}
+	if len(report.Entries) != 1 {
+		t.Fatalf("absent planned tag must not be reported: %#v", report.Entries)
+	}
+	entry := report.Entries[0]
+	if entry.LogicalID != "demo" || entry.State != migrationStateBlocked || entry.Recommendation != migrationRecommendDeleteLegacy {
+		t.Fatalf("unannotated legacy artifact was not classified as delete-legacy: %#v", entry)
+	}
+	if entry.OCIRef != f.demoRef || entry.ExistingDigest != legacy || entry.PlannedDigest != f.demoDigest || entry.InputHash != f.demoInputHash {
+		t.Fatalf("report entry does not carry the reviewed conflict: %#v", entry)
+	}
+	if entry.SourceComparison != migrationSourceUnannotated || entry.ExistingVersion != "" || entry.ExistingRevision != "" || entry.ExistingInputHash != "" {
+		t.Fatalf("unannotated artifact recorded annotations: %#v", entry)
+	}
+}
+
+func TestMigrationPreflightAcceptsIdenticalPublicDigest(t *testing.T) {
+	f := newMigrationFixture(t)
+	withManifestResolver(t, migrationResolver(t, map[string]ociManifest{
+		f.controlRef: {Digest: f.controlDigest},
+		f.demoRef:    {Digest: f.demoDigest, Annotations: map[string]string{"org.opencontainers.image.version": "1.0.1", "org.opencontainers.image.revision": f.sourceCommit, "io.higress.plugin.input-hash": f.demoInputHash}},
+		f.otherRef:   {Digest: f.otherDigest},
+	}))
+	report, err := migrationPreflight(f.catalog, f.plan, f.previous, f.evidence)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(report.Entries) != 0 {
+		t.Fatalf("a planned tag already serving the planned digest is not a conflict: %#v", report.Entries)
+	}
+}
+
+func TestMigrationPreflightRecommendationsAreDeterministic(t *testing.T) {
+	f := newMigrationFixture(t)
+	annotated := func(version, revision, inputHash string) ociManifest {
+		annotations := map[string]string{}
+		if version != "" {
+			annotations["org.opencontainers.image.version"] = version
+		}
+		if revision != "" {
+			annotations["org.opencontainers.image.revision"] = revision
+		}
+		if inputHash != "" {
+			annotations["io.higress.plugin.input-hash"] = inputHash
+		}
+		return ociManifest{Digest: "sha256:" + strings.Repeat("9", 64), Annotations: annotations}
+	}
+	for _, tc := range []struct {
+		name             string
+		manifest         ociManifest
+		recommendation   string
+		sourceComparison string
+	}{
+		{name: "unannotated-legacy", manifest: annotated("", "", ""), recommendation: migrationRecommendDeleteLegacy, sourceComparison: migrationSourceUnannotated},
+		{name: "same-inputs-managed", manifest: annotated("1.0.1", f.sourceCommit, f.demoInputHash), recommendation: migrationRecommendAdoptPublic, sourceComparison: migrationSourceMatch},
+		{name: "other-managed-build", manifest: annotated("1.0.1", strings.Repeat("7", 40), "sha256:"+strings.Repeat("8", 64)), recommendation: migrationRecommendBumpVersion, sourceComparison: migrationSourceMismatch},
+		{name: "same-source-different-version", manifest: annotated("9.9.9", f.sourceCommit, f.demoInputHash), recommendation: migrationRecommendBumpVersion, sourceComparison: migrationSourceMatch},
+		{name: "partial-annotation", manifest: annotated("1.0.1", "", ""), recommendation: migrationRecommendBumpVersion, sourceComparison: migrationSourceMismatch},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			withManifestResolver(t, migrationResolver(t, map[string]ociManifest{
+				f.controlRef: {Digest: f.controlDigest},
+				f.demoRef:    tc.manifest,
+			}))
+			report, err := migrationPreflight(f.catalog, f.plan, f.previous, f.evidence)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(report.Entries) != 1 {
+				t.Fatalf("expected exactly one conflict: %#v", report.Entries)
+			}
+			entry := report.Entries[0]
+			if entry.Recommendation != tc.recommendation || entry.SourceComparison != tc.sourceComparison {
+				t.Fatalf("recommendation=%q sourceComparison=%q, want %q/%q", entry.Recommendation, entry.SourceComparison, tc.recommendation, tc.sourceComparison)
+			}
+			if want := migrationRecommendationFromRecord(entry.ExistingVersion, entry.ExistingRevision, entry.ExistingInputHash, entry.InputHash, entry.Version, report.SourceCommit); want != entry.Recommendation {
+				t.Fatalf("recorded disposition is not re-derivable: %q != %q", entry.Recommendation, want)
+			}
+		})
+	}
+}
+
+func TestMigrationPreflightFailsClosedOnUncalibratedProbe(t *testing.T) {
+	f := newMigrationFixture(t)
+	for _, tc := range []struct {
+		name     string
+		control  ociManifest
+		err      error
+		contains string
+	}{
+		{name: "digest-mismatch", control: ociManifest{Digest: "sha256:" + strings.Repeat("2", 64)}, contains: "probe is not trustworthy"},
+		{name: "control-absent", err: notFoundError(f.controlRef), contains: "cannot calibrate"},
+		{name: "control-unauthorized", err: &migrationProbeError{message: "unauthorized: authentication required"}, contains: "authorization failure is never absence"},
+		{name: "control-unclassified", err: &migrationProbeError{message: "dial tcp: connection refused"}, contains: "cannot calibrate"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			withManifestResolver(t, func(ref string) (ociManifest, error) {
+				if ref != f.controlRef {
+					t.Fatalf("probe continued past an uncalibrated control tag: %s", ref)
+				}
+				if tc.err != nil {
+					return ociManifest{}, tc.err
+				}
+				return tc.control, nil
+			})
+			_, err := migrationPreflight(f.catalog, f.plan, f.previous, f.evidence)
+			if err == nil || !strings.Contains(err.Error(), tc.contains) {
+				t.Fatalf("uncalibrated probe was accepted: %v", err)
+			}
+		})
+	}
+}
+
+// TestMigrationControlTagSkipsExcludedEntries proves the calibration probe never
+// selects an excluded entry's public tag. That tag still serves the legacy
+// artifact that caused the exclusion, not the digest its snapshot records, so
+// calibrating against it would fail every later prepare — including a release
+// that has nothing to do with the blocked plugin.
+func TestMigrationControlTagSkipsExcludedEntries(t *testing.T) {
+	f := newMigrationFixture(t)
+	entry := func(id, fill, provenance string, blocked bool) SnapshotEntry {
+		digest := "sha256:" + strings.Repeat(fill, 64)
+		out := SnapshotEntry{LogicalID: id, Implementation: "go", SourceDir: "plugins/wasm-go/extensions/" + id,
+			Image: "plugins/" + id, Version: "1.0.0", OCIRef: "registry.example/plugins/" + id + ":1.0.0", Digest: digest,
+			InputHash: digest, SourceCommit: f.sourceCommit, ProvenanceMode: provenance}
+		if provenance == "candidate" {
+			out.CandidateRef = "registry.example/candidates/" + id + "@" + digest
+		}
+		if blocked {
+			out.Migration = &SnapshotMigration{State: migrationStateBlocked, SourceCommit: f.sourceCommit,
+				ExistingDigest: "sha256:" + strings.Repeat("1", 64), PlannedDigest: digest,
+				SourceComparison: migrationSourceUnannotated, Recommendation: migrationRecommendDeleteLegacy}
+		}
+		return out
+	}
+	previousPath := func(name string, entries ...SnapshotEntry) string {
+		path := filepath.Join(f.root, name+".json")
+		previous := Snapshot{SchemaVersion: snapshotSchemaVersion, GatewayVersion: "2.0.0", SourceCommit: f.sourceCommit,
+			CatalogSHA256: f.planValue.CatalogSHA256, PlanID: f.planValue.PlanID, ProvenanceMode: "candidate", Plugins: entries}
+		if err := writeCanonical(path, previous); err != nil {
+			t.Fatal(err)
+		}
+		return path
+	}
+	for _, tc := range []struct {
+		name       string
+		previous   string
+		wantRef    string
+		wantDigest string
+		contains   string
+	}{
+		{
+			// Both excluded entries sort ahead of the only usable control.
+			name:       "skips-excluded-entries",
+			previous:   previousPath("control-skips", entry("aaa", "2", "candidate", true), entry("bbb", "3", "public", true), entry("demo", "f", "candidate", false)),
+			wantRef:    f.controlRef,
+			wantDigest: f.controlDigest,
+		},
+		{
+			name:       "prefers-pipeline-published-tag",
+			previous:   previousPath("control-prefers", entry("adopted", "4", "public", false), entry("built", "5", "candidate", false)),
+			wantRef:    "registry.example/plugins/built:1.0.0",
+			wantDigest: "sha256:" + strings.Repeat("5", 64),
+		},
+		{
+			name:       "falls-back-to-adopted-public-tag",
+			previous:   previousPath("control-adopted", entry("adopted", "4", "public", false)),
+			wantRef:    "registry.example/plugins/adopted:1.0.0",
+			wantDigest: "sha256:" + strings.Repeat("4", 64),
+		},
+		{
+			name:     "every-entry-excluded",
+			previous: previousPath("control-all-blocked", entry("aaa", "2", "candidate", true), entry("bbb", "3", "public", true)),
+			contains: "cannot calibrate its probe",
+		},
+		{
+			name:     "no-published-provenance",
+			previous: previousPath("control-unpublished", entry("local", "6", "local", false)),
+			contains: "cannot calibrate its probe",
+		},
+		{
+			name:     "no-previous-snapshot",
+			contains: "requires the reviewed previous snapshot",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ref, digest, err := migrationControlTag(tc.previous)
+			if tc.contains != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.contains) {
+					t.Fatalf("control tag selection did not fail closed: %v", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if ref != tc.wantRef || digest != tc.wantDigest {
+				t.Fatalf("control tag = %s @ %s, want %s @ %s", ref, digest, tc.wantRef, tc.wantDigest)
+			}
+		})
+	}
+
+	// The sweep must calibrate against the surviving control and never probe an
+	// excluded entry's tag, while still classifying a real conflict.
+	sweep := previousPath("control-sweep", entry("aaa", "2", "candidate", true), entry("bbb", "3", "public", true), entry("demo", "f", "candidate", false))
+	legacy := "sha256:" + strings.Repeat("1", 64)
+	var probed []string
+	withManifestResolver(t, func(ref string) (ociManifest, error) {
+		probed = append(probed, ref)
+		if ref == f.controlRef {
+			return ociManifest{Digest: f.controlDigest}, nil
+		}
+		if ref == f.demoRef {
+			return ociManifest{Digest: legacy}, nil
+		}
+		return ociManifest{}, notFoundError(ref)
+	})
+	report, err := migrationPreflight(f.catalog, f.plan, sweep, f.evidence)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if report.ControlRef != f.controlRef || report.ControlDigest != f.controlDigest {
+		t.Fatalf("sweep calibrated against the wrong control: %#v", report)
+	}
+	if len(report.Entries) != 1 || report.Entries[0].LogicalID != "demo" || report.Entries[0].Recommendation != migrationRecommendDeleteLegacy {
+		t.Fatalf("sweep lost the conflict it still had to classify: %#v", report.Entries)
+	}
+	for _, ref := range probed {
+		if strings.Contains(ref, "/aaa:") || strings.Contains(ref, "/bbb:") {
+			t.Fatalf("sweep probed an excluded entry's public tag: %s", ref)
+		}
+	}
+}
+
+func TestMigrationPreflightAuthorizationFailureIsNeverAbsence(t *testing.T) {
+	f := newMigrationFixture(t)
+	withManifestResolver(t, func(ref string) (ociManifest, error) {
+		if ref == f.controlRef {
+			return ociManifest{Digest: f.controlDigest}, nil
+		}
+		return ociManifest{}, &migrationProbeError{message: "denied: requested access to the resource is denied"}
+	})
+	_, err := migrationPreflight(f.catalog, f.plan, f.previous, f.evidence)
+	if err == nil || !strings.Contains(err.Error(), "authorization failure is never absence") {
+		t.Fatalf("authorization failure was treated as absence: %v", err)
+	}
+}
+
+func TestMigrationPreflightWithoutCandidatesOnlySuspects(t *testing.T) {
+	f := newMigrationFixture(t)
+	withManifestResolver(t, migrationResolver(t, map[string]ociManifest{
+		f.controlRef: {Digest: f.controlDigest},
+		f.demoRef:    {Digest: "sha256:" + strings.Repeat("1", 64)},
+	}))
+	report, err := migrationPreflight(f.catalog, f.plan, f.previous, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if report.ProbeMode != migrationProbeExistenceOnly {
+		t.Fatalf("dry-run sweep reported probe mode %q", report.ProbeMode)
+	}
+	if len(report.Entries) != 1 {
+		t.Fatalf("expected the occupied planned tag to be reported: %#v", report.Entries)
+	}
+	entry := report.Entries[0]
+	if entry.State != migrationStateSuspected || entry.Recommendation != "" || entry.PlannedDigest != "" {
+		t.Fatalf("existence-only sweep blocked a plugin: %#v", entry)
+	}
+	// A dry-run report can never enter a snapshot.
+	reportPath := filepath.Join(f.root, "report.json")
+	if err := writeCanonical(reportPath, report); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := applyMigrationReport(f.snapshot, reportPath); err == nil || !strings.Contains(err.Error(), migrationProbeCandidateDigest) {
+		t.Fatalf("existence-only report was bound into a snapshot: %v", err)
+	}
+	if markdown := renderMigrationMarkdown(report); !strings.Contains(markdown, "Dry-run existence sweep") || strings.Contains(markdown, "**delete-legacy**") {
+		t.Fatalf("dry-run markdown misreported the sweep:\n%s", markdown)
+	}
+}
+
+func TestMigrationPreflightRejectsIncompleteCandidateEvidence(t *testing.T) {
+	f := newMigrationFixture(t)
+	evidence := CandidateEvidenceFile{Plugins: map[string]CandidateEvidence{
+		"demo": {CandidateRef: "registry.example/candidates/demo@" + f.demoDigest, Digest: f.demoDigest, SourceCommit: f.sourceCommit, InputHash: f.demoInputHash},
+	}}
+	path := filepath.Join(f.root, "partial-evidence.json")
+	if err := writeCanonical(path, evidence); err != nil {
+		t.Fatal(err)
+	}
+	withManifestResolver(t, migrationResolver(t, map[string]ociManifest{f.controlRef: {Digest: f.controlDigest}}))
+	if _, err := migrationPreflight(f.catalog, f.plan, f.previous, path); err == nil || !strings.Contains(err.Error(), "no matching candidate digest") {
+		t.Fatalf("sweep accepted a plan entry without candidate evidence: %v", err)
+	}
+}
+
+func TestMigrationPreflightRejectsUnhashedOrStalePlan(t *testing.T) {
+	f := newMigrationFixture(t)
+	withManifestResolver(t, migrationResolver(t, map[string]ociManifest{f.controlRef: {Digest: f.controlDigest}}))
+	edited := f.planValue
+	edited.Plugins[0].Version = "1.0.2"
+	path := filepath.Join(f.root, "edited-plan.json")
+	if err := writeCanonical(path, edited); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := migrationPreflight(f.catalog, path, f.previous, f.evidence); err == nil || !strings.Contains(err.Error(), "planId does not match canonical plan content") {
+		t.Fatalf("sweep accepted a plan edited after it was hashed: %v", err)
+	}
+	if _, err := migrationPreflight(f.catalog, f.plan, "", f.evidence); err == nil || !strings.Contains(err.Error(), "calibrate") {
+		t.Fatalf("sweep ran without a control tag: %v", err)
+	}
+}
+
+func TestApplyMigrationReportBindsExclusionIntoSnapshot(t *testing.T) {
+	f := newMigrationFixture(t)
+	legacy := "sha256:" + strings.Repeat("1", 64)
+	withManifestResolver(t, migrationResolver(t, map[string]ociManifest{
+		f.controlRef: {Digest: f.controlDigest},
+		f.demoRef:    {Digest: legacy},
+	}))
+	report, err := migrationPreflight(f.catalog, f.plan, f.previous, f.evidence)
+	if err != nil {
+		t.Fatal(err)
+	}
+	reportPath := filepath.Join(f.root, "report.json")
+	if err := writeCanonical(reportPath, report); err != nil {
+		t.Fatal(err)
+	}
+	snapshot, err := applyMigrationReport(f.snapshot, reportPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if snapshot.MigrationPreflight == nil || len(snapshot.MigrationPreflight.Excluded) != 1 || snapshot.MigrationPreflight.Excluded[0] != "demo" {
+		t.Fatalf("snapshot lost its migration preflight marker: %#v", snapshot.MigrationPreflight)
+	}
+	if snapshot.MigrationPreflight.ControlRef != f.controlRef || snapshot.MigrationPreflight.ControlDigest != f.controlDigest {
+		t.Fatalf("snapshot marker dropped the probe calibration: %#v", snapshot.MigrationPreflight)
+	}
+	byID := map[string]SnapshotEntry{}
+	for _, entry := range snapshot.Plugins {
+		byID[entry.LogicalID] = entry
+	}
+	if byID["demo"].Migration == nil || byID["demo"].Migration.Recommendation != migrationRecommendDeleteLegacy || byID["demo"].Migration.ExistingDigest != legacy || byID["demo"].Migration.PlannedDigest != f.demoDigest {
+		t.Fatalf("blocked entry lost its migration state: %#v", byID["demo"].Migration)
+	}
+	if byID["other"].Migration != nil {
+		t.Fatalf("clear entry was marked: %#v", byID["other"].Migration)
+	}
+	if err := validateSnapshotMigration(snapshot); err != nil {
+		t.Fatalf("rendered migration binding did not validate: %v", err)
+	}
+	// An empty report leaves the snapshot byte-identical to the all-green path.
+	empty := report
+	empty.Entries = []MigrationReportEntry{}
+	emptyPath := filepath.Join(f.root, "empty-report.json")
+	if err := writeCanonical(emptyPath, empty); err != nil {
+		t.Fatal(err)
+	}
+	unchanged, err := applyMigrationReport(f.snapshot, emptyPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if unchanged.MigrationPreflight != nil {
+		t.Fatalf("empty report added a marker: %#v", unchanged.MigrationPreflight)
+	}
+	wantPath := filepath.Join(f.root, "want.json")
+	gotPath := filepath.Join(f.root, "got.json")
+	if err := writeCanonical(wantPath, f.snapshot); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeCanonical(gotPath, unchanged); err != nil {
+		t.Fatal(err)
+	}
+	if string(mustRead(t, wantPath)) != string(mustRead(t, gotPath)) {
+		t.Fatal("an all-green sweep changed the snapshot bytes")
+	}
+	if markdown := renderMigrationMarkdown(report); !strings.Contains(markdown, "**delete-legacy**") || !strings.Contains(markdown, legacy) || !strings.Contains(markdown, f.demoDigest) {
+		t.Fatalf("migration report markdown lost the conflict detail:\n%s", markdown)
+	}
+	if markdown := renderMigrationMarkdown(empty); !strings.Contains(markdown, "No planned version tag is occupied") {
+		t.Fatalf("all-green markdown misreported the sweep:\n%s", markdown)
+	}
+}
+
+func TestApplyMigrationReportRejectsInconsistentReports(t *testing.T) {
+	f := newMigrationFixture(t)
+	legacy := "sha256:" + strings.Repeat("1", 64)
+	withManifestResolver(t, migrationResolver(t, map[string]ociManifest{
+		f.controlRef: {Digest: f.controlDigest},
+		f.demoRef:    {Digest: legacy},
+	}))
+	report, err := migrationPreflight(f.catalog, f.plan, f.previous, f.evidence)
+	if err != nil {
+		t.Fatal(err)
+	}
+	base := report.Entries[0]
+	for _, tc := range []struct {
+		name     string
+		mutate   func(*MigrationReportFile)
+		contains string
+	}{
+		{name: "wrong-gateway", mutate: func(r *MigrationReportFile) { r.GatewayVersion = "2.0.2" }, contains: "immutable provenance differ"},
+		{name: "wrong-plan-id", mutate: func(r *MigrationReportFile) { r.PlanID = "sha256:" + strings.Repeat("0", 64) }, contains: "immutable provenance differ"},
+		{name: "no-control", mutate: func(r *MigrationReportFile) { r.ControlDigest = "" }, contains: "calibrated control tag"},
+		{name: "unknown-plugin", mutate: func(r *MigrationReportFile) {
+			r.Entries = []MigrationReportEntry{reportEntryWith(base, func(e *MigrationReportEntry) { e.LogicalID = "ghost" })}
+		}, contains: "does not carry"},
+		{name: "unsorted", mutate: func(r *MigrationReportFile) {
+			other := reportEntryWith(base, func(e *MigrationReportEntry) { e.LogicalID = "aaa" })
+			r.Entries = []MigrationReportEntry{base, other}
+		}, contains: "not sorted and unique"},
+		{name: "hand-edited-recommendation", mutate: func(r *MigrationReportFile) {
+			r.Entries = []MigrationReportEntry{reportEntryWith(base, func(e *MigrationReportEntry) { e.Recommendation = migrationRecommendBumpVersion })}
+		}, contains: "recorded annotations require"},
+		{name: "planned-digest-drift", mutate: func(r *MigrationReportFile) {
+			r.Entries = []MigrationReportEntry{reportEntryWith(base, func(e *MigrationReportEntry) { e.PlannedDigest = legacy })}
+		}, contains: "identical existing and planned digest"},
+		{name: "reference-drift", mutate: func(r *MigrationReportFile) {
+			r.Entries = []MigrationReportEntry{reportEntryWith(base, func(e *MigrationReportEntry) { e.OCIRef = "registry.example/plugins/demo:9.9.9" })}
+		}, contains: "planned snapshot reference"},
+		{name: "suspected-state", mutate: func(r *MigrationReportFile) {
+			r.Entries = []MigrationReportEntry{reportEntryWith(base, func(e *MigrationReportEntry) { e.State = migrationStateSuspected; e.Recommendation = "" })}
+		}, contains: "only blocked entries may be bound"},
+		{name: "unsupported-recommendation", mutate: func(r *MigrationReportFile) {
+			r.Entries = []MigrationReportEntry{reportEntryWith(base, func(e *MigrationReportEntry) { e.Recommendation = "delete-everything" })}
+		}, contains: "unsupported recommendation"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			mutated := report
+			mutated.Entries = append([]MigrationReportEntry(nil), report.Entries...)
+			tc.mutate(&mutated)
+			path := filepath.Join(f.root, "mutated.json")
+			if err := writeCanonical(path, mutated); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := applyMigrationReport(f.snapshot, path); err == nil || !strings.Contains(err.Error(), tc.contains) {
+				t.Fatalf("inconsistent migration report was accepted: %v", err)
+			}
+		})
+	}
+}
+
+func reportEntryWith(entry MigrationReportEntry, mutate func(*MigrationReportEntry)) MigrationReportEntry {
+	out := entry
+	mutate(&out)
+	return out
+}
+
+func TestValidateSnapshotMigrationRequiresConsistentMarkers(t *testing.T) {
+	f := newMigrationFixture(t)
+	legacy := "sha256:" + strings.Repeat("1", 64)
+	withManifestResolver(t, migrationResolver(t, map[string]ociManifest{
+		f.controlRef: {Digest: f.controlDigest},
+		f.demoRef:    {Digest: legacy},
+	}))
+	report, err := migrationPreflight(f.catalog, f.plan, f.previous, f.evidence)
+	if err != nil {
+		t.Fatal(err)
+	}
+	reportPath := filepath.Join(f.root, "report.json")
+	if err := writeCanonical(reportPath, report); err != nil {
+		t.Fatal(err)
+	}
+	snapshot, err := applyMigrationReport(f.snapshot, reportPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mutate := func(fn func(*Snapshot)) string {
+		changed := snapshot
+		changed.Plugins = append([]SnapshotEntry(nil), snapshot.Plugins...)
+		for i := range changed.Plugins {
+			if changed.Plugins[i].Migration != nil {
+				migration := *changed.Plugins[i].Migration
+				changed.Plugins[i].Migration = &migration
+			}
+		}
+		if changed.MigrationPreflight != nil {
+			preflight := *changed.MigrationPreflight
+			changed.MigrationPreflight = &preflight
+		}
+		fn(&changed)
+		path := filepath.Join(f.root, "mutated-snapshot.json")
+		if err := writeCanonical(path, changed); err != nil {
+			t.Fatal(err)
+		}
+		return path
+	}
+	for _, tc := range []struct {
+		name     string
+		mutate   func(*Snapshot)
+		contains string
+	}{
+		{name: "dropped-preflight-marker", mutate: func(s *Snapshot) { s.MigrationPreflight = nil }, contains: "carries no migrationPreflight marker"},
+		{name: "dropped-entry-marker", mutate: func(s *Snapshot) { s.Plugins[0].Migration = nil }, contains: "excludes no plugin"},
+		{name: "excluded-list-drift", mutate: func(s *Snapshot) { s.MigrationPreflight.Excluded = []string{"demo", "other"} }, contains: "but the marked entries are"},
+		{name: "planned-digest-drift", mutate: func(s *Snapshot) { s.Plugins[0].Migration.PlannedDigest = legacy }, contains: "identical existing and planned digest"},
+		{name: "own-digest-drift", mutate: func(s *Snapshot) { s.Plugins[0].Migration.PlannedDigest = "sha256:" + strings.Repeat("3", 64) }, contains: "its own snapshot digest"},
+		{name: "hand-edited-disposition", mutate: func(s *Snapshot) { s.Plugins[0].Migration.Recommendation = migrationRecommendAdoptPublic }, contains: "not re-derivable"},
+		{name: "unsupported-state", mutate: func(s *Snapshot) { s.Plugins[0].Migration.State = "pending" }, contains: "unsupported migration state"},
+		{name: "dropped-control", mutate: func(s *Snapshot) { s.MigrationPreflight.ControlRef = "" }, contains: "calibrated control tag"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			path := mutate(tc.mutate)
+			var changed Snapshot
+			if _, err := readJSON(path, &changed); err != nil {
+				t.Fatal(err)
+			}
+			if err := validateSnapshotMigration(changed); err == nil || !strings.Contains(err.Error(), tc.contains) {
+				t.Fatalf("inconsistent migration binding was accepted: %v", err)
+			}
+		})
+	}
+	if err := validateSnapshotMigration(f.snapshot); err != nil {
+		t.Fatalf("all-green snapshot failed migration validation: %v", err)
+	}
+}
+
+// TestVerifySnapshotToleratesMigrationExclusion proves the exclusion survives
+// verification: the known-divergent public tag is never resolved, the candidate
+// for the same entry still is, and dropping either half of the marker fails
+// closed.
+func TestVerifySnapshotToleratesMigrationExclusion(t *testing.T) {
+	root := t.TempDir()
+	mustRun(t, root, "git", "init", "-q")
+	mustRun(t, root, "git", "config", "user.name", "test")
+	mustRun(t, root, "git", "config", "user.email", "test@example.com")
+	mustWrite(t, filepath.Join(root, "plugins/wasm-go/extensions/demo/main.go"), "package main\n")
+	mustWrite(t, filepath.Join(root, "plugins/wasm-go/extensions/demo/VERSION"), "1.0.0\n")
+	mustWrite(t, filepath.Join(root, "plugins/wasm-rust/extensions/.keep"), "")
+	mustRun(t, root, "git", "add", ".")
+	mustRun(t, root, "git", "commit", "-q", "-m", "source")
+	commit, _ := resolveCommit(root, "HEAD")
+	c := Catalog{SchemaVersion: 1, Registry: "registry.example", Plugins: []Plugin{{LogicalID: "demo", Implementation: "go", SourceDir: "plugins/wasm-go/extensions/demo", Image: "plugins/demo", ReleaseEligible: true, ArtifactInputs: []string{"plugins/wasm-go/extensions/demo/**"}}}}
+	catalogPath := filepath.Join(root, "catalog.json")
+	if err := writeCanonical(catalogPath, c); err != nil {
+		t.Fatal(err)
+	}
+	hash, err := inputHash(root, commit, "1.0.0", c, c.Plugins[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	planned := "sha256:" + strings.Repeat("d", 64)
+	legacy := "sha256:" + strings.Repeat("1", 64)
+	publicRef := "registry.example/plugins/demo:1.0.0"
+	snapshot := Snapshot{SchemaVersion: snapshotSchemaVersion, GatewayVersion: "2.0.0", SourceCommit: commit,
+		CatalogSHA256: sha256Hex(mustRead(t, catalogPath)), PlanID: "sha256:" + strings.Repeat("0", 64), ProvenanceMode: "candidate",
+		MigrationPreflight: &SnapshotMigrationPreflight{ControlRef: "registry.example/plugins/carried:1.0.0", ControlDigest: legacy, Excluded: []string{"demo"}},
+		Plugins: []SnapshotEntry{{LogicalID: "demo", Implementation: "go", SourceDir: c.Plugins[0].SourceDir, Image: c.Plugins[0].Image,
+			Version: "1.0.0", OCIRef: publicRef, Digest: planned, InputHash: hash, SourceCommit: commit,
+			CandidateRef: "registry.example/candidates/demo@" + planned, ProvenanceMode: "candidate",
+			Migration: &SnapshotMigration{State: migrationStateBlocked, SourceCommit: commit, ExistingDigest: legacy, PlannedDigest: planned, SourceComparison: migrationSourceUnannotated, Recommendation: migrationRecommendDeleteLegacy}}}}
+	snapshotPath := filepath.Join(root, "snapshot.json")
+	if err := writeCanonical(snapshotPath, snapshot); err != nil {
+		t.Fatal(err)
+	}
+	candidateRef := snapshot.Plugins[0].CandidateRef
+	withManifestResolver(t, func(ref string) (ociManifest, error) {
+		if ref == publicRef {
+			t.Fatalf("verification resolved the known-divergent public tag of an excluded plugin: %s", ref)
+		}
+		if ref != candidateRef {
+			t.Fatalf("verification resolved an unexpected reference: %s", ref)
+		}
+		return ociManifest{Digest: planned, Annotations: map[string]string{"org.opencontainers.image.revision": commit, "io.higress.plugin.input-hash": hash, "org.opencontainers.image.version": "1.0.0"}}, nil
+	})
+	if err := verifySnapshot(root, catalogPath, snapshotPath, commit, commit, true, "candidate"); err != nil {
+		t.Fatalf("candidate verification rejected a migration exclusion: %v", err)
+	}
+	withManifestResolver(t, func(ref string) (ociManifest, error) {
+		if ref == publicRef {
+			t.Fatalf("public verification resolved the excluded plugin's divergent tag: %s", ref)
+		}
+		t.Fatalf("public verification resolved an unexpected reference: %s", ref)
+		return ociManifest{}, nil
+	})
+	if err := verifySnapshot(root, catalogPath, snapshotPath, commit, commit, true, "public"); err != nil {
+		t.Fatalf("public verification did not tolerate the recorded exclusion: %v", err)
+	}
+	for _, tc := range []struct {
+		name     string
+		mutate   func(*Snapshot)
+		contains string
+	}{
+		{name: "dropped-marker", mutate: func(s *Snapshot) { s.MigrationPreflight = nil }, contains: "carries no migrationPreflight marker"},
+		{name: "dropped-exclusion", mutate: func(s *Snapshot) { s.Plugins[0].Migration = nil }, contains: "excludes no plugin"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			changed := snapshot
+			changed.Plugins = append([]SnapshotEntry(nil), snapshot.Plugins...)
+			migration := *snapshot.Plugins[0].Migration
+			changed.Plugins[0].Migration = &migration
+			preflight := *snapshot.MigrationPreflight
+			changed.MigrationPreflight = &preflight
+			tc.mutate(&changed)
+			path := filepath.Join(root, "tampered.json")
+			if err := writeCanonical(path, changed); err != nil {
+				t.Fatal(err)
+			}
+			if err := verifySnapshot(root, catalogPath, path, commit, commit, false, "candidate"); err == nil || !strings.Contains(err.Error(), tc.contains) {
+				t.Fatalf("verification accepted an inconsistent migration binding: %v", err)
+			}
+		})
+	}
+}

--- a/tools/plugin-release/model.go
+++ b/tools/plugin-release/model.go
@@ -20,6 +20,31 @@ const (
 	catalogSchemaVersion  = 1
 	planSchemaVersion     = 1
 	snapshotSchemaVersion = 1
+
+	migrationReportSchemaVersion = 1
+)
+
+// Migration preflight vocabulary. A planned public version tag that is already
+// occupied by a different artifact is classified at prepare time instead of
+// hard-failing the promote batch later.
+const (
+	// migrationProbeCandidateDigest compares the public tag against the built
+	// candidate digest and can block a plugin. migrationProbeExistenceOnly is
+	// the dry-run rehearsal: it reports occupied planned tags without a
+	// candidate digest to compare, so it can never block or enter a snapshot.
+	migrationProbeCandidateDigest = "candidate-digest"
+	migrationProbeExistenceOnly   = "existence-only"
+
+	migrationStateBlocked   = "blocked"
+	migrationStateSuspected = "suspected"
+
+	migrationRecommendDeleteLegacy = "delete-legacy"
+	migrationRecommendBumpVersion  = "bump-version"
+	migrationRecommendAdoptPublic  = "adopt-public"
+
+	migrationSourceMatch       = "match"
+	migrationSourceMismatch    = "mismatch"
+	migrationSourceUnannotated = "unannotated"
 )
 
 type Catalog struct {
@@ -159,6 +184,41 @@ type BootstrapEvidence struct {
 	Digest    string `json:"digest,omitempty"`
 }
 
+// MigrationReportFile is the prepare-time public registry sweep. It records the
+// control tag the probe was calibrated against, so a reviewer can see that the
+// present/absent classifications came from a method proven against a known-good
+// public artifact rather than from an unvalidated lookup.
+type MigrationReportFile struct {
+	SchemaVersion  int                    `json:"schemaVersion"`
+	GatewayVersion string                 `json:"gatewayVersion"`
+	SourceCommit   string                 `json:"sourceCommit"`
+	PlanID         string                 `json:"planId"`
+	Registry       string                 `json:"registry"`
+	ProbeMode      string                 `json:"probeMode"`
+	ControlRef     string                 `json:"controlRef"`
+	ControlDigest  string                 `json:"controlDigest"`
+	Entries        []MigrationReportEntry `json:"entries"`
+}
+
+// MigrationReportEntry describes one planned public version tag that is already
+// occupied. PlannedDigest is empty in existence-only mode, which is also the
+// only mode that reports State "suspected"; a suspected entry never blocks a
+// plugin and never enters a snapshot.
+type MigrationReportEntry struct {
+	LogicalID         string `json:"logicalId"`
+	Version           string `json:"version"`
+	OCIRef            string `json:"ociRef"`
+	ExistingDigest    string `json:"existingDigest"`
+	PlannedDigest     string `json:"plannedDigest,omitempty"`
+	InputHash         string `json:"inputHash"`
+	ExistingVersion   string `json:"existingVersion,omitempty"`
+	ExistingRevision  string `json:"existingRevision,omitempty"`
+	ExistingInputHash string `json:"existingInputHash,omitempty"`
+	SourceComparison  string `json:"sourceComparison"`
+	State             string `json:"state"`
+	Recommendation    string `json:"recommendation,omitempty"`
+}
+
 type Snapshot struct {
 	SchemaVersion   int    `json:"schemaVersion"`
 	GatewayVersion  string `json:"gatewayVersion"`
@@ -172,7 +232,46 @@ type Snapshot struct {
 	// committed bootstrap evidence the preparation PR must carry. Validation
 	// never infers bootstrap mode from a missing previous-snapshot file.
 	BootstrapEvidence *SnapshotBootstrapEvidence `json:"bootstrapEvidence,omitempty"`
-	Plugins           []SnapshotEntry            `json:"plugins"`
+	// MigrationPreflight records the prepare-time public registry sweep that
+	// excluded one or more planned plugins from this release batch. It is
+	// present exactly when some entry carries a migration marker, and its
+	// control tag proves the sweep's probe method was validated against a
+	// known-good public artifact before any classification was trusted.
+	MigrationPreflight *SnapshotMigrationPreflight `json:"migrationPreflight,omitempty"`
+	Plugins            []SnapshotEntry             `json:"plugins"`
+}
+
+// SnapshotMigrationPreflight binds the excluded set to the calibrated sweep.
+// Excluded lists every entry this snapshot keeps out of the promote batch,
+// whether this release's sweep blocked it or an earlier release did and this
+// snapshot carries the exclusion forward.
+type SnapshotMigrationPreflight struct {
+	ControlRef    string   `json:"controlRef"`
+	ControlDigest string   `json:"controlDigest"`
+	Excluded      []string `json:"excluded"`
+}
+
+// SnapshotMigration marks an entry that the promote batch must skip: the
+// planned public version tag is already occupied by a different artifact, so
+// publishing this entry would either fail the immutable-tag preflight or
+// overwrite an artifact nobody reviewed. The entry stays in the snapshot (it is
+// still the authoritative record of the planned version and candidate digest)
+// and is carried forward verbatim until a later release re-plans the plugin
+// after its disposition completes.
+type SnapshotMigration struct {
+	State string `json:"state"`
+	// SourceCommit is the plan source commit of the sweep that decided this
+	// disposition. The recommendation compares the occupant's annotations with
+	// that commit, so recording it keeps a carried exclusion re-derivable — and
+	// therefore still valid — in every later release.
+	SourceCommit      string `json:"sourceCommit"`
+	ExistingDigest    string `json:"existingDigest"`
+	PlannedDigest     string `json:"plannedDigest"`
+	ExistingVersion   string `json:"existingVersion,omitempty"`
+	ExistingRevision  string `json:"existingRevision,omitempty"`
+	ExistingInputHash string `json:"existingInputHash,omitempty"`
+	SourceComparison  string `json:"sourceComparison"`
+	Recommendation    string `json:"recommendation"`
 }
 
 // SnapshotBootstrapEvidence binds the first managed release to the exact
@@ -201,8 +300,13 @@ type SnapshotEntry struct {
 	// version tag from the candidate; the marker records bootstrap provenance
 	// and migration state and is not an exclusion from the serialized
 	// monotonic latest policy.
-	Backfill  bool            `json:"backfill,omitempty"`
-	Consumers PluginConsumers `json:"consumers,omitempty"`
+	Backfill bool `json:"backfill,omitempty"`
+	// Migration marks an entry excluded from this release's promote batch by
+	// the prepare-time registry sweep. Promotion skips it in both the version
+	// and latest phases and journals the exclusion; verification tolerates the
+	// divergent public tag it records.
+	Migration *SnapshotMigration `json:"migration,omitempty"`
+	Consumers PluginConsumers    `json:"consumers,omitempty"`
 }
 
 func cloneConsumers(in PluginConsumers) PluginConsumers {

--- a/tools/plugin-release/preparation_pr_contract_test.go
+++ b/tools/plugin-release/preparation_pr_contract_test.go
@@ -1,0 +1,197 @@
+// Copyright 2026 Higress Authors
+// Licensed under the Apache License, Version 2.0.
+
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestPreparationPRContractLabelsAndReports executes the preparation PR
+// publication block against a stubbed gh CLI. The release label is what
+// authorizes promote, so it must be applied on both the create and the update
+// path, created only when missing, and its absence must fail the step. An
+// all-green sweep must leave the PR body byte-identical to today's body.
+func TestPreparationPRContractLabelsAndReports(t *testing.T) {
+	const gateway = "2.2.6"
+	const baseBody = "Immutable candidate snapshot; review VERSION edits and digest provenance."
+	report := MigrationReportFile{
+		SchemaVersion: migrationReportSchemaVersion, GatewayVersion: gateway,
+		SourceCommit: strings.Repeat("a", 40), PlanID: "sha256:" + strings.Repeat("0", 64),
+		Registry: "registry.example", ProbeMode: migrationProbeCandidateDigest,
+		ControlRef: "registry.example/plugins/demo:1.0.0", ControlDigest: testDigest("control"),
+		Entries: []MigrationReportEntry{{
+			LogicalID: "ai-context-limit", Version: "1.0.0", OCIRef: "registry.example/plugins/ai-context-limit:1.0.0",
+			ExistingDigest: testDigest("legacy"), PlannedDigest: testDigest("planned"), InputHash: testDigest("inputs"),
+			SourceComparison: migrationSourceUnannotated, State: migrationStateBlocked, Recommendation: migrationRecommendDeleteLegacy,
+		}},
+	}
+	// The workflow reads the sweep output at these fixed paths.
+	reportPath := "/tmp/migration-report.json"
+	markdownPath := "/tmp/migration-report.md"
+	t.Cleanup(func() {
+		_ = os.Remove(reportPath)
+		_ = os.Remove(markdownPath)
+	})
+
+	for _, tc := range []struct {
+		name           string
+		blocked        bool
+		labelExists    bool
+		labelFails     bool
+		prCreateFails  bool
+		wantBody       string
+		wantBodySuffix string
+		wantLog        []string
+		wantAbsent     []string
+		wantError      bool
+	}{
+		{
+			name:           "all-green",
+			wantBody:       baseBody,
+			wantBodySuffix: "\nARG --label\nARG release/" + gateway + "\n",
+			wantLog: []string{
+				"=== label\nARG create\nARG release/" + gateway,
+				"=== pr\nARG create\nARG --base\nARG main",
+			},
+		},
+		{
+			name:        "blocked-plugins-append-report",
+			blocked:     true,
+			labelExists: true,
+			wantBody:    baseBody + "\n\n## Plugin migration preflight\n",
+			wantLog:     []string{"**delete-legacy**", testDigest("legacy"), testDigest("planned"), "=== pr\nARG create"},
+			wantAbsent:  []string{"=== label\nARG create"},
+		},
+		{
+			name:           "existing-pr-falls-back-to-edit",
+			labelExists:    true,
+			prCreateFails:  true,
+			wantBody:       baseBody,
+			wantBodySuffix: "\nARG --add-label\nARG release/" + gateway + "\n",
+			wantLog: []string{
+				"=== pr\nARG edit\nARG release/plugin-snapshot-" + gateway,
+			},
+		},
+		{
+			name:       "label-cannot-be-ensured",
+			labelFails: true,
+			wantError:  true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			bin := filepath.Join(root, "bin")
+			if err := os.MkdirAll(bin, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			current := report
+			markdown := "## Plugin migration preflight\n\nNo planned version tag is occupied by a different artifact.\n"
+			if tc.blocked {
+				markdown = renderMigrationMarkdown(report)
+			} else {
+				current.Entries = []MigrationReportEntry{}
+			}
+			if err := writeCanonical(reportPath, current); err != nil {
+				t.Fatal(err)
+			}
+			if err := writeText(markdownPath, markdown); err != nil {
+				t.Fatal(err)
+			}
+			logPath := filepath.Join(root, "gh.log")
+			statePath := filepath.Join(root, "label.state")
+			if tc.labelExists {
+				if err := os.WriteFile(statePath, []byte("release/"+gateway), 0o600); err != nil {
+					t.Fatal(err)
+				}
+			}
+			writeExecutableFixture(t, filepath.Join(bin, "gh"), `#!/usr/bin/env bash
+set -uo pipefail
+command=$1
+{
+  printf '=== %s\n' "$command"
+  for argument in "${@:2}"; do printf 'ARG %s\n' "$argument"; done
+} >> "$GH_LOG"
+case "$command" in
+  api)
+    # The same endpoint is used to probe and to confirm the label, so the
+    # stubbed registry of labels is the state file gh label create writes.
+    if [ ! -f "$GH_LABEL_STATE" ]; then exit 1; fi
+    if [ "${3:-}" = "--jq" ]; then cat "$GH_LABEL_STATE"; fi
+    exit 0
+    ;;
+  label)
+    if [ "${2:-}" != create ]; then echo "unexpected gh label invocation: $*" >&2; exit 2; fi
+    if [ "${GH_LABEL_CREATE_FAILS:-false}" = true ]; then exit 1; fi
+    printf '%s' "$3" > "$GH_LABEL_STATE"
+    exit 0
+    ;;
+  pr)
+    if [ "${2:-}" = create ] && [ "${GH_PR_CREATE_FAILS:-false}" = true ]; then exit 1; fi
+    if [ "${2:-}" != create ] && [ "${2:-}" != edit ]; then echo "unexpected gh pr invocation: $*" >&2; exit 2; fi
+    exit 0
+    ;;
+esac
+echo "unexpected gh invocation: $*" >&2
+exit 2
+`)
+			contract := workflowShellContract(t, "prepare-plugin-release.yaml", "preparation-pr-contract")
+			script := "set -euo pipefail\nbranch=\"release/plugin-snapshot-$GATEWAY_VERSION\"\n" + contract
+			cmd := exec.Command("bash", "-c", script)
+			cmd.Dir = root
+			cmd.Env = append(os.Environ(),
+				"PATH="+bin+":"+os.Getenv("PATH"),
+				"GH_LOG="+logPath,
+				"GH_LABEL_STATE="+statePath,
+				"GH_LABEL_CREATE_FAILS="+boolString(tc.labelFails),
+				"GH_PR_CREATE_FAILS="+boolString(tc.prCreateFails),
+				"GH_TOKEN=fixture-token",
+				"GITHUB_REPOSITORY=higress-group/higress",
+				"GATEWAY_VERSION="+gateway,
+			)
+			output, err := cmd.CombinedOutput()
+			if tc.wantError {
+				if err == nil {
+					t.Fatalf("preparation PR was published without its authorizing label:\n%s", output)
+				}
+				if strings.Contains(string(output), "fixture-token") {
+					t.Fatalf("preparation PR publication leaked its token:\n%s", output)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("preparation PR publication failed: %v\n%s", err, output)
+			}
+			logBytes, readErr := os.ReadFile(logPath)
+			if readErr != nil {
+				t.Fatal(readErr)
+			}
+			log := string(logBytes)
+			body := "ARG --body\nARG " + tc.wantBody + tc.wantBodySuffix
+			if !strings.Contains(log, body) {
+				t.Fatalf("preparation PR body is not exact:\nwant %q\ngot log:\n%s", body, log)
+			}
+			for _, required := range tc.wantLog {
+				if !strings.Contains(log, required) {
+					t.Fatalf("preparation PR publication lacks %q:\n%s", required, log)
+				}
+			}
+			for _, forbidden := range tc.wantAbsent {
+				if strings.Contains(log, forbidden) {
+					t.Fatalf("preparation PR publication unexpectedly ran %q:\n%s", forbidden, log)
+				}
+			}
+		})
+	}
+}
+
+func boolString(value bool) string {
+	if value {
+		return "true"
+	}
+	return "false"
+}

--- a/tools/plugin-release/promotion_latest_contract_test.go
+++ b/tools/plugin-release/promotion_latest_contract_test.go
@@ -24,6 +24,11 @@ type latestContractPlugin struct {
 	EvidenceVersion string
 	EvidenceDigest  string
 	EvidenceRef     string
+	// Blocked declares a prepare-time migration exclusion: the planned version
+	// tag is occupied by BlockedExistingDigest, so this batch publishes neither
+	// the version tag nor the latest alias for the plugin.
+	Blocked               bool
+	BlockedExistingDigest string
 }
 
 type latestContractResult struct {
@@ -231,10 +236,21 @@ func runPromotionLatestContractFixture(t *testing.T, bootstrap, corruptEvidenceS
 	for _, plugin := range plugins {
 		ref := "registry.example.invalid/plugins/" + plugin.ID + ":" + plugin.Version
 		latest := "registry.example.invalid/plugins/" + plugin.ID + ":latest"
-		snapshot["plugins"] = append(snapshot["plugins"].([]any), map[string]any{
+		snapshotEntry := map[string]any{
 			"logicalId": plugin.ID, "ociRef": ref, "digest": plugin.Digest, "version": plugin.Version,
-		})
-		registry[ref] = map[string]any{"digest": plugin.Digest, "version": plugin.Version}
+		}
+		if plugin.Blocked {
+			snapshotEntry["migration"] = map[string]any{
+				"state": "blocked", "existingDigest": plugin.BlockedExistingDigest, "plannedDigest": plugin.Digest,
+				"sourceComparison": "unannotated", "recommendation": "delete-legacy",
+			}
+			// The planned version tag is occupied by the legacy artifact this
+			// exclusion records; the batch never publishes it.
+			registry[ref] = map[string]any{"digest": plugin.BlockedExistingDigest, "version": ""}
+		} else {
+			registry[ref] = map[string]any{"digest": plugin.Digest, "version": plugin.Version}
+		}
+		snapshot["plugins"] = append(snapshot["plugins"].([]any), snapshotEntry)
 		if plugin.CurrentDigest != "" {
 			registry[latest] = map[string]any{"digest": plugin.CurrentDigest, "version": plugin.CurrentVersion}
 		}


### PR DESCRIPTION
Implements S3 + S4 of Proposal #4634 (SPEC-4634004 + SPEC-4634005). S1+S2 (layout unification) will follow separately.

## S3 — Onboarding migration preflight at prepare
- New `plugin-release migration-preflight` subcommand: sweeps the public registry for every planned plugin's ociRef before the prep PR is created; the probe is calibrated against a control tag derived from the previous snapshot, and registry auth failures are treated as failures (never as absence).
- Conflicting plugins (tag exists with a different digest) get a per-plugin migration report (existing digest, planned digest, source comparison, recommended disposition) appended to the prep PR body, and carry `migration.state=blocked` in the plan/snapshot.
- Promote honors the exclusion: blocked plugins are journaled as `migration-excluded` and skipped; an all-blocked plan fails closed. All-green path is byte-identical to today.

## S4 — Approval chain reduced to two gates
- Prepare's `plugin-release-candidate` environment gate removed (candidate namespace is content-addressed; rationale documented in-workflow).
- Promote's verify-and-promote phase replaces its `plugin-release-production` environment with a fail-closed authorization check: source_commit must be reachable from main AND belong to exactly one merged preparation PR (deterministic branch/title) carrying the `release/<version>` label; the bot's prep-PR creation now ensures the label exists and applies it.
- The `latest`-move job keeps its independent `plugin-release-production` environment gate (largest blast radius) — unchanged.

## Verification
- `tools/plugin-release` full module tests: PASS (`go test -p 1 -count=1`, 29-35s, includes new migration-preflight tests).
- Both workflow YAMLs parse (yaml.safe_load) — one indentation defect in the generated body-append block was caught and fixed before commit.
- Go changes confined to tools/plugin-release (+migration.go 496 lines, model/commands/io/main wiring); workflows touched only at the described gates.

Implementation: Qwen3.8-Max agent session (per maintainer dispatch), finished and committed by the maintainer after an agent-session interruption; co-authored trailer records the split.
