### PR TITLE
feat(release): unify published plugin layout, pull-verify latest moves, align emergency channel (Proposal #4634 S1+S2)

### DIFF
--- a/.github/workflows/emergency-overwrite-plugin-tag.yaml
+++ b/.github/workflows/emergency-overwrite-plugin-tag.yaml
@@ -1,17 +1,17 @@
 name: Emergency Overwrite Plugin Tag
 
 # One-off, maintainer-only workflow for emergency same-version overwrites of a
-# public plugin tag (e.g. mcp-server:2.0.1). The immutable-release pipeline
-# (prepare/promote) intentionally cannot re-push an existing version tag; this
-# workflow exists OUTSIDE that pipeline for urgent fixes when the registry-side
-# tag-immutability rule has been deliberately and temporarily lifted by an
-# admin. It publishes the Envoy-loadable 2-layer OCI variant with full
-# provenance annotations and reports the new digest for the recovery PR that
-# must follow (snapshots/evidence digest refresh).
+# public plugin tag. It is intentionally outside immutable prepare/promote and
+# must be used only while an administrator has temporarily lifted registry tag
+# immutability. A successful overwrite is followed by an automated evidence PR.
 
 on:
   workflow_dispatch:
     inputs:
+      gateway_version:
+        description: "Stable gateway version whose evidence and snapshot bind this plugin release"
+        required: true
+        type: string
       logical_id:
         description: "Plugin logical ID in the release catalog (e.g. mcp-server)"
         required: true
@@ -25,12 +25,12 @@ on:
         required: true
         type: string
       move_latest:
-        description: "Also move the latest tag to the overwritten digest (opt-in: moving latest for an older version can regress it below a newer release)"
+        description: "Also move latest to the overwritten digest (opt-in: an older version can regress latest)"
         required: true
         default: false
         type: boolean
       dry_run:
-        description: "Build and validate only; never push"
+        description: "Authorize, validate, build, and verify lineage inputs only; never push"
         required: true
         default: true
         type: boolean
@@ -38,71 +38,146 @@ on:
 permissions:
   contents: read
 
-run-name: emergency-overwrite ${{ inputs.logical_id }}:${{ inputs.version }} @ ${{ inputs.source_commit }}
+run-name: emergency-overwrite ${{ inputs.gateway_version }} ${{ inputs.logical_id }}:${{ inputs.version }} @ ${{ inputs.source_commit }}
 
 jobs:
+  authorize:
+    name: Authorize triggering maintainer
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Require maintain or admin permission
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TRIGGERING_ACTOR: ${{ github.triggering_actor }}
+        run: |
+          set -euo pipefail
+          # BEGIN emergency-authorization-contract
+          actor="$TRIGGERING_ACTOR"
+          if ! [[ "$actor" =~ ^[A-Za-z0-9]([A-Za-z0-9-]{0,37}[A-Za-z0-9])?$ ]]; then
+            echo "Emergency authorization: actor=${actor:-<invalid>} permission=invalid-actor" >> "$GITHUB_STEP_SUMMARY"
+            echo "emergency overwrite is not authorized: invalid triggering actor" >&2
+            exit 1
+          fi
+          permission=api-error
+          if response=$(gh api "repos/$GITHUB_REPOSITORY/collaborators/$actor/permission"); then
+            permission=$(jq -r '.permission // "none"' <<<"$response")
+          fi
+          echo "Emergency authorization: actor=$actor permission=$permission" >> "$GITHUB_STEP_SUMMARY"
+          case "$permission" in
+            maintain|admin) ;;
+            *) echo "emergency overwrite is not authorized: $actor has permission $permission; require maintain or admin" >&2; exit 1 ;;
+          esac
+          # END emergency-authorization-contract
+
   validate:
     name: Validate + build (no registry writes)
+    needs: authorize
     runs-on: ubuntu-latest
     timeout-minutes: 40
     outputs:
+      evidence_base: ${{ steps.tool.outputs.evidence_base }}
       image: ${{ steps.resolve.outputs.image }}
       input_hash: ${{ steps.hash.outputs.input_hash }}
     steps:
       - name: Harden runner
         run: |
           sudo rm -rf /usr/local/bin/gsutil /usr/local/bin/gh /usr/local/bin/docker-credential-* || true
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
-          # Check out main: the emergency-input-hash subcommand ships with this
-          # workflow, which may postdate inputs.source_commit. The plugin tree
-          # is switched to source_commit below, after the tool is built.
-          ref: main
+          # Pin evidence and the release tool to the dispatch commit so rerunning
+          # the same workflow run keeps the same deterministic evidence base.
+          ref: ${{ github.sha }}
           fetch-depth: 0
-      - uses: actions/setup-go@v5
+          persist-credentials: false
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: "1.24.0"
       - uses: oras-project/setup-oras@8d34698a59f5ffe24821f0b48ab62a3de8b64b20 # v1.2.3
         with:
           version: 1.2.3
-      - name: Build release tool and switch tree to the source commit
+      - name: Build current release tool and validate source ancestry
+        id: tool
         env:
           SOURCE_COMMIT: ${{ inputs.source_commit }}
-        run: |
-          set -euo pipefail
-          git cat-file -e "$SOURCE_COMMIT^{commit}"
-          git merge-base --is-ancestor "$SOURCE_COMMIT" origin/main
-          (cd tools/plugin-release && go build -o /usr/local/bin/plugin-release .)
-          git checkout -q "$SOURCE_COMMIT"
-      - name: Resolve catalog entry and validate inputs
-        id: resolve
-        env:
-          LOGICAL_ID: ${{ inputs.logical_id }}
-          VERSION: ${{ inputs.version }}
-          SOURCE_COMMIT: ${{ inputs.source_commit }}
+          WORKFLOW_REF: ${{ github.ref }}
+          WORKFLOW_SHA: ${{ github.sha }}
         run: |
           set -euo pipefail
           [[ "$SOURCE_COMMIT" =~ ^[0-9a-f]{40}$ ]]
-          test "$(git rev-parse HEAD)" = "$SOURCE_COMMIT"
+          [[ "$WORKFLOW_SHA" =~ ^[0-9a-f]{40}$ ]]
+          test "$WORKFLOW_REF" = refs/heads/main
+          test "$(git rev-parse HEAD)" = "$WORKFLOW_SHA"
+          git cat-file -e "$SOURCE_COMMIT^{commit}"
+          git fetch --no-tags origin main
+          evidence_base=$WORKFLOW_SHA
+          git merge-base --is-ancestor "$evidence_base" refs/remotes/origin/main
+          git merge-base --is-ancestor "$SOURCE_COMMIT" "$evidence_base"
+          mkdir -p /tmp/emergency-overwrite-artifact
+          (cd tools/plugin-release && GOMAXPROCS=1 go build -p 1 -o /tmp/emergency-overwrite-artifact/plugin-release .)
+          echo "evidence_base=$evidence_base" >> "$GITHUB_OUTPUT"
+      - name: Resolve catalog entry and validate release evidence binding
+        id: resolve
+        env:
+          GATEWAY_VERSION: ${{ inputs.gateway_version }}
+          LOGICAL_ID: ${{ inputs.logical_id }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          [[ "$GATEWAY_VERSION" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]
+          [[ "$LOGICAL_ID" =~ ^[a-z0-9][a-z0-9._-]*$ ]]
           [[ "$VERSION" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]
-          entry=$(jq -er --arg id "$LOGICAL_ID" '.plugins[] | select(.logicalId==$id and .releaseEligible!=false)' plugins/release/catalog.json)
+          entry=$(jq -cer --arg id "$LOGICAL_ID" '[.plugins[] | select(.logicalId==$id and .releaseEligible!=false)] | select(length == 1) | .[0]' plugins/release/catalog.json)
           implementation=$(jq -r .implementation <<<"$entry")
           source_dir=$(jq -r .sourceDir <<<"$entry")
           image=$(jq -r .image <<<"$entry")
+          registry=$(jq -er .registry plugins/release/catalog.json)
           [[ "$implementation" = "go" ]] || { echo "emergency overwrite currently supports go plugins only" >&2; exit 1; }
-          # The overwritten tag must be exactly the version currently recorded in the snapshot of its gateway release.
           [[ "$source_dir" = plugins/wasm-go/extensions/* ]]
-          # Committed VERSION must match the requested tag: the overwrite must not smuggle in a different number.
-          committed=$(tr -d '[:space:]' < "$source_dir/VERSION")
-          test "$committed" = "$VERSION" || { echo "VERSION file says $committed, refusing to overwrite $VERSION" >&2; exit 1; }
-          # Compute the deterministic input hash exactly like the release tool (artifact inputs + shared groups at this commit).
-          plugin-release validate-catalog --root . --catalog plugins/release/catalog.json
+          evidence="plugins/release/evidence/$GATEWAY_VERSION.json"
+          snapshot="plugins/release/snapshots/$GATEWAY_VERSION.json"
+          test -f "$evidence"; test -f "$snapshot"
+          candidate=$(jq -cer --arg id "$LOGICAL_ID" '.plugins[$id]' "$evidence")
+          release=$(jq -cer --arg id "$LOGICAL_ID" '[.plugins[] | select(.logicalId==$id)] | select(length == 1) | .[0]' "$snapshot")
+          test "$(jq -er .gatewayVersion "$snapshot")" = "$GATEWAY_VERSION"
+          test "$(jq -er .version <<<"$release")" = "$VERSION"
+          test "$(jq -er .image <<<"$release")" = "$image"
+          test "$(jq -er .ociRef <<<"$release")" = "$registry/$image:$VERSION"
+          candidate_digest=$(jq -er '.digest | select(test("^sha256:[0-9a-f]{64}$"))' <<<"$candidate")
+          candidate_source=$(jq -er '.sourceCommit | select(test("^[0-9a-f]{40}$"))' <<<"$candidate")
+          test "$(jq -er .digest <<<"$release")" = "$candidate_digest"
+          test "$(jq -er .inputHash <<<"$release")" = "$(jq -er .inputHash <<<"$candidate")"
+          test "$(jq -er .sourceCommit <<<"$release")" = "$candidate_source"
+          candidate_ref=$(jq -er .candidateRef <<<"$candidate")
+          test "$(jq -er .candidateRef <<<"$release")" = "$candidate_ref"
+          [[ "$candidate_ref" == *"@$candidate_digest" ]]
+          /tmp/emergency-overwrite-artifact/plugin-release validate-catalog --root . --catalog plugins/release/catalog.json
           echo "IMPLEMENTATION=$implementation" >> "$GITHUB_ENV"
           echo "SOURCE_DIR=$source_dir" >> "$GITHUB_ENV"
           echo "IMAGE=$image" >> "$GITHUB_ENV"
           echo "BUILD_NAME=$(basename "$source_dir")" >> "$GITHUB_ENV"
+          echo "CANDIDATE_SOURCE_COMMIT=$candidate_source" >> "$GITHUB_ENV"
+          echo "EVIDENCE_PATH=$evidence" >> "$GITHUB_ENV"
+          echo "SNAPSHOT_PATH=$snapshot" >> "$GITHUB_ENV"
           echo "image=$image" >> "$GITHUB_OUTPUT"
-      - name: Compute input hash (release-tool compatible)
+      - name: Switch tree to the selected source and validate build inputs
+        env:
+          LOGICAL_ID: ${{ inputs.logical_id }}
+          SOURCE_COMMIT: ${{ inputs.source_commit }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          git checkout -q "$SOURCE_COMMIT"
+          test "$(git rev-parse HEAD)" = "$SOURCE_COMMIT"
+          git merge-base --is-ancestor "$CANDIDATE_SOURCE_COMMIT" "$SOURCE_COMMIT"
+          entry=$(jq -cer --arg id "$LOGICAL_ID" '[.plugins[] | select(.logicalId==$id and .releaseEligible!=false)] | select(length == 1) | .[0]' plugins/release/catalog.json)
+          test "$(jq -r .implementation <<<"$entry")" = "$IMPLEMENTATION"
+          test "$(jq -r .sourceDir <<<"$entry")" = "$SOURCE_DIR"
+          test "$(jq -r .image <<<"$entry")" = "$IMAGE"
+          committed=$(tr -d '[:space:]' < "$SOURCE_DIR/VERSION")
+          test "$committed" = "$VERSION" || { echo "VERSION file says $committed, refusing to overwrite $VERSION" >&2; exit 1; }
+          /tmp/emergency-overwrite-artifact/plugin-release validate-catalog --root . --catalog plugins/release/catalog.json
+      - name: Compute input hash (current release-tool contract)
         id: hash
         env:
           LOGICAL_ID: ${{ inputs.logical_id }}
@@ -110,11 +185,7 @@ jobs:
           SOURCE_COMMIT: ${{ inputs.source_commit }}
         run: |
           set -euo pipefail
-          # inputHash selects catalog artifact inputs + shared input groups at SOURCE_COMMIT and hashes
-          # the file bytes plus the version string, mirroring tools/plugin-release inputHash().
-          # Run the binary built from main above: the checked-out source_commit tree may predate
-          # the emergency-input-hash subcommand, so go run here could compile a tool without it.
-          plugin-release emergency-input-hash --root . --catalog plugins/release/catalog.json \
+          /tmp/emergency-overwrite-artifact/plugin-release emergency-input-hash --root . --catalog plugins/release/catalog.json \
             --id "$LOGICAL_ID" --commit "$SOURCE_COMMIT" --version "$VERSION" > /tmp/input-hash.txt
           grep -Eq '^sha256:[0-9a-f]{64}$' /tmp/input-hash.txt
           echo "input_hash=$(cat /tmp/input-hash.txt)" >> "$GITHUB_OUTPUT"
@@ -126,48 +197,48 @@ jobs:
           (cd "$source" && go test ./...)
           make -C plugins/wasm-go PLUGIN_NAME="$build_name" build
           test -s "$source/plugin.wasm"
-          sha256sum "$source/plugin.wasm" | tee -a "$GITHUB_STEP_SUMMARY"
-      - name: Upload built artifact for the publish job
-        uses: actions/upload-artifact@v4
+          cp "$source/plugin.wasm" /tmp/emergency-overwrite-artifact/plugin.wasm
+          sha256sum /tmp/emergency-overwrite-artifact/plugin.wasm | tee -a "$GITHUB_STEP_SUMMARY"
+      - name: Upload current tool and built artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: emergency-overwrite-artifact
-          path: ${{ env.SOURCE_DIR }}/plugin.wasm
+          path: /tmp/emergency-overwrite-artifact/
           if-no-files-found: error
           retention-days: 3
 
   publish:
-    name: Overwrite tag (waits for maintainer approval)
-    needs: validate
+    name: Overwrite tag and publish evidence PR
+    needs: [authorize, validate]
     if: ${{ !inputs.dry_run }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    # Any registry write waits here for a review from the @maintainers team
-    # (same reviewer group as higress-release-manager). This environment also
-    # holds the production registry credentials the promote pipeline uses —
-    # registry vars/secrets are environment-scoped in this repository.
-    environment: plugin-release-production
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
+        id: app-token
         with:
-          ref: ${{ inputs.source_commit }}
-          fetch-depth: 1
-      - uses: actions/download-artifact@v4
+          app-id: ${{ vars.RELEASE_PR_APP_ID }}
+          private-key: ${{ secrets.RELEASE_PR_APP_PRIVATE_KEY }}
+          owner: higress-group
+          repositories: higress
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          ref: ${{ needs.validate.outputs.evidence_base }}
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4
         with:
           name: emergency-overwrite-artifact
-          path: emergency-artifact
+          path: /tmp/emergency-overwrite-artifact
       - uses: oras-project/setup-oras@8d34698a59f5ffe24821f0b48ab62a3de8b64b20 # v1.2.3
         with:
           version: 1.2.3
-      - name: Publish 2-layer OCI variant over the existing tag
+      - name: Publish deterministic two-layer OCI manifest
+        id: publish
         env:
-          # Match the promote pipeline exactly: public pushes use the
-          # PRODUCTION registry credentials, and the registry host resolves
-          # from the same variable promote reads (candidate host is an
-          # identical fallback observed in successful promote runs).
-          REGISTRY: ${{ vars.PLUGIN_PUBLIC_REGISTRY || vars.PLUGIN_CANDIDATE_REGISTRY }}
+          REGISTRY: ${{ vars.PLUGIN_PUBLIC_REGISTRY }}
           REGISTRY_USERNAME: ${{ secrets.PRODUCTION_REGISTRY_USERNAME }}
           REGISTRY_PASSWORD: ${{ secrets.PRODUCTION_REGISTRY_PASSWORD }}
-          LOGICAL_ID: ${{ inputs.logical_id }}
           VERSION: ${{ inputs.version }}
           SOURCE_COMMIT: ${{ inputs.source_commit }}
           MOVE_LATEST: ${{ inputs.move_latest }}
@@ -178,34 +249,91 @@ jobs:
           test -n "$REGISTRY"; test -n "$REGISTRY_USERNAME"; test -n "$REGISTRY_PASSWORD"
           echo "$REGISTRY_PASSWORD" | oras login "$REGISTRY" -u "$REGISTRY_USERNAME" --password-stdin
           ref="$REGISTRY/$IMAGE_REF:$VERSION"
-          echo "::warning::Emergency overwrite: this replaces the manifest behind $ref. Registry tag-immutability must have been lifted by an admin for this repo."
-          before=$(oras manifest fetch "$ref" --descriptor | jq -r .digest || true)
-          stage=$(mktemp -d); printf '%s' '{}' > "$stage/config.json"; cp emergency-artifact/plugin.wasm "$stage/plugin.wasm"
-          push_result=$(cd "$stage" && oras push "$ref" \
-            "config.json:application/vnd.module.wasm.config.v1+json" \
-            "plugin.wasm:application/vnd.module.wasm.content.layer.v1+wasm" \
-            --annotation "org.opencontainers.image.revision=$SOURCE_COMMIT" \
-            --annotation "org.opencontainers.image.version=$VERSION" \
-            --annotation "io.higress.plugin.input-hash=$INPUT_HASH" \
-            --format json)
-          digest=$(jq -ser '.[0].digest | select(test("^sha256:[0-9a-f]{64}$"))' <<<"$push_result")
-          # Verify the published manifest is the Envoy-loadable 2-layer variant.
-          manifest=$(oras manifest fetch "$REGISTRY/$IMAGE_REF@$digest")
-          jq -e '
-            (.layers | length == 2) and
-            (.layers[0].mediaType == "application/vnd.module.wasm.config.v1+json") and
-            (.layers[1].mediaType == "application/vnd.module.wasm.content.layer.v1+wasm") and
-            (.annotations["org.opencontainers.image.revision"] == env.SOURCE_COMMIT) and
-            (.annotations["org.opencontainers.image.version"] == env.VERSION) and
-            (.annotations["io.higress.plugin.input-hash"] == env.INPUT_HASH)
-          ' >/dev/null <<<"$manifest"
-          after=$(oras manifest fetch "$ref" --descriptor | jq -r .digest)
+          echo "::warning::Emergency overwrite replaces $ref; registry tag immutability must have been temporarily lifted by an administrator."
+          before=$(oras manifest fetch "$ref" --descriptor | jq -er '.digest | select(test("^sha256:[0-9a-f]{64}$"))')
+          # BEGIN plugin-manifest-publish-contract
+          publish_plugin_manifest() {
+            local ref=$1 wasm=$2 source_commit=$3 version=$4 input_hash=$5
+            local stage push_result digest manifest repo source_created wasm_digest wasm_size
+            # Bash normally clears errexit inside command substitution. Restore it
+            # because both callers capture this function's digest that way.
+            set -e
+            if ! [[ "$source_commit" =~ ^[0-9a-f]{40}$ ]]; then echo "invalid plugin source commit" >&2; return 1; fi
+            if ! [[ "$version" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then echo "invalid stable plugin version" >&2; return 1; fi
+            if ! [[ "$input_hash" =~ ^sha256:[0-9a-f]{64}$ ]]; then echo "invalid plugin input hash" >&2; return 1; fi
+            if ! test -s "$wasm"; then echo "plugin.wasm is missing or empty" >&2; return 1; fi
+            if ! source_created=$(git show -s --format=%cI "$source_commit"); then echo "cannot resolve plugin source commit time" >&2; return 1; fi
+            if ! [[ "$source_created" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(Z|[+-][0-9]{2}:[0-9]{2})$ ]]; then echo "invalid plugin source commit time" >&2; return 1; fi
+            wasm_digest="sha256:$(sha256sum "$wasm" | awk '{print $1}')"
+            wasm_size=$(wc -c < "$wasm"); wasm_size=${wasm_size//[[:space:]]/}
+            stage=$(mktemp -d)
+            if ! printf '%s' '{}' > "$stage/config.json" || ! cp "$wasm" "$stage/plugin.wasm"; then
+              rm -rf "$stage"; echo "failed to stage plugin manifest layers" >&2; return 1
+            fi
+            if ! push_result=$(cd "$stage" && oras push "$ref" \
+              "config.json:application/vnd.module.wasm.config.v1+json" \
+              "plugin.wasm:application/vnd.module.wasm.content.layer.v1+wasm" \
+              --image-spec v1.0 \
+              --annotation "org.opencontainers.image.created=$source_created" \
+              --annotation "org.opencontainers.image.revision=$source_commit" \
+              --annotation "org.opencontainers.image.version=$version" \
+              --annotation "io.higress.plugin.input-hash=$input_hash" \
+              --format json); then
+              rm -rf "$stage"; echo "plugin manifest push failed: $ref" >&2; return 1
+            fi
+            rm -rf "$stage"
+            if ! digest=$(jq -ser 'select(length == 1) | .[0].digest | strings | select(test("^sha256:[0-9a-f]{64}$"))' <<<"$push_result"); then
+              echo "plugin manifest push returned a malformed descriptor: $ref" >&2; return 1
+            fi
+            repo=${ref%:*}
+            if ! manifest=$(oras manifest fetch "$repo@$digest"); then
+              echo "published plugin manifest cannot be resolved by digest: $repo@$digest" >&2; return 1
+            fi
+            if ! jq -se --arg commit "$source_commit" --arg created "$source_created" --arg version "$version" --arg input_hash "$input_hash" --arg wasm_digest "$wasm_digest" --argjson wasm_size "$wasm_size" '
+              length == 1 and (.[0] |
+                (keys == ["annotations","config","layers","mediaType","schemaVersion"]) and
+                .schemaVersion == 2 and
+                .mediaType == "application/vnd.oci.image.manifest.v1+json" and
+                (.config == {
+                  "mediaType":"application/vnd.unknown.config.v1+json",
+                  "digest":"sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a",
+                  "size":2
+                }) and
+                (.annotations == {
+                  "org.opencontainers.image.created": $created,
+                  "org.opencontainers.image.revision": $commit,
+                  "org.opencontainers.image.version": $version,
+                  "io.higress.plugin.input-hash": $input_hash
+                }) and
+                (.layers | type == "array" and length == 2) and
+                (.layers[0] == {
+                  "mediaType":"application/vnd.module.wasm.config.v1+json",
+                  "digest":"sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a",
+                  "size":2,
+                  "annotations":{"org.opencontainers.image.title":"config.json"}
+                }) and
+                (.layers[1] == {
+                  "mediaType":"application/vnd.module.wasm.content.layer.v1+wasm",
+                  "digest":$wasm_digest,
+                  "size":$wasm_size,
+                  "annotations":{"org.opencontainers.image.title":"plugin.wasm"}
+                })
+              )
+            ' >/dev/null <<<"$manifest"; then
+              echo "published plugin manifest does not match the deterministic two-layer contract: $ref" >&2; return 1
+            fi
+            printf '%s\n' "$digest"
+          }
+          # END plugin-manifest-publish-contract
+          digest=$(publish_plugin_manifest "$ref" /tmp/emergency-overwrite-artifact/plugin.wasm "$SOURCE_COMMIT" "$VERSION" "$INPUT_HASH")
+          after=$(oras manifest fetch "$ref" --descriptor | jq -er '.digest | select(test("^sha256:[0-9a-f]{64}$"))')
           test "$after" = "$digest"
           if [ "$MOVE_LATEST" = "true" ]; then
             oras cp "$REGISTRY/$IMAGE_REF@$digest" "$REGISTRY/$IMAGE_REF:latest"
-            latest_digest=$(oras manifest fetch "$REGISTRY/$IMAGE_REF:latest" --descriptor | jq -r .digest)
-            test "$latest_digest" = "$digest"
+            test "$(oras manifest fetch "$REGISTRY/$IMAGE_REF:latest" --descriptor | jq -er .digest)" = "$digest"
           fi
+          printf '%s\n' "$digest" > /tmp/emergency-digest.txt
+          echo "digest=$digest" >> "$GITHUB_OUTPUT"
           {
             echo "## Emergency overwrite report"
             echo "- ref: \`$ref\`"
@@ -214,6 +342,64 @@ jobs:
             echo "- input hash: \`$INPUT_HASH\`"
             echo "- source commit: \`$SOURCE_COMMIT\`"
             echo "- latest moved: $MOVE_LATEST"
-            echo ""
-            echo "Follow-up: no snapshot edit is needed — the fix commit is on main; the next gateway release auto-bumps this plugin and re-releases it through the verified pipeline. (Trigger it with trigger-plugin-release.yaml.)"
-          } | tee -a "$GITHUB_STEP_SUMMARY"
+          } >> "$GITHUB_STEP_SUMMARY"
+      - name: Append emergency lineage with the current release tool
+        env:
+          GATEWAY_VERSION: ${{ inputs.gateway_version }}
+          LOGICAL_ID: ${{ inputs.logical_id }}
+          VERSION: ${{ inputs.version }}
+          SOURCE_COMMIT: ${{ inputs.source_commit }}
+          WORKFLOW_RUN_ID: ${{ github.run_id }}
+          IMAGE_REF: ${{ needs.validate.outputs.image }}
+          INPUT_HASH: ${{ needs.validate.outputs.input_hash }}
+          DIGEST: ${{ steps.publish.outputs.digest }}
+        run: |
+          set -euo pipefail
+          tool=/tmp/emergency-overwrite-artifact/plugin-release
+          evidence="plugins/release/evidence/$GATEWAY_VERSION.json"
+          snapshot="plugins/release/snapshots/$GATEWAY_VERSION.json"
+          chmod 0700 "$tool"
+          test -x "$tool"
+          "$tool" append-emergency-lineage --evidence "$evidence" --snapshot "$snapshot" --output "$evidence" \
+            --gateway-version "$GATEWAY_VERSION" --id "$LOGICAL_ID" --version "$VERSION" --image "$IMAGE_REF" \
+            --digest "$DIGEST" --input-hash "$INPUT_HASH" --source-commit "$SOURCE_COMMIT" --workflow-run-id "$WORKFLOW_RUN_ID"
+      - name: Create or update deterministic emergency evidence PR
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GATEWAY_VERSION: ${{ inputs.gateway_version }}
+          LOGICAL_ID: ${{ inputs.logical_id }}
+          VERSION: ${{ inputs.version }}
+          SOURCE_COMMIT: ${{ inputs.source_commit }}
+          EVIDENCE_BASE: ${{ needs.validate.outputs.evidence_base }}
+          WORKFLOW_RUN_ID: ${{ github.run_id }}
+          DIGEST: ${{ steps.publish.outputs.digest }}
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "$EVIDENCE_BASE"
+          evidence="plugins/release/evidence/$GATEWAY_VERSION.json"
+          branch="release/plugin-emergency-evidence-$GATEWAY_VERSION-$LOGICAL_ID-$WORKFLOW_RUN_ID"
+          title="chore: record emergency plugin lineage $GATEWAY_VERSION $LOGICAL_ID"
+          body="Records emergency overwrite workflow run $WORKFLOW_RUN_ID for $LOGICAL_ID:$VERSION at $DIGEST. The registry write precedes this PR, so a failed evidence publication must be retried with the same run ID."
+          gh auth setup-git
+          remote_line=$(git ls-remote --heads origin "refs/heads/$branch")
+          if [ -n "$remote_line" ]; then
+            remote_sha=${remote_line%%[[:space:]]*}
+            [[ "$remote_sha" =~ ^[0-9a-f]{40}$ ]]
+            git fetch --no-tags origin "refs/heads/$branch"
+            test "$(git rev-parse FETCH_HEAD)" = "$remote_sha"
+            test "$(git rev-parse FETCH_HEAD^)" = "$EVIDENCE_BASE"
+            mapfile -t remote_paths < <(git diff --name-only "$EVIDENCE_BASE" FETCH_HEAD)
+            test "${#remote_paths[@]}" = 1
+            test "${remote_paths[0]}" = "$evidence"
+            test "$(git show "FETCH_HEAD:$evidence" | sha256sum | awk '{print $1}')" = "$(sha256sum "$evidence" | awk '{print $1}')"
+          else
+            git checkout -q -B "$branch" "$EVIDENCE_BASE"
+            git add -- "$evidence"
+            mapfile -t staged_paths < <(git diff --cached --name-only)
+            test "${#staged_paths[@]}" = 1
+            test "${staged_paths[0]}" = "$evidence"
+            git -c user.name="higress-release-bot" -c user.email="release-bot@higress.io" commit -s -m "chore: record emergency plugin lineage $GATEWAY_VERSION $LOGICAL_ID"
+            git push --set-upstream origin "HEAD:refs/heads/$branch"
+          fi
+          gh pr create --base main --head "$branch" --title "$title" --body "$body" || gh pr edit "$branch" --title "$title" --body "$body"
+          echo "Emergency evidence PR branch: \`$branch\`" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/emergency-overwrite-plugin-tag.yaml
+++ b/.github/workflows/emergency-overwrite-plugin-tag.yaml
@@ -40,6 +40,10 @@ permissions:
 
 run-name: emergency-overwrite ${{ inputs.gateway_version }} ${{ inputs.logical_id }}:${{ inputs.version }} @ ${{ inputs.source_commit }}
 
+concurrency:
+  group: emergency-overwrite-${{ inputs.logical_id }}-${{ inputs.version }}
+  cancel-in-progress: false
+
 jobs:
   authorize:
     name: Authorize triggering maintainer
@@ -55,18 +59,20 @@ jobs:
           # BEGIN emergency-authorization-contract
           actor="$TRIGGERING_ACTOR"
           if ! [[ "$actor" =~ ^[A-Za-z0-9]([A-Za-z0-9-]{0,37}[A-Za-z0-9])?$ ]]; then
-            echo "Emergency authorization: actor=${actor:-<invalid>} permission=invalid-actor" >> "$GITHUB_STEP_SUMMARY"
+            echo "Emergency authorization: actor=${actor:-<invalid>} role_name=invalid-actor" >> "$GITHUB_STEP_SUMMARY"
             echo "emergency overwrite is not authorized: invalid triggering actor" >&2
             exit 1
           fi
-          permission=api-error
+          role_name=api-error
           if response=$(gh api "repos/$GITHUB_REPOSITORY/collaborators/$actor/permission"); then
-            permission=$(jq -r '.permission // "none"' <<<"$response")
+            if ! role_name=$(jq -er '.role_name | strings | select(length > 0)' <<<"$response"); then
+              role_name=invalid-response
+            fi
           fi
-          echo "Emergency authorization: actor=$actor permission=$permission" >> "$GITHUB_STEP_SUMMARY"
-          case "$permission" in
+          echo "Emergency authorization: actor=$actor role_name=$role_name" >> "$GITHUB_STEP_SUMMARY"
+          case "$role_name" in
             maintain|admin) ;;
-            *) echo "emergency overwrite is not authorized: $actor has permission $permission; require maintain or admin" >&2; exit 1 ;;
+            *) echo "emergency overwrite is not authorized: $actor has role_name $role_name; require maintain or admin" >&2; exit 1 ;;
           esac
           # END emergency-authorization-contract
 
@@ -78,6 +84,8 @@ jobs:
     outputs:
       evidence_base: ${{ steps.tool.outputs.evidence_base }}
       image: ${{ steps.resolve.outputs.image }}
+      public_registry: ${{ steps.resolve.outputs.public_registry }}
+      public_repository: ${{ steps.resolve.outputs.public_repository }}
       input_hash: ${{ steps.hash.outputs.input_hash }}
     steps:
       - name: Harden runner
@@ -132,6 +140,8 @@ jobs:
           source_dir=$(jq -r .sourceDir <<<"$entry")
           image=$(jq -r .image <<<"$entry")
           registry=$(jq -er .registry plugins/release/catalog.json)
+          [[ "$registry" =~ ^[a-z0-9][a-z0-9.-]*(\:[0-9]+)?$ ]]
+          repository="$registry/$image"
           [[ "$implementation" = "go" ]] || { echo "emergency overwrite currently supports go plugins only" >&2; exit 1; }
           [[ "$source_dir" = plugins/wasm-go/extensions/* ]]
           evidence="plugins/release/evidence/$GATEWAY_VERSION.json"
@@ -142,7 +152,7 @@ jobs:
           test "$(jq -er .gatewayVersion "$snapshot")" = "$GATEWAY_VERSION"
           test "$(jq -er .version <<<"$release")" = "$VERSION"
           test "$(jq -er .image <<<"$release")" = "$image"
-          test "$(jq -er .ociRef <<<"$release")" = "$registry/$image:$VERSION"
+          test "$(jq -er .ociRef <<<"$release")" = "$repository:$VERSION"
           candidate_digest=$(jq -er '.digest | select(test("^sha256:[0-9a-f]{64}$"))' <<<"$candidate")
           candidate_source=$(jq -er '.sourceCommit | select(test("^[0-9a-f]{40}$"))' <<<"$candidate")
           test "$(jq -er .digest <<<"$release")" = "$candidate_digest"
@@ -160,6 +170,8 @@ jobs:
           echo "EVIDENCE_PATH=$evidence" >> "$GITHUB_ENV"
           echo "SNAPSHOT_PATH=$snapshot" >> "$GITHUB_ENV"
           echo "image=$image" >> "$GITHUB_OUTPUT"
+          echo "public_registry=$registry" >> "$GITHUB_OUTPUT"
+          echo "public_repository=$repository" >> "$GITHUB_OUTPUT"
       - name: Switch tree to the selected source and validate build inputs
         env:
           LOGICAL_ID: ${{ inputs.logical_id }}
@@ -214,6 +226,38 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
+      # Re-affirm the dispatch authorization inside the only job that mutates the
+      # public registry. "Re-run failed jobs" resumes this job without running
+      # `authorize` again, and github.triggering_actor is then whoever clicked
+      # the re-run, so the early gate alone does not cover a resumed run. This
+      # must stay the first step: ahead of App-token creation, checkout,
+      # registry login, and every write. The body is byte-identical to the
+      # authorize job's contract so the two gates cannot drift.
+      - name: Re-require maintain or admin permission
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TRIGGERING_ACTOR: ${{ github.triggering_actor }}
+        run: |
+          set -euo pipefail
+          # BEGIN emergency-authorization-contract
+          actor="$TRIGGERING_ACTOR"
+          if ! [[ "$actor" =~ ^[A-Za-z0-9]([A-Za-z0-9-]{0,37}[A-Za-z0-9])?$ ]]; then
+            echo "Emergency authorization: actor=${actor:-<invalid>} role_name=invalid-actor" >> "$GITHUB_STEP_SUMMARY"
+            echo "emergency overwrite is not authorized: invalid triggering actor" >&2
+            exit 1
+          fi
+          role_name=api-error
+          if response=$(gh api "repos/$GITHUB_REPOSITORY/collaborators/$actor/permission"); then
+            if ! role_name=$(jq -er '.role_name | strings | select(length > 0)' <<<"$response"); then
+              role_name=invalid-response
+            fi
+          fi
+          echo "Emergency authorization: actor=$actor role_name=$role_name" >> "$GITHUB_STEP_SUMMARY"
+          case "$role_name" in
+            maintain|admin) ;;
+            *) echo "emergency overwrite is not authorized: $actor has role_name $role_name; require maintain or admin" >&2; exit 1 ;;
+          esac
+          # END emergency-authorization-contract
       - uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
         id: app-token
         with:
@@ -233,24 +277,37 @@ jobs:
       - uses: oras-project/setup-oras@8d34698a59f5ffe24821f0b48ab62a3de8b64b20 # v1.2.3
         with:
           version: 1.2.3
-      - name: Publish deterministic two-layer OCI manifest
+      - name: Stage desired manifest and update stable tag
         id: publish
         env:
-          REGISTRY: ${{ vars.PLUGIN_PUBLIC_REGISTRY }}
+          REGISTRY: ${{ needs.validate.outputs.public_registry }}
+          REPOSITORY: ${{ needs.validate.outputs.public_repository }}
+          CONFIGURED_REGISTRY: ${{ vars.PLUGIN_PUBLIC_REGISTRY }}
           REGISTRY_USERNAME: ${{ secrets.PRODUCTION_REGISTRY_USERNAME }}
           REGISTRY_PASSWORD: ${{ secrets.PRODUCTION_REGISTRY_PASSWORD }}
+          GATEWAY_VERSION: ${{ inputs.gateway_version }}
+          LOGICAL_ID: ${{ inputs.logical_id }}
           VERSION: ${{ inputs.version }}
           SOURCE_COMMIT: ${{ inputs.source_commit }}
-          MOVE_LATEST: ${{ inputs.move_latest }}
+          WORKFLOW_RUN_ID: ${{ github.run_id }}
+          RUN_ATTEMPT: ${{ github.run_attempt }}
           IMAGE_REF: ${{ needs.validate.outputs.image }}
           INPUT_HASH: ${{ needs.validate.outputs.input_hash }}
         run: |
           set -euo pipefail
-          test -n "$REGISTRY"; test -n "$REGISTRY_USERNAME"; test -n "$REGISTRY_PASSWORD"
+          test -n "$REGISTRY"; test -n "$REPOSITORY"; test -n "$REGISTRY_USERNAME"; test -n "$REGISTRY_PASSWORD"
+          # BEGIN emergency-registry-binding-contract
+          validate_emergency_repository() {
+            local configured_registry=$1 validated_registry=$2 validated_repository=$3 image=$4
+            test "$configured_registry" = "$validated_registry" || { echo "production registry does not match the validated catalog registry" >&2; return 1; }
+            test "$validated_repository" = "$validated_registry/$image" || { echo "validated public repository does not match the selected catalog image" >&2; return 1; }
+          }
+          # END emergency-registry-binding-contract
+          validate_emergency_repository "$CONFIGURED_REGISTRY" "$REGISTRY" "$REPOSITORY" "$IMAGE_REF"
           echo "$REGISTRY_PASSWORD" | oras login "$REGISTRY" -u "$REGISTRY_USERNAME" --password-stdin
-          ref="$REGISTRY/$IMAGE_REF:$VERSION"
-          echo "::warning::Emergency overwrite replaces $ref; registry tag immutability must have been temporarily lifted by an administrator."
-          before=$(oras manifest fetch "$ref" --descriptor | jq -er '.digest | select(test("^sha256:[0-9a-f]{64}$"))')
+          ref="$REPOSITORY:$VERSION"
+          emergency_candidate="$REPOSITORY:emergency-${SOURCE_COMMIT}-${INPUT_HASH#sha256:}"
+          echo "::warning::Emergency overwrite may replace $ref; registry tag immutability must have been temporarily lifted by an administrator."
           # BEGIN plugin-manifest-publish-contract
           publish_plugin_manifest() {
             local ref=$1 wasm=$2 source_commit=$3 version=$4 input_hash=$5
@@ -325,44 +382,111 @@ jobs:
             printf '%s\n' "$digest"
           }
           # END plugin-manifest-publish-contract
-          digest=$(publish_plugin_manifest "$ref" /tmp/emergency-overwrite-artifact/plugin.wasm "$SOURCE_COMMIT" "$VERSION" "$INPUT_HASH")
-          after=$(oras manifest fetch "$ref" --descriptor | jq -er '.digest | select(test("^sha256:[0-9a-f]{64}$"))')
-          test "$after" = "$digest"
-          if [ "$MOVE_LATEST" = "true" ]; then
-            oras cp "$REGISTRY/$IMAGE_REF@$digest" "$REGISTRY/$IMAGE_REF:latest"
-            test "$(oras manifest fetch "$REGISTRY/$IMAGE_REF:latest" --descriptor | jq -er .digest)" = "$digest"
-          fi
-          printf '%s\n' "$digest" > /tmp/emergency-digest.txt
+          digest=$(publish_plugin_manifest "$emergency_candidate" /tmp/emergency-overwrite-artifact/plugin.wasm "$SOURCE_COMMIT" "$VERSION" "$INPUT_HASH")
+          candidate_digest=$(oras manifest fetch "$emergency_candidate" --descriptor | jq -er '.digest | select(test("^sha256:[0-9a-f]{64}$"))')
+          test "$candidate_digest" = "$digest"
+
+          tool=/tmp/emergency-overwrite-artifact/plugin-release
+          chmod 0700 "$tool"
+          test -x "$tool"
+          # BEGIN emergency-pull-verification-contract
+          # The incident channel is the only path that replaces a public stable
+          # tag, so it must clear the same loadability gate the immutable
+          # pipeline applies before a latest move. Verification re-pulls the
+          # staged candidate from the registry by digest and inspects what the
+          # registry actually serves: the manifest bytes, both layer blobs, and
+          # the Wasm module compiled from the pulled layer. Local build output is
+          # never a substitute, because a registry-side transformation or a
+          # partial push is exactly what this gate has to catch.
+          verify_emergency_pull() {
+            local tool=$1 repository=$2 digest=$3 source_commit=$4 version=$5 input_hash=$6 pull_dir=$7
+            local source_created
+            if ! test -x "$tool"; then echo "release tool is not executable: $tool" >&2; return 1; fi
+            if ! [[ "$digest" =~ ^sha256:[0-9a-f]{64}$ ]]; then echo "invalid staged candidate digest" >&2; return 1; fi
+            if ! [[ "$source_commit" =~ ^[0-9a-f]{40}$ ]]; then echo "invalid plugin source commit" >&2; return 1; fi
+            if ! [[ "$version" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then echo "invalid stable plugin version" >&2; return 1; fi
+            if ! [[ "$input_hash" =~ ^sha256:[0-9a-f]{64}$ ]]; then echo "invalid plugin input hash" >&2; return 1; fi
+            if ! [[ "$repository" == */* ]]; then echo "invalid public plugin repository: $repository" >&2; return 1; fi
+            if ! source_created=$(git show -s --format=%cI "$source_commit"); then echo "cannot resolve plugin source commit time" >&2; return 1; fi
+            if ! [[ "$source_created" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(Z|[+-][0-9]{2}:[0-9]{2})$ ]]; then
+              echo "invalid plugin source commit time" >&2; return 1
+            fi
+            rm -rf "$pull_dir"
+            if ! mkdir -p "$pull_dir"; then echo "cannot create the emergency pull directory: $pull_dir" >&2; return 1; fi
+            if ! oras manifest fetch "$repository@$digest" --output "$pull_dir/manifest.json"; then
+              rm -rf "$pull_dir"; echo "staged emergency candidate manifest cannot be pulled: $repository@$digest" >&2; return 1
+            fi
+            if ! oras pull "$repository@$digest" --output "$pull_dir" >/dev/null; then
+              rm -rf "$pull_dir"; echo "staged emergency candidate layers cannot be pulled: $repository@$digest" >&2; return 1
+            fi
+            if ! "$tool" verify-pulled-plugin --manifest "$pull_dir/manifest.json" --config "$pull_dir/config.json" --wasm "$pull_dir/plugin.wasm" \
+              --digest "$digest" --source-commit "$source_commit" --source-created "$source_created" --version "$version" --input-hash "$input_hash"; then
+              rm -rf "$pull_dir"
+              echo "staged emergency candidate failed pulled-artifact verification; the stable tag was not modified: $repository@$digest" >&2
+              return 1
+            fi
+            rm -rf "$pull_dir"
+          }
+          # END emergency-pull-verification-contract
+          verify_emergency_pull "$tool" "$REPOSITORY" "$digest" "$SOURCE_COMMIT" "$VERSION" "$INPUT_HASH" /tmp/emergency-pull-verification
+          echo "Staged emergency candidate \`$emergency_candidate@$digest\` passed the pulled-artifact verification gate." >> "$GITHUB_STEP_SUMMARY"
+
+          # Validate and stage the exact lineage bytes before touching the stable
+          # tag. If the later evidence publication fails, a same-run retry can
+          # reuse the desired digest without performing a second overwrite.
+          evidence="plugins/release/evidence/$GATEWAY_VERSION.json"
+          snapshot="plugins/release/snapshots/$GATEWAY_VERSION.json"
+          "$tool" append-emergency-lineage --evidence "$evidence" --snapshot "$snapshot" --output /tmp/staged-emergency-evidence.json \
+            --gateway-version "$GATEWAY_VERSION" --id "$LOGICAL_ID" --version "$VERSION" --image "$IMAGE_REF" \
+            --digest "$digest" --input-hash "$INPUT_HASH" --source-commit "$SOURCE_COMMIT" --workflow-run-id "$WORKFLOW_RUN_ID"
+          predecessor=$(jq -er --arg id "$LOGICAL_ID" '.plugins[$id] | if ((.lineage // []) | length) > 0 then .lineage[-1].digest else .digest end | select(test("^sha256:[0-9a-f]{64}$"))' "$evidence")
+
+          # BEGIN emergency-stable-overwrite-contract
+          promote_emergency_candidate() {
+            local candidate_ref=$1 stable_ref=$2 predecessor=$3 desired=$4 run_attempt=$5
+            local descriptor current after candidate_repo
+            if ! [[ "$run_attempt" =~ ^[1-9][0-9]*$ ]]; then
+              echo "invalid workflow run attempt" >&2
+              return 1
+            fi
+            if ! descriptor=$(oras manifest fetch "$stable_ref" --descriptor); then
+              echo "emergency stable tag is absent or cannot be resolved: $stable_ref" >&2
+              return 1
+            fi
+            if ! current=$(jq -ser 'select(length == 1) | .[0] | select(.mediaType == "application/vnd.oci.image.manifest.v1+json") | .digest | strings | select(test("^sha256:[0-9a-f]{64}$"))' <<<"$descriptor"); then
+              echo "emergency stable tag descriptor is malformed: $stable_ref" >&2
+              return 1
+            fi
+            if [ "$current" = "$predecessor" ]; then
+              candidate_repo=${candidate_ref%:*}
+              oras cp "$candidate_repo@$desired" "$stable_ref"
+            elif [ "$current" = "$desired" ] && [ "$run_attempt" -gt 1 ]; then
+              echo "Stable tag already serves the desired digest; healing same-run evidence retry." >&2
+            else
+              echo "emergency stable tag predecessor conflict: $stable_ref has $current, expected $predecessor" >&2
+              return 1
+            fi
+            if ! after=$(oras manifest fetch "$stable_ref" --descriptor | jq -er '.digest | select(test("^sha256:[0-9a-f]{64}$"))'); then
+              echo "emergency stable tag cannot be re-resolved after publication: $stable_ref" >&2
+              return 1
+            fi
+            test "$after" = "$desired" || { echo "emergency stable tag does not serve the desired digest after publication" >&2; return 1; }
+            EMERGENCY_PREVIOUS_DIGEST=$current
+          }
+          # END emergency-stable-overwrite-contract
+          promote_emergency_candidate "$emergency_candidate" "$ref" "$predecessor" "$digest" "$RUN_ATTEMPT"
+          before=$EMERGENCY_PREVIOUS_DIGEST
           echo "digest=$digest" >> "$GITHUB_OUTPUT"
           {
             echo "## Emergency overwrite report"
             echo "- ref: \`$ref\`"
+            echo "- staged candidate: \`$emergency_candidate@$digest\`"
+            echo "- committed predecessor: \`$predecessor\`"
             echo "- previous digest: \`$before\`"
             echo "- new digest: \`$digest\`"
             echo "- input hash: \`$INPUT_HASH\`"
             echo "- source commit: \`$SOURCE_COMMIT\`"
-            echo "- latest moved: $MOVE_LATEST"
           } >> "$GITHUB_STEP_SUMMARY"
-      - name: Append emergency lineage with the current release tool
-        env:
-          GATEWAY_VERSION: ${{ inputs.gateway_version }}
-          LOGICAL_ID: ${{ inputs.logical_id }}
-          VERSION: ${{ inputs.version }}
-          SOURCE_COMMIT: ${{ inputs.source_commit }}
-          WORKFLOW_RUN_ID: ${{ github.run_id }}
-          IMAGE_REF: ${{ needs.validate.outputs.image }}
-          INPUT_HASH: ${{ needs.validate.outputs.input_hash }}
-          DIGEST: ${{ steps.publish.outputs.digest }}
-        run: |
-          set -euo pipefail
-          tool=/tmp/emergency-overwrite-artifact/plugin-release
-          evidence="plugins/release/evidence/$GATEWAY_VERSION.json"
-          snapshot="plugins/release/snapshots/$GATEWAY_VERSION.json"
-          chmod 0700 "$tool"
-          test -x "$tool"
-          "$tool" append-emergency-lineage --evidence "$evidence" --snapshot "$snapshot" --output "$evidence" \
-            --gateway-version "$GATEWAY_VERSION" --id "$LOGICAL_ID" --version "$VERSION" --image "$IMAGE_REF" \
-            --digest "$DIGEST" --input-hash "$INPUT_HASH" --source-commit "$SOURCE_COMMIT" --workflow-run-id "$WORKFLOW_RUN_ID"
       - name: Create or update deterministic emergency evidence PR
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
@@ -377,6 +501,8 @@ jobs:
           set -euo pipefail
           test "$(git rev-parse HEAD)" = "$EVIDENCE_BASE"
           evidence="plugins/release/evidence/$GATEWAY_VERSION.json"
+          test -s /tmp/staged-emergency-evidence.json
+          cp /tmp/staged-emergency-evidence.json "$evidence"
           branch="release/plugin-emergency-evidence-$GATEWAY_VERSION-$LOGICAL_ID-$WORKFLOW_RUN_ID"
           title="chore: record emergency plugin lineage $GATEWAY_VERSION $LOGICAL_ID"
           body="Records emergency overwrite workflow run $WORKFLOW_RUN_ID for $LOGICAL_ID:$VERSION at $DIGEST. The registry write precedes this PR, so a failed evidence publication must be retried with the same run ID."
@@ -403,3 +529,44 @@ jobs:
           fi
           gh pr create --base main --head "$branch" --title "$title" --body "$body" || gh pr edit "$branch" --title "$title" --body "$body"
           echo "Emergency evidence PR branch: \`$branch\`" >> "$GITHUB_STEP_SUMMARY"
+      # Retention rule: the emergency-<source-commit>-<input-hash> staging tag
+      # is retained permanently as public provenance of what was verified and
+      # promoted. It is content-addressed by commit+input-hash (one per overwrite
+      # attempt, collision-free) and serves the same manifest as the stable tag.
+      # Registries commonly implement tag deletion as manifest deletion (ACR
+      # included), so untagging the staging reference could destroy the manifest
+      # the stable tag serves; oras 1.2.3 has no portable tag-only unlink. Do not
+      # attempt cleanup: the durable record of an overwrite is the committed
+      # lineage evidence and its PR, and the staging tag is the auditable pointer
+      # to exactly what was verified before promotion.
+      - name: Record the retained emergency staging tag
+        env:
+          REPOSITORY: ${{ needs.validate.outputs.public_repository }}
+          VERSION: ${{ inputs.version }}
+          SOURCE_COMMIT: ${{ inputs.source_commit }}
+          INPUT_HASH: ${{ needs.validate.outputs.input_hash }}
+          DIGEST: ${{ steps.publish.outputs.digest }}
+        run: |
+          set -euo pipefail
+          # BEGIN emergency-staging-cleanup-contract
+          # Retention policy: the emergency-<source-commit>-<input-hash> staging
+          # tag is RETAINED as public provenance of what was verified and
+          # promoted. It is content-addressed by commit+input-hash (collision
+          # free, one per overwrite attempt) and serves the same manifest as the
+          # stable tag. Registries commonly implement tag deletion as manifest
+          # deletion (ACR included), so untagging the staging reference could
+          # destroy the manifest the stable tag serves; there is no portable
+          # tag-only unlink in oras 1.2.3. Do NOT attempt cleanup here.
+          staging_ref="$REPOSITORY:emergency-${SOURCE_COMMIT}-${INPUT_HASH#sha256:}"
+          echo "- emergency staging tag **retained** as provenance: \`$staging_ref\` (shares manifest $DIGEST with the stable tag by design)" >> "$GITHUB_STEP_SUMMARY"
+          # END emergency-staging-cleanup-contract
+      - name: Move latest only after evidence publication
+        if: ${{ inputs.move_latest }}
+        env:
+          REPOSITORY: ${{ needs.validate.outputs.public_repository }}
+          DIGEST: ${{ steps.publish.outputs.digest }}
+        run: |
+          set -euo pipefail
+          oras cp "$REPOSITORY@$DIGEST" "$REPOSITORY:latest"
+          test "$(oras manifest fetch "$REPOSITORY:latest" --descriptor | jq -er '.digest | select(test("^sha256:[0-9a-f]{64}$"))')" = "$DIGEST"
+          echo "Emergency latest moved to \`$DIGEST\` after evidence PR publication." >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/prepare-plugin-release.yaml
+++ b/.github/workflows/prepare-plugin-release.yaml
@@ -249,16 +249,92 @@ jobs:
             esac
           }
           # END plugin-build-contract
+          # BEGIN plugin-manifest-publish-contract
+          publish_plugin_manifest() {
+            local ref=$1 wasm=$2 source_commit=$3 version=$4 input_hash=$5
+            local stage push_result digest manifest repo source_created wasm_digest wasm_size
+            # Bash normally clears errexit inside command substitution. Restore it
+            # because both callers capture this function's digest that way.
+            set -e
+            if ! [[ "$source_commit" =~ ^[0-9a-f]{40}$ ]]; then echo "invalid plugin source commit" >&2; return 1; fi
+            if ! [[ "$version" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then echo "invalid stable plugin version" >&2; return 1; fi
+            if ! [[ "$input_hash" =~ ^sha256:[0-9a-f]{64}$ ]]; then echo "invalid plugin input hash" >&2; return 1; fi
+            if ! test -s "$wasm"; then echo "plugin.wasm is missing or empty" >&2; return 1; fi
+            if ! source_created=$(git show -s --format=%cI "$source_commit"); then echo "cannot resolve plugin source commit time" >&2; return 1; fi
+            if ! [[ "$source_created" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(Z|[+-][0-9]{2}:[0-9]{2})$ ]]; then echo "invalid plugin source commit time" >&2; return 1; fi
+            wasm_digest="sha256:$(sha256sum "$wasm" | awk '{print $1}')"
+            wasm_size=$(wc -c < "$wasm"); wasm_size=${wasm_size//[[:space:]]/}
+            stage=$(mktemp -d)
+            if ! printf '%s' '{}' > "$stage/config.json" || ! cp "$wasm" "$stage/plugin.wasm"; then
+              rm -rf "$stage"; echo "failed to stage plugin manifest layers" >&2; return 1
+            fi
+            if ! push_result=$(cd "$stage" && oras push "$ref" \
+              "config.json:application/vnd.module.wasm.config.v1+json" \
+              "plugin.wasm:application/vnd.module.wasm.content.layer.v1+wasm" \
+              --image-spec v1.0 \
+              --annotation "org.opencontainers.image.created=$source_created" \
+              --annotation "org.opencontainers.image.revision=$source_commit" \
+              --annotation "org.opencontainers.image.version=$version" \
+              --annotation "io.higress.plugin.input-hash=$input_hash" \
+              --format json); then
+              rm -rf "$stage"; echo "plugin manifest push failed: $ref" >&2; return 1
+            fi
+            rm -rf "$stage"
+            if ! digest=$(jq -ser 'select(length == 1) | .[0].digest | strings | select(test("^sha256:[0-9a-f]{64}$"))' <<<"$push_result"); then
+              echo "plugin manifest push returned a malformed descriptor: $ref" >&2; return 1
+            fi
+            repo=${ref%:*}
+            if ! manifest=$(oras manifest fetch "$repo@$digest"); then
+              echo "published plugin manifest cannot be resolved by digest: $repo@$digest" >&2; return 1
+            fi
+            if ! jq -se --arg commit "$source_commit" --arg created "$source_created" --arg version "$version" --arg input_hash "$input_hash" --arg wasm_digest "$wasm_digest" --argjson wasm_size "$wasm_size" '
+              length == 1 and (.[0] |
+                (keys == ["annotations","config","layers","mediaType","schemaVersion"]) and
+                .schemaVersion == 2 and
+                .mediaType == "application/vnd.oci.image.manifest.v1+json" and
+                (.config == {
+                  "mediaType":"application/vnd.unknown.config.v1+json",
+                  "digest":"sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a",
+                  "size":2
+                }) and
+                (.annotations == {
+                  "org.opencontainers.image.created": $created,
+                  "org.opencontainers.image.revision": $commit,
+                  "org.opencontainers.image.version": $version,
+                  "io.higress.plugin.input-hash": $input_hash
+                }) and
+                (.layers | type == "array" and length == 2) and
+                (.layers[0] == {
+                  "mediaType":"application/vnd.module.wasm.config.v1+json",
+                  "digest":"sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a",
+                  "size":2,
+                  "annotations":{"org.opencontainers.image.title":"config.json"}
+                }) and
+                (.layers[1] == {
+                  "mediaType":"application/vnd.module.wasm.content.layer.v1+wasm",
+                  "digest":$wasm_digest,
+                  "size":$wasm_size,
+                  "annotations":{"org.opencontainers.image.title":"plugin.wasm"}
+                })
+              )
+            ' >/dev/null <<<"$manifest"; then
+              echo "published plugin manifest does not match the deterministic two-layer contract: $ref" >&2; return 1
+            fi
+            printf '%s\n' "$digest"
+          }
+          # END plugin-manifest-publish-contract
           # BEGIN candidate-publish-contract
           resolve_or_build_candidate() {
             local candidate=$1 implementation=$2 source=$3 build_name=$4 source_commit=$5 version=$6 input_hash=$7
-            local candidate_repo descriptor manifest resolved_digest push_result lookup_error auth_error wasm
+            local candidate_repo descriptor manifest resolved_digest lookup_error auth_error source_created wasm
             # Bash normally clears errexit inside command substitution. Restore
             # it because the caller captures this function's digest that way.
             set -e
             if ! [[ "$source_commit" =~ ^[0-9a-f]{40}$ ]]; then echo "invalid candidate source commit" >&2; return 1; fi
             if ! [[ "$version" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then echo "invalid stable candidate version" >&2; return 1; fi
             if ! [[ "$input_hash" =~ ^sha256:[0-9a-f]{64}$ ]]; then echo "invalid candidate input hash" >&2; return 1; fi
+            if ! source_created=$(git show -s --format=%cI "$source_commit"); then echo "cannot resolve candidate source commit time" >&2; return 1; fi
+            if ! [[ "$source_created" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(Z|[+-][0-9]{2}:[0-9]{2})$ ]]; then echo "invalid candidate source commit time" >&2; return 1; fi
             candidate_repo=${candidate%:*}
             lookup_error=$(mktemp)
             if descriptor=$(oras manifest fetch "$candidate" --descriptor 2>"$lookup_error"); then
@@ -275,16 +351,34 @@ jobs:
                 echo "existing candidate manifest cannot be resolved by digest: $candidate_repo@$resolved_digest" >&2
                 return 1
               fi
-              if ! jq -se --arg commit "$source_commit" --arg version "$version" --arg input_hash "$input_hash" '
+              if ! jq -se --arg commit "$source_commit" --arg created "$source_created" --arg version "$version" --arg input_hash "$input_hash" '
                 length == 1 and (.[0] |
+                  (keys == ["annotations","config","layers","mediaType","schemaVersion"]) and
                   .schemaVersion == 2 and
                   .mediaType == "application/vnd.oci.image.manifest.v1+json" and
-                  (.annotations["org.opencontainers.image.revision"] == $commit) and
-                  (.annotations["org.opencontainers.image.version"] == $version) and
-                  (.annotations["io.higress.plugin.input-hash"] == $input_hash) and
-                  (.layers | type == "array" and length == 1) and
-                  (.layers[0].mediaType == "application/vnd.module.wasm.content.layer.v1+wasm") and
-                  (.layers[0].digest | strings | test("^sha256:[0-9a-f]{64}$"))
+                  (.config == {
+                    "mediaType":"application/vnd.unknown.config.v1+json",
+                    "digest":"sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a",
+                    "size":2
+                  }) and
+                  (.annotations == {
+                    "org.opencontainers.image.created": $created,
+                    "org.opencontainers.image.revision": $commit,
+                    "org.opencontainers.image.version": $version,
+                    "io.higress.plugin.input-hash": $input_hash
+                  }) and
+                  (.layers | type == "array" and length == 2) and
+                  (.layers[0] == {
+                    "mediaType":"application/vnd.module.wasm.config.v1+json",
+                    "digest":"sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a",
+                    "size":2,
+                    "annotations":{"org.opencontainers.image.title":"config.json"}
+                  }) and
+                  ((.layers[1] | keys) == ["annotations","digest","mediaType","size"]) and
+                  (.layers[1].mediaType == "application/vnd.module.wasm.content.layer.v1+wasm") and
+                  (.layers[1].digest | strings | test("^sha256:[0-9a-f]{64}$")) and
+                  (.layers[1].size | numbers and . > 8) and
+                  (.layers[1].annotations == {"org.opencontainers.image.title":"plugin.wasm"})
                 )
               ' >/dev/null <<<"$manifest"; then
                 echo "existing candidate manifest does not match its planned provenance: $candidate" >&2
@@ -317,15 +411,7 @@ jobs:
               echo "candidate build did not produce plugin.wasm: $candidate" >&2
               return 1
             fi
-            if ! push_result=$(oras push "$candidate" "$wasm:application/vnd.module.wasm.content.layer.v1+wasm" --annotation "org.opencontainers.image.revision=$source_commit" --annotation "org.opencontainers.image.version=$version" --annotation "io.higress.plugin.input-hash=$input_hash" --format json); then
-              echo "candidate push failed: $candidate" >&2
-              return 1
-            fi
-            if ! resolved_digest=$(jq -ser 'select(length == 1) | .[0].digest | strings | select(test("^sha256:[0-9a-f]{64}$"))' <<<"$push_result"); then
-              echo "candidate push returned a malformed descriptor: $candidate" >&2
-              return 1
-            fi
-            printf '%s\n' "$resolved_digest"
+            publish_plugin_manifest "$candidate" "$wasm" "$source_commit" "$version" "$input_hash"
           }
           # END candidate-publish-contract
           jq -n '{plugins:{}}' >/tmp/candidates.json

--- a/.github/workflows/prepare-plugin-release.yaml
+++ b/.github/workflows/prepare-plugin-release.yaml
@@ -233,6 +233,7 @@ jobs:
           set -euo pipefail
           test -n "$CANDIDATE_REGISTRY"; test -n "$REGISTRY_USERNAME"; test -n "$REGISTRY_PASSWORD"
           echo "$REGISTRY_PASSWORD" | oras login "$CANDIDATE_REGISTRY" -u "$REGISTRY_USERNAME" --password-stdin
+          (cd tools/plugin-release && GOMAXPROCS=1 go build -p 1 -o /tmp/plugin-release-prepare .)
           # BEGIN plugin-build-contract
           prepare_test_and_build_plugin() {
             local implementation=$1 source=$2 build_name=$3
@@ -325,14 +326,15 @@ jobs:
           # END plugin-manifest-publish-contract
           # BEGIN candidate-publish-contract
           resolve_or_build_candidate() {
-            local candidate=$1 implementation=$2 source=$3 build_name=$4 source_commit=$5 version=$6 input_hash=$7
-            local candidate_repo descriptor manifest resolved_digest lookup_error auth_error source_created wasm
+            local candidate=$1 implementation=$2 source=$3 build_name=$4 source_commit=$5 version=$6 input_hash=$7 release_tool=$8
+            local candidate_repo descriptor manifest resolved_digest lookup_error auth_error source_created wasm wasm_digest wasm_size pull_dir verify_error
             # Bash normally clears errexit inside command substitution. Restore
             # it because the caller captures this function's digest that way.
             set -e
             if ! [[ "$source_commit" =~ ^[0-9a-f]{40}$ ]]; then echo "invalid candidate source commit" >&2; return 1; fi
             if ! [[ "$version" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then echo "invalid stable candidate version" >&2; return 1; fi
             if ! [[ "$input_hash" =~ ^sha256:[0-9a-f]{64}$ ]]; then echo "invalid candidate input hash" >&2; return 1; fi
+            if ! test -x "$release_tool"; then echo "candidate verifier is missing or not executable" >&2; return 1; fi
             if ! source_created=$(git show -s --format=%cI "$source_commit"); then echo "cannot resolve candidate source commit time" >&2; return 1; fi
             if ! [[ "$source_created" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(Z|[+-][0-9]{2}:[0-9]{2})$ ]]; then echo "invalid candidate source commit time" >&2; return 1; fi
             candidate_repo=${candidate%:*}
@@ -347,10 +349,13 @@ jobs:
                 echo "existing candidate descriptor is malformed: $candidate" >&2
                 return 1
               fi
-              if ! manifest=$(oras manifest fetch "$candidate_repo@$resolved_digest"); then
+              pull_dir=$(mktemp -d)
+              if ! oras manifest fetch "$candidate_repo@$resolved_digest" --output "$pull_dir/manifest.json"; then
+                rm -rf "$pull_dir"
                 echo "existing candidate manifest cannot be resolved by digest: $candidate_repo@$resolved_digest" >&2
                 return 1
               fi
+              manifest=$(<"$pull_dir/manifest.json")
               if ! jq -se --arg commit "$source_commit" --arg created "$source_created" --arg version "$version" --arg input_hash "$input_hash" '
                 length == 1 and (.[0] |
                   (keys == ["annotations","config","layers","mediaType","schemaVersion"]) and
@@ -381,9 +386,44 @@ jobs:
                   (.layers[1].annotations == {"org.opencontainers.image.title":"plugin.wasm"})
                 )
               ' >/dev/null <<<"$manifest"; then
+                rm -rf "$pull_dir"
                 echo "existing candidate manifest does not match its planned provenance: $candidate" >&2
                 return 1
               fi
+              # Rebuild even on reuse: metadata alone cannot prove that an
+              # existing candidate contains the selected source bytes.
+              prepare_test_and_build_plugin "$implementation" "$source" "$build_name" >&2
+              wasm="$source/plugin.wasm"
+              if ! test -s "$wasm"; then
+                rm -rf "$pull_dir"
+                echo "candidate build did not produce plugin.wasm: $candidate" >&2
+                return 1
+              fi
+              wasm_digest="sha256:$(sha256sum "$wasm" | awk '{print $1}')"
+              wasm_size=$(wc -c < "$wasm"); wasm_size=${wasm_size//[[:space:]]/}
+              if ! jq -e --arg digest "$wasm_digest" --argjson size "$wasm_size" '.layers[1].digest == $digest and .layers[1].size == $size' "$pull_dir/manifest.json" >/dev/null; then
+                rm -rf "$pull_dir"
+                echo "existing candidate Wasm descriptor does not match the deterministic source build: $candidate" >&2
+                return 1
+              fi
+              if ! oras pull "$candidate_repo@$resolved_digest" --output "$pull_dir" >/dev/null; then
+                rm -rf "$pull_dir"
+                echo "existing candidate blobs cannot be pulled by digest: $candidate_repo@$resolved_digest" >&2
+                return 1
+              fi
+              if ! test -f "$pull_dir/config.json" || ! test -f "$pull_dir/plugin.wasm" || ! cmp -s "$wasm" "$pull_dir/plugin.wasm"; then
+                rm -rf "$pull_dir"
+                echo "existing candidate pulled blobs do not match the deterministic source build: $candidate" >&2
+                return 1
+              fi
+              verify_error=$(mktemp)
+              if ! "$release_tool" verify-pulled-plugin --manifest "$pull_dir/manifest.json" --config "$pull_dir/config.json" --wasm "$pull_dir/plugin.wasm" --digest "$resolved_digest" --source-commit "$source_commit" --source-created "$source_created" --version "$version" --input-hash "$input_hash" 2>"$verify_error"; then
+                cat "$verify_error" >&2
+                rm -f "$verify_error"; rm -rf "$pull_dir"
+                echo "existing candidate failed strict pulled-artifact validation: $candidate" >&2
+                return 1
+              fi
+              rm -f "$verify_error"; rm -rf "$pull_dir"
               printf '%s\n' "$resolved_digest"
               return 0
             fi
@@ -425,7 +465,7 @@ jobs:
             # Both hashes are fixed-width SHA-256 hex strings, so concatenation
             # retains their complete identities while meeting OCI's 128-byte tag limit.
             candidate="$CANDIDATE_REGISTRY/candidates/$id:${plan_id}${input_hash#sha256:}"
-            digest=$(resolve_or_build_candidate "$candidate" "$implementation" "$source" "$build_name" "$source_commit" "$version" "$input_hash")
+            digest=$(resolve_or_build_candidate "$candidate" "$implementation" "$source" "$build_name" "$source_commit" "$version" "$input_hash" /tmp/plugin-release-prepare)
             jq --arg id "$id" --arg ref "${candidate%@*}@$digest" --arg digest "$digest" --arg commit "$source_commit" --arg hash "$input_hash" '.plugins[$id]={candidateRef:$ref,digest:$digest,sourceCommit:$commit,inputHash:$hash}' /tmp/candidates.json >/tmp/candidates.next && mv /tmp/candidates.next /tmp/candidates.json
           done
           cp /tmp/candidates.json "plugins/release/evidence/$GATEWAY_VERSION.json"

--- a/.github/workflows/promote-plugin-release.yaml
+++ b/.github/workflows/promote-plugin-release.yaml
@@ -436,14 +436,39 @@ jobs:
             echo "every snapshot plugin is excluded by migration preflight; no latest alias can move" >&2
             exit 1
           fi
+          (cd tools/plugin-release && GOMAXPROCS=1 go build -p 1 -o /tmp/plugin-release .)
+          pull_gate_failures=0
           while read -r entry; do
             id=$(jq -r .logicalId <<<"$entry"); ref=$(jq -r .ociRef <<<"$entry"); digest=$(jq -r .digest <<<"$entry")
             if [ "$(jq -r '.migration.state // empty' <<<"$entry")" = blocked ]; then
               continue
             fi
+            version=$(jq -r .version <<<"$entry"); source_commit=$(jq -r .sourceCommit <<<"$entry"); input_hash=$(jq -r .inputHash <<<"$entry")
+            image=${ref%:*}; latest="$image:latest"; digest_ref="$image@$digest"
+            pull_dir="/tmp/plugin-release-pull-$id"
+            pull_error=$(mktemp)
+            rm -rf "$pull_dir"; mkdir -p "$pull_dir"
+            pull_reason=""; source_created=""
+            if ! oras manifest fetch "$digest_ref" --output "$pull_dir/manifest.json" 2>"$pull_error"; then
+              pull_reason="manifest fetch failed: $(tr '\r\n' '  ' < "$pull_error")"
+            elif ! oras pull "$digest_ref" --output "$pull_dir" >/dev/null 2>"$pull_error"; then
+              pull_reason="artifact pull failed: $(tr '\r\n' '  ' < "$pull_error")"
+            elif ! source_created=$(git show -s --format=%cI "$source_commit" 2>"$pull_error"); then
+              pull_reason="source commit timestamp lookup failed: $(tr '\r\n' '  ' < "$pull_error")"
+            elif ! [[ "$source_created" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(Z|[+-][0-9]{2}:[0-9]{2})$ ]]; then
+              pull_reason="source commit timestamp is not canonical RFC3339: $source_created"
+            elif ! /tmp/plugin-release verify-pulled-plugin --manifest "$pull_dir/manifest.json" --config "$pull_dir/config.json" --wasm "$pull_dir/plugin.wasm" --digest "$digest" --source-commit "$source_commit" --source-created "$source_created" --version "$version" --input-hash "$input_hash" 2>"$pull_error"; then
+              pull_reason="artifact validation failed: $(tr '\r\n' '  ' < "$pull_error")"
+            fi
+            rm -f "$pull_error"
+            if [ -n "$pull_reason" ]; then
+              pull_reason=${pull_reason:0:320}
+              pull_gate_failures=$((pull_gate_failures + 1))
+              jq --arg ref "$ref" --arg latest "$latest" --arg digest "$digest" --arg version "$version" --arg digestRef "$digest_ref" --arg reason "$pull_reason" '.entries += [{ref:$ref,latest:$latest,digest:$digest,version:$version,preflight:"pull-gate-failed",pullGate:{status:"failed",digestRef:$digestRef,reason:$reason}}]' "/tmp/plugin-release-latest-$SNAPSHOT_SHA256.json" > /tmp/journal.next && mv /tmp/journal.next "/tmp/plugin-release-latest-$SNAPSHOT_SHA256.json"
+              echo "Latest skipped for $ref@$digest: $pull_reason" >> "$GITHUB_STEP_SUMMARY"
+              continue
+            fi
             test "$(oras manifest fetch "$ref" --descriptor | jq -r .digest)" = "$digest"
-            version=$(jq -r .version <<<"$entry")
-            image=${ref%:*}; latest="$image:latest"
             if latest_json=$(descriptor_or_absent "$latest"); then
               old_digest=$(jq -r .digest <<<"$latest_json")
               if [ "$old_digest" = "$digest" ]; then
@@ -464,7 +489,7 @@ jobs:
                     test "$(jq -er .publicRef <<<"$bootstrap_entry")" = "$image:$bootstrap_version" || { echo "bootstrap evidence public reference does not match latest image: $id" >&2; exit 1; }
                     if [ "$bootstrap_status" = public ]; then
                       [[ "$(jq -er .digest <<<"$bootstrap_entry")" =~ ^sha256:[0-9a-f]{64}$ ]]
-                      (cd tools/plugin-release && go run . semver-compare --current "$bootstrap_version" --candidate "$version")
+                      /tmp/plugin-release semver-compare --current "$bootstrap_version" --candidate "$version"
                       test "$bootstrap_version" != "$version" || { echo "latest alias conflict: $latest is unannotated and bootstrap does not authorize replacing the same stable version" >&2; exit 1; }
                     else
                       test "$bootstrap_version" = "$version" || { echo "missing bootstrap entry version does not match selected plugin version: $id" >&2; exit 1; }
@@ -475,7 +500,7 @@ jobs:
                     echo "existing latest lacks a stable version annotation outside a verified bootstrap snapshot: $latest" >&2; exit 1
                   fi
                 else
-                  (cd tools/plugin-release && go run . semver-compare --current "$old" --candidate "$version")
+                  /tmp/plugin-release semver-compare --current "$old" --candidate "$version"
                   if [ "$old" = "$version" ]; then
                     echo "latest alias conflict: $latest serves $old at $old_digest, snapshot requires $digest" >&2; exit 1
                   fi
@@ -487,14 +512,19 @@ jobs:
               test "$status" = 1 || exit "$status"
               old_digest=""; old=""; state=create
             fi
-            jq --arg ref "$ref" --arg latest "$latest" --arg digest "$digest" --arg version "$version" --arg oldDigest "$old_digest" --arg oldVersion "$old" --arg state "$state" '.entries += [{ref:$ref,latest:$latest,digest:$digest,version:$version,oldDigest:$oldDigest,oldVersion:$oldVersion,preflight:$state}]' "/tmp/plugin-release-latest-$SNAPSHOT_SHA256.json" > /tmp/journal.next && mv /tmp/journal.next "/tmp/plugin-release-latest-$SNAPSHOT_SHA256.json"
+            jq --arg ref "$ref" --arg latest "$latest" --arg digest "$digest" --arg version "$version" --arg oldDigest "$old_digest" --arg oldVersion "$old" --arg state "$state" --arg digestRef "$digest_ref" '.entries += [{ref:$ref,latest:$latest,digest:$digest,version:$version,oldDigest:$oldDigest,oldVersion:$oldVersion,preflight:$state,pullGate:{status:"passed",digestRef:$digestRef}}]' "/tmp/plugin-release-latest-$SNAPSHOT_SHA256.json" > /tmp/journal.next && mv /tmp/journal.next "/tmp/plugin-release-latest-$SNAPSHOT_SHA256.json"
           done < <(jq -c '.plugins[]' "$SNAPSHOT_PATH")
-          # Identical aliases are accepted without a mutable write; create and
-          # advance are the only writes, and the complete set is then
-          # re-resolved before the phase is considered complete.
-          jq -c '.entries[] | select(.preflight != "identical")' "/tmp/plugin-release-latest-$SNAPSHOT_SHA256.json" | while read -r entry; do ref=$(jq -r .ref <<<"$entry"); oras cp "${ref%:*}@$(jq -r .digest <<<"$entry")" "$(jq -r .latest <<<"$entry")"; done
-          jq -c '.entries[]' "/tmp/plugin-release-latest-$SNAPSHOT_SHA256.json" | while read -r entry; do test "$(oras manifest fetch "$(jq -r .latest <<<"$entry")" --descriptor | jq -r .digest)" = "$(jq -r .digest <<<"$entry")"; done
-          jq --argjson excluded "$(jq -c '[.plugins[] | select((.migration.state // "") == "blocked") | {logicalId, ociRef, version, existingDigest: .migration.existingDigest, recommendation: .migration.recommendation}]' "$SNAPSHOT_PATH")" '.phase="latest-complete" | .migrationExcluded = $excluded' "/tmp/plugin-release-latest-$SNAPSHOT_SHA256.json" > /tmp/journal.next && mv /tmp/journal.next "/tmp/plugin-release-latest-$SNAPSHOT_SHA256.json"
+          # Every remote pull gate and alias preflight above completes before the
+          # first mutable latest write. Failed pulls skip only their own alias.
+          jq -c '.entries[] | select(.pullGate.status == "passed" and .preflight != "identical")' "/tmp/plugin-release-latest-$SNAPSHOT_SHA256.json" | while read -r entry; do ref=$(jq -r .ref <<<"$entry"); oras cp "${ref%:*}@$(jq -r .digest <<<"$entry")" "$(jq -r .latest <<<"$entry")"; done
+          jq -c '.entries[] | select(.pullGate.status == "passed")' "/tmp/plugin-release-latest-$SNAPSHOT_SHA256.json" | while read -r entry; do test "$(oras manifest fetch "$(jq -r .latest <<<"$entry")" --descriptor | jq -r .digest)" = "$(jq -r .digest <<<"$entry")"; done
+          excluded=$(jq -c '[.plugins[] | select((.migration.state // "") == "blocked") | {logicalId, ociRef, version, existingDigest: .migration.existingDigest, recommendation: .migration.recommendation}]' "$SNAPSHOT_PATH")
+          if [ "$pull_gate_failures" -gt 0 ]; then
+            jq --argjson excluded "$excluded" --argjson failures "$pull_gate_failures" '.phase="latest-partial" | .pullGateFailures=$failures | .migrationExcluded=$excluded' "/tmp/plugin-release-latest-$SNAPSHOT_SHA256.json" > /tmp/journal.next && mv /tmp/journal.next "/tmp/plugin-release-latest-$SNAPSHOT_SHA256.json"
+            echo "$pull_gate_failures public artifact pull gate(s) failed; passing latest aliases were processed, no completion marker was published" >&2
+            exit 1
+          fi
+          jq --argjson excluded "$excluded" '.phase="latest-complete" | .migrationExcluded = $excluded' "/tmp/plugin-release-latest-$SNAPSHOT_SHA256.json" > /tmp/journal.next && mv /tmp/journal.next "/tmp/plugin-release-latest-$SNAPSHOT_SHA256.json"
           # END promotion-latest-contract
           # The registry marker is the cross-workflow completion gate. Its
           # immutable content is the fully reverified version/latest batch.
@@ -514,7 +544,7 @@ jobs:
             marker_digest=$(cd /tmp && oras push "$marker" "$marker_journal:application/vnd.higress.plugin-release-batch.v1+json" --format json | jq -r .digest)
           fi
           jq --arg ref "$marker" --arg digest "$marker_digest" '.completionMarker={ref:$ref,digest:$digest}' "/tmp/plugin-release-latest-$SNAPSHOT_SHA256.json" > /tmp/journal.next && mv /tmp/journal.next "/tmp/plugin-release-latest-$SNAPSHOT_SHA256.json"
-      - name: Persist complete latest batch journal
+      - name: Persist latest batch journal
         if: ${{ always() }}
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:

--- a/docs/developers/immutable-plugin-releases.md
+++ b/docs/developers/immutable-plugin-releases.md
@@ -17,11 +17,12 @@ controls exist.
   with an expiry policy.
 - Scope the credential able to write `plugins/<plugin>:<VERSION>` and `:latest`
   as narrowly as GitHub still allows, and remove equivalent public-write access
-  from legacy Wasm workflows and users. Since SPEC-4634005 only the latest-move
-  job keeps the protected `plugin-release-production` environment, so the
-  version-tag phase reads that credential without an environment gate: it must
-  be a repository-scoped secret, which means every workflow in this repository
-  can read it. Review that exposure before each release, keep the credential
+  from legacy Wasm workflows and users. Since SPEC-4634005 only the routine
+  latest-move job keeps the protected `plugin-release-production` environment,
+  both the version-tag phase and the self-authorizing emergency workflow read
+  that credential without an environment gate. It must therefore be a
+  repository-scoped secret, which means every workflow in this repository can
+  read it. Review that exposure before each release, keep the credential
   limited to the plugin namespaces, and never reference it from a
   pull-request-triggered workflow.
 - Give the protected `plugin-server-production` environment the sole
@@ -44,7 +45,10 @@ controls exist.
   explicit registry absence evidence is treated as missing.
 - Create a scoped GitHub App for each downstream repository dispatch/PR
   receiver. It may update the deterministic dependency PR but may not merge,
-  tag, or release.
+  tag, or release. Configure the emergency evidence publisher as
+  `RELEASE_PR_APP_ID` and `RELEASE_PR_APP_PRIVATE_KEY`; its installation on
+  `higress-group/higress` needs repository contents and pull-request write
+  permission, but no merge, tag, release, or registry permission.
 - Grant the release preparation App label write permission in addition to its
   contents and pull-request permissions. It applies `release/<gateway-version>`
   to the preparation PR it opens, and promote refuses to run without that label
@@ -80,12 +84,20 @@ repository source alone.
    see "Bootstrap deferral and backfill" below.
 3. Build/test every plan entry through the protected candidate publisher. Each
    candidate is keyed by plan ID/input hash and reports its manifest digest,
-   source commit, and input hash. Before the snapshot is rendered, the workflow
-   sweeps the public registry for every planned version tag and compares each
-   occupied tag with the candidate digest just built; see "Onboarding migration
-   preflight" below. Render the snapshot only after every changed
-   entry has matching evidence. A later source or `VERSION` edit invalidates
-   that evidence.
+   source commit, and input hash. Candidate and emergency publication execute
+   the same fail-closed manifest contract: exactly two ordered OCI layers,
+   `config.json` as `application/vnd.module.wasm.config.v1+json` followed by
+   `plugin.wasm` as
+   `application/vnd.module.wasm.content.layer.v1+wasm`, with OCI image-spec v1.0,
+   `created` fixed to the source commit time, and identical revision, version,
+   and input-hash annotations. Reuse validates that exact layout;
+   publication also binds the layer descriptors to the local bytes and returns
+   only a validated SHA-256 manifest digest. Before the snapshot is rendered,
+   the workflow sweeps the public registry for every planned version tag and
+   compares each occupied tag with the candidate digest just built; see
+   "Onboarding migration preflight" below. Render the snapshot only after every
+   changed entry has matching
+   evidence. A later source or `VERSION` edit invalidates that evidence.
 4. Review and merge the one preparation PR containing `VERSION` edits and
    `plugins/release/snapshots/<gateway-version>.json`. The snapshot carries all
    release-eligible plugins, including unchanged entries carried forward by
@@ -103,15 +115,22 @@ repository source alone.
    code-freeze commit the snapshot records, is reachable from `main`, and
    belongs to exactly one merged preparation PR from
    `release/plugin-snapshot-<gateway-version>` carrying the
-   `release/<gateway-version>` label. A production publisher may create a missing public version tag or
-   accept an identical existing digest only. It must fail before mutation on a
-   conflicting digest, and it skips every entry the migration preflight
-   excluded. Advance `latest` only after the full batch verifies and
-   only when its stable SemVer cannot move backwards; this move is the second
-   human gate and still waits for the protected `plugin-release-production`
-   environment approval. An existing `latest`
-   already serving the desired digest is accepted before reading legacy
-   version annotations and is never rewritten.
+   `release/<gateway-version>` label. A production publisher may create a
+   missing public version tag or accept an identical existing digest only. It
+   must fail before mutation on a conflicting digest, and it skips every entry
+   the migration preflight excluded. Before any `latest` write, it fetches and
+   pulls every non-blocked public artifact remotely by its snapshot digest. The
+   local gate verifies the OCI schema and two-layer order, provenance,
+   descriptor sizes and digests, object-valued JSON config, Wasm framing, and
+   required Proxy-Wasm entry-point exports. All pulls finish before the first
+   mutable copy. A failed plugin is journaled and skipped while passing plugins
+   are processed; the persisted journal is marked `latest-partial`, the job
+   then fails, and no completion marker is published. Advance `latest` only
+   when its stable SemVer cannot move backwards; this move is the second human
+   gate and still waits for the protected `plugin-release-production`
+   environment approval. An existing `latest` already serving the desired
+   digest is accepted before reading legacy version annotations and is never
+   rewritten.
 6. Build `higress/plugin-server:<gateway-version>` from the exact approved
    plugin-server commit and snapshot. Its dry run checks out and tests that
    exact plugin-server source, binds the gateway version/path/plan/previous
@@ -132,6 +151,12 @@ repository source alone.
    authorization. After the Higress release, dispatch Standalone with
    immutable release/chart/image identities. It derives a deterministic PR key
    and must not read a newer branch head.
+
+The hosted release runner can prove static Wasm structure and required
+Proxy-Wasm exports, but it cannot instantiate a generic Envoy/Proxy-Wasm host
+for every plugin. Host-specific startup and request-path behavior therefore
+remain covered by plugin tests and pre-release integration testing; the public
+pull gate does not claim runtime compatibility.
 
 ## Onboarding migration preflight
 
@@ -166,10 +191,9 @@ every planned tag before the preparation PR is opened.
     reviewed stable version greater than the occupied one.
   - `adopt-public` — the occupant was built from the same source commit and the
     same input hash as this plan, so the published tag already serves these
-    inputs and may be left alone. Until the published layouts are unified
-    (proposal #4634 S1/S2), this is how a tag previously patched by
-    `emergency-overwrite-plugin-tag` presents itself: same inputs, different
-    bytes, because that channel publishes the 2-layer variant.
+    inputs and may be left alone. Candidate and emergency publication now share
+    byte-identical manifest construction, so matching inputs produce the same
+    digest and do not create a synthetic migration conflict.
   Deleting a tag is only ever recommended for an unannotated occupant. An
   artifact the pipeline cannot classify is never deleted automatically; the
   disposition is re-derived from the recorded annotations during snapshot
@@ -287,17 +311,44 @@ and Standalone defaults remain pinned and do not depend on `latest`.
 
 ### Emergency same-version overwrite
 
-- An ACR admin temporarily lifts the tag-immutability rule for the plugin
-  repo; a maintainer then runs `emergency-overwrite-plugin-tag` (first
-  `dry_run=true`, then the real run, which waits for the
-  `plugin-release-production` approval), and the admin re-arms the rule
-  immediately after the run reports the new digest.
+- An ACR admin temporarily lifts the tag-immutability rule for the one plugin
+  repository. A maintainer dispatches `emergency-overwrite-plugin-tag` with the
+  required stable `gateway_version`, logical ID, existing stable plugin
+  version, and exact merged source commit, first with `dry_run=true` and then
+  with `dry_run=false`. The workflow has no environment gate: it queries the
+  collaborators API for `github.triggering_actor` (including the actor who
+  initiates a rerun), records the result in the step summary, and proceeds only
+  for `maintain` or `admin`; malformed actors, lower permissions, and API
+  failures deny access. The admin re-arms immutability immediately after the
+  run reports the new digest.
+- Before any registry login or write, the workflow binds the selected catalog
+  entry, candidate evidence, and release snapshot to that gateway/plugin/
+  version/public-reference tuple. It builds the release tool from current
+  `main` before checking out the older fix commit, then computes the current
+  input hash, tests and builds that exact source. The artifact passed to the
+  publishing job contains both that current tool and the built Wasm. The
+  overwrite uses the same deterministic two-layer manifest contract as a
+  candidate; moving `latest` remains an explicit opt-in because it can regress
+  the alias.
+- After a successful registry write, the release tool pinned to the main-branch
+  dispatch SHA idempotently appends an emergency lineage record (new digest,
+  input hash, source commit, and workflow run ID) to the gateway's candidate
+  evidence. The release GitHub App creates or updates
+  `release/plugin-emergency-evidence-<gateway>-<plugin>-<run-id>` and its pull
+  request. The pinned base, branch key, and lineage run ID make an exact workflow
+  rerun safe; a reused run ID with different evidence fails closed.
+- Registry mutation and evidence publication cannot be atomic. If the registry
+  succeeds but lineage commit, push, or PR creation fails, the workflow remains
+  failed and its summary still exposes the new registry digest. Keep
+  immutability lifted only long enough to rerun the same workflow run so it
+  verifies/reproduces the same bytes and completes the same deterministic
+  evidence branch; do not dispatch a different run as a substitute. Merge the
+  evidence PR before treating the incident as closed.
 - A plugin whose tag was overwritten must receive a version bump at the next
   gateway release. This happens automatically: the fix commit changes the
-  input hash, so plan re-plans it.
-- Bundled plugin-server/Console images embed snapshot bytes and are healed
-  only by the next gateway release; the overwrite heals tag-pulling
-  (Envoy-direct) consumers immediately.
+  input hash, so plan re-plans it. Bundled plugin-server/Console images embed
+  snapshot bytes and are healed only by the next gateway release; the overwrite
+  heals tag-pulling (Envoy-direct) consumers immediately.
 
 ## Exact Standalone packaging
 

--- a/docs/developers/immutable-plugin-releases.md
+++ b/docs/developers/immutable-plugin-releases.md
@@ -90,9 +90,13 @@ repository source alone.
    `plugin.wasm` as
    `application/vnd.module.wasm.content.layer.v1+wasm`, with OCI image-spec v1.0,
    `created` fixed to the source commit time, and identical revision, version,
-   and input-hash annotations. Reuse validates that exact layout;
-   publication also binds the layer descriptors to the local bytes and returns
-   only a validated SHA-256 manifest digest. Before the snapshot is rendered,
+   and input-hash annotations. Reuse first performs the normal deterministic
+   source build, then resolves and pulls the digest-pinned candidate, requires
+   its config bytes to be exactly `{}`, compares its Wasm bytes with that build,
+   and applies the same strict manifest and Proxy-Wasm validation as promotion;
+   metadata alone is never sufficient. Publication binds the layer descriptors
+   to the local bytes and returns only a validated SHA-256 manifest digest.
+   Before the snapshot is rendered,
    the workflow sweeps the public registry for every planned version tag and
    compares each occupied tag with the candidate digest just built; see
    "Onboarding migration preflight" below. Render the snapshot only after every
@@ -121,8 +125,11 @@ repository source alone.
    the migration preflight excluded. Before any `latest` write, it fetches and
    pulls every non-blocked public artifact remotely by its snapshot digest. The
    local gate verifies the OCI schema and two-layer order, provenance,
-   descriptor sizes and digests, object-valued JSON config, Wasm framing, and
-   required Proxy-Wasm entry-point exports. All pulls finish before the first
+   descriptor sizes and digests, canonical empty JSON config, and complete Wasm
+   validity. It also requires exported memory, exact `(i32,i32)->i32`
+   signatures for `proxy_on_vm_start` and `proxy_on_configure`, and a
+   `proxy_abi_version_0_2_*` function with signature `()->()`. All pulls finish
+   before the first
    mutable copy. A failed plugin is journaled and skipped while passing plugins
    are processed; the persisted journal is marked `latest-partial`, the job
    then fails, and no completion marker is published. Advance `latest` only
@@ -152,11 +159,63 @@ repository source alone.
    immutable release/chart/image identities. It derives a deterministic PR key
    and must not read a newer branch head.
 
-The hosted release runner can prove static Wasm structure and required
-Proxy-Wasm exports, but it cannot instantiate a generic Envoy/Proxy-Wasm host
-for every plugin. Host-specific startup and request-path behavior therefore
-remain covered by plugin tests and pre-release integration testing; the public
-pull gate does not claim runtime compatibility.
+### What the pull gate proves today
+
+The remotely pulled gate has exactly two levels, and both are static with
+respect to plugin behavior:
+
+- **Structural.** The pulled manifest must be a canonical OCI v1.0 schema 2
+  image manifest in the deterministic two-layer form Envoy loads: the
+  empty-JSON config descriptor, exactly four provenance annotations (`created`,
+  `revision`, `version`, `io.higress.plugin.input-hash`), layer 0 `config.json`
+  with media type `application/vnd.module.wasm.config.v1+json`, and layer 1
+  `plugin.wasm` with media type
+  `application/vnd.module.wasm.content.layer.v1+wasm`. Every descriptor size and
+  digest must equal the pulled bytes, and `config.json` must be the canonical
+  empty JSON object. This is the defect class behind the one-layer `latest`
+  incident this change responds to: such a manifest is not loadable by Envoy,
+  and the gate rejects it.
+- **Compile level.** The pulled `plugin.wasm` bytes are compiled with wazero
+  (`CompileModule`, interpreter backend) and the compiled module's exports are
+  inspected: exported memory, exact `(i32,i32)->i32` signatures for
+  `proxy_on_vm_start` and `proxy_on_configure`, and a `proxy_abi_version_0_2_*`
+  export with signature `()->()`.
+
+The module is compiled but never instantiated, so no plugin code executes. The
+gate proves that the registry serves a well-formed, digest-consistent,
+compilable Proxy-Wasm module; it does not prove that the plugin initializes
+inside Envoy or serves a request. That runtime coverage remains where it already
+is: each plugin's own `go test ./...` inside the build contract, and the
+pre-release e2e suites — `make higress-wasmplugin-test` installs the built
+plugins into a cluster and drives the WASM conformance cases under
+`test/e2e/conformance/tests/`. The hosted release runner cannot instantiate a
+generic Envoy/Proxy-Wasm host for every plugin inside the release job, and the
+public pull gate makes no runtime compatibility claim.
+
+## Runtime smoke gate (future)
+
+Placeholder for the runtime half of the pull gate, deliberately not implemented
+by this change. The design it would follow:
+
+- A minimal, digest-pinned Higress/Envoy runner image — no cluster, no Helm, no
+  kind. It is `envoy` plus a static bootstrap that loads exactly one plugin from
+  `oci://<registry>/<image>@<digest>`, the digest the release just published.
+- The runner boots the plugin through the real Proxy-Wasm host, so
+  `proxy_on_vm_start` and `proxy_on_configure` execute against the plugin's
+  configuration, and asserts a host log without plugin errors plus a live admin
+  endpoint.
+- One request-path smoke assertion: a single listener and route with the plugin
+  attached, one request, and a check that a response is produced instead of the
+  `500` Envoy returns for a rejected Wasm configuration.
+- Wiring: the position today's pull gate already holds — before any `latest`
+  write in promote, and before the stable-tag copy in the emergency channel —
+  with per-plugin granularity so one failing plugin is journaled and skipped
+  while the rest proceed, and the phase fails before any mutable alias moves.
+- Preconditions to settle first: a published, versioned runner image with its own
+  digest pin and provenance; a decision on how plugin-specific configuration is
+  supplied for plugins that reject an empty config; and the runner's cost inside
+  the release job budget. Until those exist, the compile and structural gate
+  above is the release-blocking check and the e2e suites carry runtime coverage.
 
 ## Onboarding migration preflight
 
@@ -317,33 +376,60 @@ and Standalone defaults remain pinned and do not depend on `latest`.
   version, and exact merged source commit, first with `dry_run=true` and then
   with `dry_run=false`. The workflow has no environment gate: it queries the
   collaborators API for `github.triggering_actor` (including the actor who
-  initiates a rerun), records the result in the step summary, and proceeds only
-  for `maintain` or `admin`; malformed actors, lower permissions, and API
-  failures deny access. The admin re-arms immutability immediately after the
-  run reports the new digest.
+  initiates a rerun), records `role_name` in the step summary, and proceeds only
+  for `maintain` or `admin`; malformed actors, legacy `write` role names, API
+  failures, and malformed responses deny access. The publishing job repeats that
+  identical check as its first step, before App-token creation, checkout, and
+  registry login, because "Re-run failed jobs" resumes the publishing job without
+  running `authorize` again and the triggering actor of a resumed run is whoever
+  clicked re-run. The admin re-arms immutability immediately after the run
+  reports the new digest.
 - Before any registry login or write, the workflow binds the selected catalog
   entry, candidate evidence, and release snapshot to that gateway/plugin/
-  version/public-reference tuple. It builds the release tool from current
-  `main` before checking out the older fix commit, then computes the current
-  input hash, tests and builds that exact source. The artifact passed to the
-  publishing job contains both that current tool and the built Wasm. The
-  overwrite uses the same deterministic two-layer manifest contract as a
-  candidate; moving `latest` remains an explicit opt-in because it can regress
-  the alias.
-- After a successful registry write, the release tool pinned to the main-branch
-  dispatch SHA idempotently appends an emergency lineage record (new digest,
-  input hash, source commit, and workflow run ID) to the gateway's candidate
-  evidence. The release GitHub App creates or updates
+  version/public-reference tuple. The catalog-derived registry and repository
+  are passed into publication, and the configured production registry must
+  equal that registry. It builds the release tool from current `main` before
+  checking out the older fix commit, then computes the current input hash,
+  tests and builds that exact source. The artifact passed to the publishing job
+  contains both that current tool and the built Wasm.
+- Runs are serialized by logical ID and version. Publication first writes the
+  desired deterministic two-layer manifest to an emergency candidate tag keyed
+  by the source commit and input hash. Before changing the stable tag, the
+  workflow re-pulls that staged candidate from the public registry by digest and
+  runs the same `verify-pulled-plugin` gate promote applies before a `latest`
+  move, so the incident channel cannot publish an artifact Envoy will not load.
+  The gate inspects what the registry serves, never the local build output, and
+  a failure aborts before any stable-tag mutation. The workflow then stages and
+  validates the lineage update and resolves the committed predecessor (the last
+  lineage digest, or the original candidate digest when no lineage exists). The
+  stable tag must exist and serve that predecessor; the workflow then copies the
+  staged digest to the stable tag, re-resolves it, and re-checks the published
+  manifest against the deterministic two-layer contract. Any absent or
+  conflicting stable tag fails without an overwrite.
+- The release GitHub App immediately creates or verifies
   `release/plugin-emergency-evidence-<gateway>-<plugin>-<run-id>` and its pull
-  request. The pinned base, branch key, and lineage run ID make an exact workflow
-  rerun safe; a reused run ID with different evidence fails closed.
-- Registry mutation and evidence publication cannot be atomic. If the registry
-  succeeds but lineage commit, push, or PR creation fails, the workflow remains
-  failed and its summary still exposes the new registry digest. Keep
-  immutability lifted only long enough to rerun the same workflow run so it
-  verifies/reproduces the same bytes and completes the same deterministic
-  evidence branch; do not dispatch a different run as a substitute. Merge the
-  evidence PR before treating the incident as closed.
+  request from the prevalidated lineage bytes. Only after that succeeds may the
+  explicit `move_latest` option copy the digest to `latest`. A rerun of the
+  same workflow run may find the stable tag already at the desired digest; a
+  later run attempt records the missing evidence without copying the stable tag
+  again. A first attempt cannot use that path, and a reused run ID with
+  different evidence fails closed.
+- Staging tags are retained permanently as provenance. The
+  `emergency-<source-commit>-<input-hash>` tag is content-addressed by commit
+  and input-hash (one per overwrite attempt, collision-free) and serves the same
+  manifest as the stable tag. Registries commonly implement tag deletion as
+  manifest deletion (ACR included), so untagging the staging reference could
+  destroy the manifest the stable tag serves, and oras 1.2.3 provides no
+  portable tag-only unlink. The committed lineage and its PR remain the durable
+  record of an overwrite; the staging tag is the auditable public pointer to
+  exactly what was verified before promotion. Do not attempt manual deletion of
+  these tags.
+- Registry mutation and evidence publication cannot be atomic. If the stable
+  copy succeeds but lineage commit, push, or PR creation fails, the workflow
+  remains failed. Keep immutability lifted only long enough to rerun the same
+  workflow run so it verifies/reproduces the same bytes and completes the same
+  deterministic evidence branch; do not dispatch a different run as a
+  substitute. Merge the evidence PR before treating the incident as closed.
 - A plugin whose tag was overwritten must receive a version bump at the next
   gateway release. This happens automatically: the fix commit changes the
   input hash, so plan re-plans it. Bundled plugin-server/Console images embed

--- a/tools/plugin-release/approval_chain_contract_test.go
+++ b/tools/plugin-release/approval_chain_contract_test.go
@@ -54,8 +54,8 @@ func TestApprovalChainHasExactlyTwoHumanGates(t *testing.T) {
 	if strings.Contains(emergency, "environment:") {
 		t.Fatal("emergency overwrite must not request an environment approval")
 	}
-	if !strings.Contains(emergency, "github.triggering_actor") || !strings.Contains(emergency, "collaborators/$actor/permission") {
-		t.Fatal("emergency overwrite must authorize the triggering actor through the collaborators API")
+	if !strings.Contains(emergency, "github.triggering_actor") || !strings.Contains(emergency, "collaborators/$actor/permission") || !strings.Contains(emergency, ".role_name") {
+		t.Fatal("emergency overwrite must authorize the triggering actor through the collaborators API role_name")
 	}
 }
 
@@ -65,16 +65,19 @@ func TestEmergencyAuthorizationRequiresTriggeringMaintainer(t *testing.T) {
 		name       string
 		actor      string
 		permission string
+		roleName   string
 		apiFails   bool
+		omitRole   bool
 		want       string
 		wantError  bool
 	}{
-		{name: "maintainer", actor: "release-maintainer", permission: "maintain", want: "actor=release-maintainer permission=maintain"},
-		{name: "administrator", actor: "release-admin", permission: "admin", want: "actor=release-admin permission=admin"},
-		{name: "write-collaborator", actor: "writer", permission: "write", want: "permission=write", wantError: true},
-		{name: "read-collaborator", actor: "reader", permission: "read", want: "permission=read", wantError: true},
-		{name: "api-failure", actor: "maintainer", apiFails: true, want: "permission=api-error", wantError: true},
-		{name: "invalid-actor", actor: "bad/actor", permission: "admin", want: "permission=invalid-actor", wantError: true},
+		{name: "maintainer-with-legacy-write", actor: "release-maintainer", permission: "write", roleName: "maintain", want: "actor=release-maintainer role_name=maintain"},
+		{name: "administrator", actor: "release-admin", permission: "admin", roleName: "admin", want: "actor=release-admin role_name=admin"},
+		{name: "write-collaborator", actor: "writer", permission: "write", roleName: "write", want: "role_name=write", wantError: true},
+		{name: "read-collaborator", actor: "reader", permission: "read", roleName: "read", want: "role_name=read", wantError: true},
+		{name: "missing-role-name", actor: "malformed", permission: "admin", omitRole: true, want: "role_name=invalid-response", wantError: true},
+		{name: "api-failure", actor: "maintainer", apiFails: true, want: "role_name=api-error", wantError: true},
+		{name: "invalid-actor", actor: "bad/actor", permission: "admin", roleName: "admin", want: "role_name=invalid-actor", wantError: true},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			root := t.TempDir()
@@ -89,19 +92,23 @@ if [ "$GH_API_FAILS" = true ]; then
 fi
 test "$1" = api
 test "$2" = "repos/higress-group/higress/collaborators/$TRIGGERING_ACTOR/permission"
-jq -cn --arg permission "$FIXTURE_PERMISSION" '{permission:$permission}'
+if [ "$OMIT_ROLE" = true ]; then
+  jq -cn --arg permission "$FIXTURE_PERMISSION" '{permission:$permission}'
+else
+  jq -cn --arg permission "$FIXTURE_PERMISSION" --arg role_name "$FIXTURE_ROLE_NAME" '{permission:$permission,role_name:$role_name}'
+fi
 `)
 			summary := filepath.Join(root, "summary.md")
-			apiFails := "false"
-			if tc.apiFails {
-				apiFails = "true"
-			}
+			apiFails := strconv.FormatBool(tc.apiFails)
+			omitRole := strconv.FormatBool(tc.omitRole)
 			cmd := exec.Command("bash", "-c", "set -euo pipefail\n"+contract)
 			cmd.Env = append(os.Environ(),
 				"PATH="+bin+":"+os.Getenv("PATH"),
 				"GH_TOKEN=fixture-token",
 				"GH_API_FAILS="+apiFails,
+				"OMIT_ROLE="+omitRole,
 				"FIXTURE_PERMISSION="+tc.permission,
+				"FIXTURE_ROLE_NAME="+tc.roleName,
 				"GITHUB_REPOSITORY=higress-group/higress",
 				"GITHUB_STEP_SUMMARY="+summary,
 				"TRIGGERING_ACTOR="+tc.actor,
@@ -127,11 +134,13 @@ jq -cn --arg permission "$FIXTURE_PERMISSION" '{permission:$permission}'
 	}
 }
 
-func TestEmergencyWorkflowBindsEvidenceBeforeMutationAndAutomatesRetryablePR(t *testing.T) {
+func TestEmergencyWorkflowStagesAndBindsPublicationBeforeLatest(t *testing.T) {
 	emergency := mustWorkflow(t, "emergency-overwrite-plugin-tag.yaml")
 	for _, required := range []string{
 		"gateway_version:",
 		"required: true",
+		"group: emergency-overwrite-${{ inputs.logical_id }}-${{ inputs.version }}",
+		"cancel-in-progress: false",
 		"ref: ${{ github.sha }}",
 		`test "$WORKFLOW_REF" = refs/heads/main`,
 		`git merge-base --is-ancestor "$evidence_base" refs/remotes/origin/main`,
@@ -140,13 +149,20 @@ func TestEmergencyWorkflowBindsEvidenceBeforeMutationAndAutomatesRetryablePR(t *
 		"git merge-base --is-ancestor \"$CANDIDATE_SOURCE_COMMIT\" \"$SOURCE_COMMIT\"",
 		"ref: ${{ needs.validate.outputs.evidence_base }}",
 		"Upload current tool and built artifact",
+		`public_registry: ${{ steps.resolve.outputs.public_registry }}`,
+		`public_repository: ${{ steps.resolve.outputs.public_repository }}`,
+		`CONFIGURED_REGISTRY: ${{ vars.PLUGIN_PUBLIC_REGISTRY }}`,
+		`validate_emergency_repository "$CONFIGURED_REGISTRY" "$REGISTRY" "$REPOSITORY" "$IMAGE_REF"`,
+		`emergency_candidate="$REPOSITORY:emergency-${SOURCE_COMMIT}-${INPUT_HASH#sha256:}"`,
 		"chmod 0700 \"$tool\"",
 		"append-emergency-lineage",
+		`if ((.lineage // []) | length) > 0 then .lineage[-1].digest else .digest end`,
 		"actions/create-github-app-token@",
 		`branch="release/plugin-emergency-evidence-$GATEWAY_VERSION-$LOGICAL_ID-$WORKFLOW_RUN_ID"`,
 		`gh pr create --base main --head "$branch"`,
 		`|| gh pr edit "$branch"`,
 		"registry write precedes this PR",
+		"Move latest only after evidence publication",
 	} {
 		if !strings.Contains(emergency, required) {
 			t.Fatalf("emergency workflow lacks %q", required)
@@ -155,15 +171,470 @@ func TestEmergencyWorkflowBindsEvidenceBeforeMutationAndAutomatesRetryablePR(t *
 	buildTool := strings.Index(emergency, "go build -p 1 -o /tmp/emergency-overwrite-artifact/plugin-release")
 	checkoutSource := strings.Index(emergency, "git checkout -q \"$SOURCE_COMMIT\"")
 	validateEvidence := strings.Index(emergency, `candidate=$(jq -cer --arg id "$LOGICAL_ID"`)
+	registryBinding := strings.Index(emergency, `validate_emergency_repository "$CONFIGURED_REGISTRY"`)
 	registryLogin := strings.Index(emergency, "oras login")
-	registryPush := strings.Index(emergency, `digest=$(publish_plugin_manifest`)
-	appendLineage := strings.Index(emergency, "append-emergency-lineage")
+	candidatePush := strings.Index(emergency, `digest=$(publish_plugin_manifest "$emergency_candidate"`)
+	stageLineage := strings.Index(emergency, `--output /tmp/staged-emergency-evidence.json`)
+	stableCopy := strings.Index(emergency, `oras cp "$candidate_repo@$desired" "$stable_ref"`)
 	openPR := strings.Index(emergency, "gh pr create")
-	if buildTool < 0 || checkoutSource < 0 || validateEvidence < 0 || registryLogin < 0 || registryPush < 0 || appendLineage < 0 || openPR < 0 {
+	latestCopy := strings.Index(emergency, `oras cp "$REPOSITORY@$DIGEST" "$REPOSITORY:latest"`)
+	if buildTool < 0 || checkoutSource < 0 || validateEvidence < 0 || registryBinding < 0 || registryLogin < 0 || candidatePush < 0 || stageLineage < 0 || stableCopy < 0 || openPR < 0 || latestCopy < 0 {
 		t.Fatal("emergency workflow lost a required ordering boundary")
 	}
-	if !(buildTool < validateEvidence && validateEvidence < checkoutSource && checkoutSource < registryLogin && registryLogin < registryPush && registryPush < appendLineage && appendLineage < openPR) {
-		t.Fatal("emergency workflow must build the current tool, validate current-main evidence, switch to the source, mutate the registry, append lineage, then publish its PR")
+	if !(buildTool < validateEvidence && validateEvidence < checkoutSource && checkoutSource < registryBinding && registryBinding < registryLogin && registryLogin < candidatePush && candidatePush < stageLineage && stageLineage < stableCopy && stableCopy < openPR && openPR < latestCopy) {
+		t.Fatal("emergency workflow must validate/build, stage the candidate and lineage, conditionally copy stable, publish evidence, then optionally move latest")
+	}
+}
+
+func TestEmergencyRegistryBindingRejectsConfigurationDrift(t *testing.T) {
+	contract := workflowShellContract(t, "emergency-overwrite-plugin-tag.yaml", "emergency-registry-binding-contract")
+	for _, tc := range []struct {
+		name       string
+		configured string
+		validated  string
+		repository string
+		image      string
+		wantError  bool
+	}{
+		{name: "exact", configured: "registry.example.invalid:5000", validated: "registry.example.invalid:5000", repository: "registry.example.invalid:5000/plugins/demo", image: "plugins/demo"},
+		{name: "registry-drift", configured: "other.example.invalid", validated: "registry.example.invalid", repository: "registry.example.invalid/plugins/demo", image: "plugins/demo", wantError: true},
+		{name: "repository-drift", configured: "registry.example.invalid", validated: "registry.example.invalid", repository: "registry.example.invalid/plugins/other", image: "plugins/demo", wantError: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			script := "set -euo pipefail\n" + contract + "\nvalidate_emergency_repository \"$CONFIGURED\" \"$VALIDATED\" \"$REPOSITORY\" \"$IMAGE\"\n"
+			cmd := exec.Command("bash", "-c", script)
+			cmd.Env = append(os.Environ(), "CONFIGURED="+tc.configured, "VALIDATED="+tc.validated, "REPOSITORY="+tc.repository, "IMAGE="+tc.image)
+			output, err := cmd.CombinedOutput()
+			if tc.wantError && err == nil {
+				t.Fatalf("registry mismatch was accepted: %s", output)
+			}
+			if !tc.wantError && err != nil {
+				t.Fatalf("valid registry binding failed: %v\n%s", err, output)
+			}
+		})
+	}
+}
+
+func TestEmergencyStableOverwriteRequiresCommittedPredecessorAndHealsRetry(t *testing.T) {
+	contract := workflowShellContract(t, "emergency-overwrite-plugin-tag.yaml", "emergency-stable-overwrite-contract")
+	predecessor := testDigest("predecessor")
+	desired := testDigest("desired")
+	conflict := testDigest("conflict")
+	for _, tc := range []struct {
+		name       string
+		current    string
+		runAttempt string
+		wantError  bool
+		wantCopies int
+	}{
+		{name: "committed-predecessor", current: predecessor, runAttempt: "1", wantCopies: 1},
+		{name: "same-run-retry-at-desired", current: desired, runAttempt: "2"},
+		{name: "first-attempt-cannot-claim-desired", current: desired, runAttempt: "1", wantError: true},
+		{name: "predecessor-conflict", current: conflict, runAttempt: "1", wantError: true},
+		{name: "missing-stable-tag", runAttempt: "1", wantError: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			bin := filepath.Join(root, "bin")
+			if err := os.MkdirAll(bin, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			state := filepath.Join(root, "stable-digest")
+			logPath := filepath.Join(root, "oras.log")
+			if tc.current != "" {
+				if err := os.WriteFile(state, []byte(tc.current), 0o600); err != nil {
+					t.Fatal(err)
+				}
+			}
+			writeExecutableFixture(t, filepath.Join(bin, "oras"), `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "$ORAS_LOG"
+if [ "$1 $2" = "manifest fetch" ]; then
+  if [ ! -f "$ORAS_STATE" ]; then echo "manifest unknown" >&2; exit 1; fi
+  jq -cn --arg digest "$(cat "$ORAS_STATE")" '{mediaType:"application/vnd.oci.image.manifest.v1+json",digest:$digest}'
+  exit 0
+fi
+if [ "$1" = cp ]; then
+  test "$2" = "registry.example.invalid/plugins/demo@$DESIRED"
+  test "$3" = "registry.example.invalid/plugins/demo:1.2.3"
+  printf '%s' "$DESIRED" > "$ORAS_STATE"
+  exit 0
+fi
+exit 2
+`)
+			script := "set -euo pipefail\n" + contract + "\npromote_emergency_candidate registry.example.invalid/plugins/demo:emergency-content registry.example.invalid/plugins/demo:1.2.3 \"$PREDECESSOR\" \"$DESIRED\" \"$RUN_ATTEMPT\"\n"
+			cmd := exec.Command("bash", "-c", script)
+			cmd.Env = append(os.Environ(),
+				"PATH="+bin+":"+os.Getenv("PATH"),
+				"ORAS_LOG="+logPath,
+				"ORAS_STATE="+state,
+				"PREDECESSOR="+predecessor,
+				"DESIRED="+desired,
+				"RUN_ATTEMPT="+tc.runAttempt,
+			)
+			output, err := cmd.CombinedOutput()
+			if tc.wantError && err == nil {
+				t.Fatalf("unsafe stable state was accepted: %s", output)
+			}
+			if !tc.wantError && err != nil {
+				t.Fatalf("safe stable transition failed: %v\n%s", err, output)
+			}
+			logBytes, readErr := os.ReadFile(logPath)
+			if readErr != nil {
+				t.Fatal(readErr)
+			}
+			if got := strings.Count(string(logBytes), "cp "); got != tc.wantCopies {
+				t.Fatalf("stable copy count = %d, want %d:\n%s", got, tc.wantCopies, logBytes)
+			}
+		})
+	}
+}
+
+// TestEmergencyPullVerificationGatesTheStableTagOverwrite proves the incident
+// channel clears the same loadability gate as the immutable pipeline before it
+// may replace a public stable tag: the staged candidate is re-pulled from the
+// registry by digest and verified as the registry serves it, never as the local
+// build produced it, and any failure aborts before a stable-tag mutation.
+func TestEmergencyPullVerificationGatesTheStableTagOverwrite(t *testing.T) {
+	emergency := mustWorkflow(t, "emergency-overwrite-plugin-tag.yaml")
+	contract := workflowShellContract(t, "emergency-overwrite-plugin-tag.yaml", "emergency-pull-verification-contract")
+	for _, required := range []string{
+		`oras manifest fetch "$repository@$digest" --output "$pull_dir/manifest.json"`,
+		`oras pull "$repository@$digest" --output "$pull_dir"`,
+		`"$tool" verify-pulled-plugin --manifest "$pull_dir/manifest.json" --config "$pull_dir/config.json" --wasm "$pull_dir/plugin.wasm"`,
+		`--digest "$digest" --source-commit "$source_commit" --source-created "$source_created" --version "$version" --input-hash "$input_hash"`,
+		"the stable tag was not modified",
+	} {
+		if !strings.Contains(contract, required) {
+			t.Fatalf("emergency pull verification lacks %q", required)
+		}
+	}
+	// The gate verifies registry state; the local build output is not an input.
+	if strings.Contains(contract, "/tmp/emergency-overwrite-artifact/plugin.wasm") {
+		t.Fatal("emergency pull verification inspected the local build output instead of the pulled artifact")
+	}
+	stagingPush := strings.Index(emergency, `digest=$(publish_plugin_manifest "$emergency_candidate"`)
+	gate := strings.Index(emergency, `verify_emergency_pull "$tool" "$REPOSITORY" "$digest"`)
+	lineage := strings.Index(emergency, `--output /tmp/staged-emergency-evidence.json`)
+	stableCopy := strings.Index(emergency, `oras cp "$candidate_repo@$desired" "$stable_ref"`)
+	latestCopy := strings.Index(emergency, `oras cp "$REPOSITORY@$DIGEST" "$REPOSITORY:latest"`)
+	if stagingPush < 0 || gate < 0 || lineage < 0 || stableCopy < 0 || latestCopy < 0 {
+		t.Fatal("emergency workflow lost a required ordering boundary")
+	}
+	if !(stagingPush < gate && gate < lineage && lineage < stableCopy && stableCopy < latestCopy) {
+		t.Fatal("the pulled-artifact gate must run after staging the candidate and before the lineage staging, the stable-tag copy, and any latest move")
+	}
+
+	digest := testDigest("staged")
+	inputHash := testDigest("inputs")
+	repository := "registry.example.invalid/plugins/demo"
+	for _, tc := range []struct {
+		name       string
+		failStep   string
+		toolStatus string
+		digest     string
+		version    string
+		inputHash  string
+		commit     string
+		noTool     bool
+		want       string
+		wantError  bool
+		wantVerify bool
+	}{
+		{name: "staged-candidate-loads", wantVerify: true},
+		{name: "verifier-rejects-artifact", toolStatus: "1", want: "failed pulled-artifact verification; the stable tag was not modified", wantError: true, wantVerify: true},
+		{name: "manifest-cannot-be-pulled", failStep: "fetch", want: "manifest cannot be pulled", wantError: true},
+		{name: "layers-cannot-be-pulled", failStep: "pull", want: "layers cannot be pulled", wantError: true},
+		{name: "malformed-digest", digest: "sha256:short", want: "invalid staged candidate digest", wantError: true},
+		{name: "malformed-version", version: "1.2", want: "invalid stable plugin version", wantError: true},
+		{name: "malformed-input-hash", inputHash: "not-a-hash", want: "invalid plugin input hash", wantError: true},
+		{name: "malformed-source-commit", commit: strings.Repeat("z", 40), want: "invalid plugin source commit", wantError: true},
+		{name: "tool-not-executable", noTool: true, want: "release tool is not executable", wantError: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			mustRun(t, root, "git", "init", "-q")
+			mustRun(t, root, "git", "config", "user.name", "test")
+			mustRun(t, root, "git", "config", "user.email", "test@example.com")
+			mustWrite(t, filepath.Join(root, "main.go"), "package main\n")
+			mustRun(t, root, "git", "add", ".")
+			mustRun(t, root, "git", "commit", "-q", "-m", "fix")
+			commit, err := resolveCommit(root, "HEAD")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if tc.commit != "" {
+				commit = tc.commit
+			}
+			bin := filepath.Join(root, "bin")
+			if err := os.MkdirAll(bin, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			writeExecutableFixture(t, filepath.Join(bin, "oras"), `#!/usr/bin/env bash
+set -uo pipefail
+printf '%s\n' "$*" >> "$ORAS_LOG"
+if [ "$1 $2" = "manifest fetch" ]; then
+  if [ "${FAIL_STEP:-}" = fetch ]; then echo "registry unavailable" >&2; exit 1; fi
+  test "$3" = "$WANT_REF" || { echo "unexpected manifest fetch reference: $3" >&2; exit 2; }
+  test "${4:-}" = "--output" || { echo "manifest fetch did not write a file: $*" >&2; exit 2; }
+  printf '%s' "$MANIFEST_BODY" > "$5"
+  exit 0
+fi
+if [ "$1" = pull ]; then
+  if [ "${FAIL_STEP:-}" = pull ]; then echo "blob unknown to registry" >&2; exit 1; fi
+  test "$2" = "$WANT_REF" || { echo "unexpected pull reference: $2" >&2; exit 2; }
+  test "${3:-}" = "--output" || { echo "pull did not write a directory: $*" >&2; exit 2; }
+  printf '%s' '{}' > "$4/config.json"
+  printf 'wasm-bytes' > "$4/plugin.wasm"
+  exit 0
+fi
+echo "unsupported fake oras invocation: $*" >&2
+exit 2
+`)
+			tool := filepath.Join(root, "plugin-release")
+			if !tc.noTool {
+				writeExecutableFixture(t, tool, "#!/usr/bin/env bash\nset -uo pipefail\nprintf '%s\\n' \"$*\" >> \"$TOOL_LOG\"\nexit "+tc.toolStatus+"\n")
+			} else if err := os.WriteFile(tool, []byte("not executable\n"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			toolLog := filepath.Join(root, "tool.log")
+			orasLog := filepath.Join(root, "oras.log")
+			summary := filepath.Join(root, "summary.md")
+			pullDir := filepath.Join(root, "pull")
+			for _, path := range []string{toolLog, orasLog} {
+				if err := os.WriteFile(path, nil, 0o600); err != nil {
+					t.Fatal(err)
+				}
+			}
+			version := "1.2.3"
+			if tc.version != "" {
+				version = tc.version
+			}
+			wantDigest := digest
+			if tc.digest != "" {
+				wantDigest = tc.digest
+			}
+			wantHash := inputHash
+			if tc.inputHash != "" {
+				wantHash = tc.inputHash
+			}
+			script := "set -euo pipefail\n" + contract +
+				"\nverify_emergency_pull \"$TOOL\" \"$REPOSITORY\" \"$DIGEST\" \"$SOURCE_COMMIT\" \"$VERSION\" \"$INPUT_HASH\" \"$PULL_DIR\"\n"
+			cmd := exec.Command("bash", "-c", script)
+			cmd.Dir = root
+			cmd.Env = append(os.Environ(),
+				"PATH="+bin+":"+os.Getenv("PATH"),
+				"ORAS_LOG="+orasLog,
+				"TOOL_LOG="+toolLog,
+				"TOOL="+tool,
+				"FAIL_STEP="+tc.failStep,
+				"WANT_REF="+repository+"@"+digest,
+				"MANIFEST_BODY={}",
+				"REPOSITORY="+repository,
+				"DIGEST="+wantDigest,
+				"SOURCE_COMMIT="+commit,
+				"VERSION="+version,
+				"INPUT_HASH="+wantHash,
+				"PULL_DIR="+pullDir,
+				"GITHUB_STEP_SUMMARY="+summary,
+			)
+			output, err := cmd.CombinedOutput()
+			if tc.want != "" && !strings.Contains(string(output), tc.want) {
+				t.Fatalf("gate output lacks %q:\n%s", tc.want, output)
+			}
+			if tc.wantError {
+				if err == nil {
+					t.Fatalf("an unverifiable staged candidate was accepted:\n%s", output)
+				}
+			} else if err != nil {
+				t.Fatalf("a loadable staged candidate was rejected: %v\n%s", err, output)
+			}
+			verifyLog, readErr := os.ReadFile(toolLog)
+			if readErr != nil {
+				t.Fatal(readErr)
+			}
+			if tc.wantVerify != strings.Contains(string(verifyLog), "verify-pulled-plugin") {
+				t.Fatalf("verifier invocation = %q, want invoked %v", verifyLog, tc.wantVerify)
+			}
+			if tc.wantVerify {
+				for _, required := range []string{
+					"--manifest " + pullDir + "/manifest.json",
+					"--config " + pullDir + "/config.json",
+					"--wasm " + pullDir + "/plugin.wasm",
+					"--digest " + digest,
+					"--source-commit " + commit,
+					"--version " + version,
+					"--input-hash " + inputHash,
+				} {
+					if !strings.Contains(string(verifyLog), required) {
+						t.Fatalf("verifier was not bound to the pulled artifact (%q missing): %q", required, verifyLog)
+					}
+				}
+				if !strings.Contains(string(verifyLog), "--source-created ") {
+					t.Fatalf("verifier did not receive the source commit timestamp: %q", verifyLog)
+				}
+			}
+			orasLogBytes, readErr := os.ReadFile(orasLog)
+			if readErr != nil {
+				t.Fatal(readErr)
+			}
+			if tc.wantVerify {
+				for _, required := range []string{
+					"manifest fetch " + repository + "@" + digest + " --output " + pullDir + "/manifest.json",
+					"pull " + repository + "@" + digest + " --output " + pullDir,
+				} {
+					if !strings.Contains(string(orasLogBytes), required) {
+						t.Fatalf("the staged candidate was not re-pulled by digest (%q missing): %q", required, orasLogBytes)
+					}
+				}
+			}
+			for _, unexpected := range []string{"cp ", "push ", "delete "} {
+				if strings.Contains(string(orasLogBytes), unexpected) {
+					t.Fatalf("the pull gate mutated the registry with %q: %q", unexpected, orasLogBytes)
+				}
+			}
+			if _, statErr := os.Stat(pullDir); !os.IsNotExist(statErr) {
+				t.Fatalf("the gate left its pull directory behind: %v", statErr)
+			}
+		})
+	}
+}
+
+// TestEmergencyStagingTagIsRetainedAsProvenance proves the retention policy:
+// the emergency staging tag is never deleted (registries implement tag deletion
+// as manifest deletion, which would destroy the stable tag's manifest), the
+// contract performs no registry mutation, and the run summary records the
+// retained provenance reference.
+func TestEmergencyStagingTagIsRetainedAsProvenance(t *testing.T) {
+	contract := workflowShellContract(t, "emergency-overwrite-plugin-tag.yaml", "emergency-staging-cleanup-contract")
+	repository := "registry.example.invalid/plugins/demo"
+	digest := testDigest("published")
+	inputHash := testDigest("inputs")
+	sourceCommit := strings.Repeat("a", 40)
+	stagingRef := repository + ":emergency-" + sourceCommit + "-" + strings.TrimPrefix(inputHash, "sha256:")
+	root := t.TempDir()
+	bin := filepath.Join(root, "bin")
+	if err := os.MkdirAll(bin, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeExecutableFixture(t, filepath.Join(bin, "oras"), "#!/usr/bin/env bash\necho \"oras $*\" >> \"$ORAS_LOG\"\nexit 0\n")
+	summary := filepath.Join(root, "summary.md")
+	cmd := exec.Command("bash", "-c", "set -euo pipefail\n"+contract)
+	cmd.Dir = root
+	cmd.Env = append(os.Environ(),
+		"PATH="+bin+":"+os.Getenv("PATH"),
+		"ORAS_LOG="+filepath.Join(root, "oras.log"),
+		"REPOSITORY="+repository,
+		"VERSION=1.2.3",
+		"SOURCE_COMMIT="+sourceCommit,
+		"INPUT_HASH="+inputHash,
+		"DIGEST="+digest,
+		"GITHUB_STEP_SUMMARY="+summary,
+	)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("retention contract failed: %v\n%s", err, output)
+	}
+	if logBytes, readErr := os.ReadFile(filepath.Join(root, "oras.log")); readErr == nil {
+		for _, forbidden := range []string{"delete", "push ", "cp "} {
+			if strings.Contains(string(logBytes), forbidden) {
+				t.Fatalf("retention contract mutated the registry with %q: %q", forbidden, logBytes)
+			}
+		}
+	}
+	summaryBytes, readErr := os.ReadFile(summary)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if !strings.Contains(string(summaryBytes), stagingRef) {
+		t.Fatalf("run summary does not record the retained staging reference %q: %q", stagingRef, summaryBytes)
+	}
+}
+// TestEmergencyPublishJobReaffirmsAuthorization closes the re-run bypass: the
+// job that mutates the public registry repeats the maintain/admin check as its
+// first step, so resuming it under a different triggering actor cannot complete
+// an overwrite nobody authorized.
+func TestEmergencyPublishJobReaffirmsAuthorization(t *testing.T) {
+	emergency := mustWorkflow(t, "emergency-overwrite-plugin-tag.yaml")
+	contracts := workflowShellContracts(t, "emergency-overwrite-plugin-tag.yaml", "emergency-authorization-contract")
+	if len(contracts) != 2 {
+		t.Fatalf("emergency workflow has %d authorization contracts, want the authorize job's and the publish job's", len(contracts))
+	}
+	if contracts[0] != contracts[1] {
+		t.Fatal("the publish job's authorization gate drifted from the authorize job's")
+	}
+	publish := workflowJobSection(t, emergency, "publish")
+	recheck := strings.Index(publish, "# BEGIN emergency-authorization-contract")
+	appToken := strings.Index(publish, "actions/create-github-app-token@")
+	checkout := strings.Index(publish, "uses: actions/checkout@")
+	login := strings.Index(publish, "oras login")
+	stagingPush := strings.Index(publish, `digest=$(publish_plugin_manifest "$emergency_candidate"`)
+	stableCopy := strings.Index(publish, `oras cp "$candidate_repo@$desired" "$stable_ref"`)
+	if recheck < 0 || appToken < 0 || checkout < 0 || login < 0 || stagingPush < 0 || stableCopy < 0 {
+		t.Fatal("emergency publish job lost an expected step boundary")
+	}
+	if !(recheck < appToken && appToken < checkout && checkout < login && login < stagingPush && stagingPush < stableCopy) {
+		t.Fatal("the publish job must re-require maintain or admin permission before App-token creation, checkout, registry login, and every mutation")
+	}
+	if strings.Contains(publish[:recheck], "oras ") || strings.Contains(publish[:recheck], "gh api") {
+		t.Fatal("the publish job performs a registry or API call before re-affirming authorization")
+	}
+	if !strings.Contains(publish, "TRIGGERING_ACTOR: ${{ github.triggering_actor }}") {
+		t.Fatal("the publish job must authorize github.triggering_actor, the actor who resumed the run")
+	}
+
+	// The duplicated contract must really execute as a gate in the publish job.
+	for _, tc := range []struct {
+		name      string
+		actor     string
+		roleName  string
+		wantError bool
+	}{
+		{name: "maintainer-rerun", actor: "release-maintainer", roleName: "maintain"},
+		{name: "administrator-rerun", actor: "release-admin", roleName: "admin"},
+		{name: "write-collaborator-rerun", actor: "writer", roleName: "write", wantError: true},
+		{name: "read-collaborator-rerun", actor: "reader", roleName: "read", wantError: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			bin := filepath.Join(root, "bin")
+			if err := os.MkdirAll(bin, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			writeExecutableFixture(t, filepath.Join(bin, "gh"), `#!/usr/bin/env bash
+set -euo pipefail
+test "$1" = api
+test "$2" = "repos/higress-group/higress/collaborators/$TRIGGERING_ACTOR/permission"
+jq -cn --arg role_name "$FIXTURE_ROLE_NAME" '{permission:"write",role_name:$role_name}'
+`)
+			summary := filepath.Join(root, "summary.md")
+			cmd := exec.Command("bash", "-c", "set -euo pipefail\n"+contracts[1])
+			cmd.Env = append(os.Environ(),
+				"PATH="+bin+":"+os.Getenv("PATH"),
+				"GH_TOKEN=fixture-token",
+				"FIXTURE_ROLE_NAME="+tc.roleName,
+				"GITHUB_REPOSITORY=higress-group/higress",
+				"GITHUB_STEP_SUMMARY="+summary,
+				"TRIGGERING_ACTOR="+tc.actor,
+			)
+			output, err := cmd.CombinedOutput()
+			if tc.wantError && err == nil {
+				t.Fatalf("an unauthorized re-run actor reached the publishing job: %s", output)
+			}
+			if !tc.wantError && err != nil {
+				t.Fatalf("an authorized re-run actor was rejected: %v\n%s", err, output)
+			}
+			summaryBytes, readErr := os.ReadFile(summary)
+			if readErr != nil {
+				t.Fatal(readErr)
+			}
+			if !strings.Contains(string(summaryBytes), "actor="+tc.actor+" role_name="+tc.roleName) {
+				t.Fatalf("publish-job authorization did not record its decision: %s", summaryBytes)
+			}
+			if strings.Contains(string(output)+string(summaryBytes), "fixture-token") {
+				t.Fatal("publish-job authorization leaked its GitHub token")
+			}
+		})
 	}
 }
 

--- a/tools/plugin-release/approval_chain_contract_test.go
+++ b/tools/plugin-release/approval_chain_contract_test.go
@@ -48,10 +48,122 @@ func TestApprovalChainHasExactlyTwoHumanGates(t *testing.T) {
 		}
 	}
 
-	// The emergency channel is unchanged by this sub-item; its gate stays.
+	// Emergency overwrite self-authorizes the triggering actor through the
+	// collaborators API instead of consuming the independent latest gate.
 	emergency := mustWorkflow(t, "emergency-overwrite-plugin-tag.yaml")
-	if !strings.Contains(emergency, "environment: plugin-release-production") {
-		t.Fatal("emergency overwrite lost its production gate")
+	if strings.Contains(emergency, "environment:") {
+		t.Fatal("emergency overwrite must not request an environment approval")
+	}
+	if !strings.Contains(emergency, "github.triggering_actor") || !strings.Contains(emergency, "collaborators/$actor/permission") {
+		t.Fatal("emergency overwrite must authorize the triggering actor through the collaborators API")
+	}
+}
+
+func TestEmergencyAuthorizationRequiresTriggeringMaintainer(t *testing.T) {
+	contract := workflowShellContract(t, "emergency-overwrite-plugin-tag.yaml", "emergency-authorization-contract")
+	for _, tc := range []struct {
+		name       string
+		actor      string
+		permission string
+		apiFails   bool
+		want       string
+		wantError  bool
+	}{
+		{name: "maintainer", actor: "release-maintainer", permission: "maintain", want: "actor=release-maintainer permission=maintain"},
+		{name: "administrator", actor: "release-admin", permission: "admin", want: "actor=release-admin permission=admin"},
+		{name: "write-collaborator", actor: "writer", permission: "write", want: "permission=write", wantError: true},
+		{name: "read-collaborator", actor: "reader", permission: "read", want: "permission=read", wantError: true},
+		{name: "api-failure", actor: "maintainer", apiFails: true, want: "permission=api-error", wantError: true},
+		{name: "invalid-actor", actor: "bad/actor", permission: "admin", want: "permission=invalid-actor", wantError: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			bin := filepath.Join(root, "bin")
+			if err := os.MkdirAll(bin, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			writeExecutableFixture(t, filepath.Join(bin, "gh"), `#!/usr/bin/env bash
+set -euo pipefail
+if [ "$GH_API_FAILS" = true ]; then
+  exit 23
+fi
+test "$1" = api
+test "$2" = "repos/higress-group/higress/collaborators/$TRIGGERING_ACTOR/permission"
+jq -cn --arg permission "$FIXTURE_PERMISSION" '{permission:$permission}'
+`)
+			summary := filepath.Join(root, "summary.md")
+			apiFails := "false"
+			if tc.apiFails {
+				apiFails = "true"
+			}
+			cmd := exec.Command("bash", "-c", "set -euo pipefail\n"+contract)
+			cmd.Env = append(os.Environ(),
+				"PATH="+bin+":"+os.Getenv("PATH"),
+				"GH_TOKEN=fixture-token",
+				"GH_API_FAILS="+apiFails,
+				"FIXTURE_PERMISSION="+tc.permission,
+				"GITHUB_REPOSITORY=higress-group/higress",
+				"GITHUB_STEP_SUMMARY="+summary,
+				"TRIGGERING_ACTOR="+tc.actor,
+			)
+			output, err := cmd.CombinedOutput()
+			if tc.wantError && err == nil {
+				t.Fatalf("unauthorized emergency actor was accepted: %s", output)
+			}
+			if !tc.wantError && err != nil {
+				t.Fatalf("authorized emergency actor was rejected: %v\n%s", err, output)
+			}
+			summaryBytes, readErr := os.ReadFile(summary)
+			if readErr != nil {
+				t.Fatal(readErr)
+			}
+			if !strings.Contains(string(summaryBytes), tc.want) {
+				t.Fatalf("authorization summary lacks %q: %s", tc.want, summaryBytes)
+			}
+			if strings.Contains(string(output), "fixture-token") || strings.Contains(string(summaryBytes), "fixture-token") {
+				t.Fatal("emergency authorization leaked its GitHub token")
+			}
+		})
+	}
+}
+
+func TestEmergencyWorkflowBindsEvidenceBeforeMutationAndAutomatesRetryablePR(t *testing.T) {
+	emergency := mustWorkflow(t, "emergency-overwrite-plugin-tag.yaml")
+	for _, required := range []string{
+		"gateway_version:",
+		"required: true",
+		"ref: ${{ github.sha }}",
+		`test "$WORKFLOW_REF" = refs/heads/main`,
+		`git merge-base --is-ancestor "$evidence_base" refs/remotes/origin/main`,
+		"go build -p 1 -o /tmp/emergency-overwrite-artifact/plugin-release",
+		"git checkout -q \"$SOURCE_COMMIT\"",
+		"git merge-base --is-ancestor \"$CANDIDATE_SOURCE_COMMIT\" \"$SOURCE_COMMIT\"",
+		"ref: ${{ needs.validate.outputs.evidence_base }}",
+		"Upload current tool and built artifact",
+		"chmod 0700 \"$tool\"",
+		"append-emergency-lineage",
+		"actions/create-github-app-token@",
+		`branch="release/plugin-emergency-evidence-$GATEWAY_VERSION-$LOGICAL_ID-$WORKFLOW_RUN_ID"`,
+		`gh pr create --base main --head "$branch"`,
+		`|| gh pr edit "$branch"`,
+		"registry write precedes this PR",
+	} {
+		if !strings.Contains(emergency, required) {
+			t.Fatalf("emergency workflow lacks %q", required)
+		}
+	}
+	buildTool := strings.Index(emergency, "go build -p 1 -o /tmp/emergency-overwrite-artifact/plugin-release")
+	checkoutSource := strings.Index(emergency, "git checkout -q \"$SOURCE_COMMIT\"")
+	validateEvidence := strings.Index(emergency, `candidate=$(jq -cer --arg id "$LOGICAL_ID"`)
+	registryLogin := strings.Index(emergency, "oras login")
+	registryPush := strings.Index(emergency, `digest=$(publish_plugin_manifest`)
+	appendLineage := strings.Index(emergency, "append-emergency-lineage")
+	openPR := strings.Index(emergency, "gh pr create")
+	if buildTool < 0 || checkoutSource < 0 || validateEvidence < 0 || registryLogin < 0 || registryPush < 0 || appendLineage < 0 || openPR < 0 {
+		t.Fatal("emergency workflow lost a required ordering boundary")
+	}
+	if !(buildTool < validateEvidence && validateEvidence < checkoutSource && checkoutSource < registryLogin && registryLogin < registryPush && registryPush < appendLineage && appendLineage < openPR) {
+		t.Fatal("emergency workflow must build the current tool, validate current-main evidence, switch to the source, mutate the registry, append lineage, then publish its PR")
 	}
 }
 

--- a/tools/plugin-release/emergency_lineage.go
+++ b/tools/plugin-release/emergency_lineage.go
@@ -1,0 +1,145 @@
+// Copyright 2026 Higress Authors
+// Licensed under the Apache License, Version 2.0.
+
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+var workflowRunIDPattern = regexp.MustCompile(`^[1-9][0-9]*$`)
+
+func commandAppendEmergencyLineage(args []string) error {
+	fs := flag.NewFlagSet("append-emergency-lineage", flag.ContinueOnError)
+	evidencePath := fs.String("evidence", "", "candidate evidence JSON to update")
+	snapshotPath := fs.String("snapshot", "", "release snapshot that binds the candidate evidence")
+	outputPath := fs.String("output", "", "canonical updated evidence output")
+	gatewayVersion := fs.String("gateway-version", "", "stable gateway release version")
+	logicalID := fs.String("id", "", "logical plugin ID")
+	version := fs.String("version", "", "stable plugin version")
+	image := fs.String("image", "", "catalog public image path")
+	digest := fs.String("digest", "", "emergency manifest digest")
+	inputHash := fs.String("input-hash", "", "emergency source input hash")
+	sourceCommit := fs.String("source-commit", "", "emergency source commit")
+	workflowRunID := fs.String("workflow-run-id", "", "GitHub Actions workflow run ID")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if *evidencePath == "" || *snapshotPath == "" || *outputPath == "" {
+		return errors.New("--evidence, --snapshot, and --output are required")
+	}
+	record := EmergencyLineage{
+		Digest:        *digest,
+		InputHash:     *inputHash,
+		SourceCommit:  *sourceCommit,
+		WorkflowRunID: *workflowRunID,
+	}
+	evidence, err := appendEmergencyLineage(*evidencePath, *snapshotPath, *gatewayVersion, *logicalID, *version, *image, record)
+	if err != nil {
+		return err
+	}
+	return writeCanonical(*outputPath, evidence)
+}
+
+func appendEmergencyLineage(evidencePath, snapshotPath, gatewayVersion, logicalID, version, image string, record EmergencyLineage) (CandidateEvidenceFile, error) {
+	gateway, err := parseSemver(gatewayVersion)
+	if err != nil || gateway.prerelease != "" {
+		return CandidateEvidenceFile{}, errors.New("gateway version must be stable SemVer")
+	}
+	pluginVersion, err := parseSemver(version)
+	if err != nil || pluginVersion.prerelease != "" {
+		return CandidateEvidenceFile{}, errors.New("plugin version must be stable SemVer")
+	}
+	if !safeIDPattern.MatchString(logicalID) {
+		return CandidateEvidenceFile{}, errors.New("logical plugin ID is invalid")
+	}
+	if !strings.HasPrefix(image, "plugins/") || !safeIDPattern.MatchString(strings.TrimPrefix(image, "plugins/")) {
+		return CandidateEvidenceFile{}, errors.New("plugin image must be a safe plugins/<name> path")
+	}
+	if err := validateEmergencyLineageRecord(record); err != nil {
+		return CandidateEvidenceFile{}, fmt.Errorf("new emergency lineage: %w", err)
+	}
+
+	var evidence CandidateEvidenceFile
+	if _, err := readJSON(evidencePath, &evidence); err != nil {
+		return CandidateEvidenceFile{}, err
+	}
+	candidate, ok := evidence.Plugins[logicalID]
+	if !ok {
+		return CandidateEvidenceFile{}, fmt.Errorf("candidate evidence does not contain requested plugin %s", logicalID)
+	}
+	if !digestPattern.MatchString(candidate.Digest) || !commitPattern.MatchString(candidate.SourceCommit) ||
+		!digestPattern.MatchString(candidate.InputHash) || !strings.HasSuffix(candidate.CandidateRef, "@"+candidate.Digest) {
+		return CandidateEvidenceFile{}, fmt.Errorf("candidate evidence for %s has invalid immutable provenance", logicalID)
+	}
+	seenRuns := map[string]EmergencyLineage{}
+	for i, existing := range candidate.Lineage {
+		if err := validateEmergencyLineageRecord(existing); err != nil {
+			return CandidateEvidenceFile{}, fmt.Errorf("candidate evidence lineage %d for %s: %w", i, logicalID, err)
+		}
+		if prior, duplicate := seenRuns[existing.WorkflowRunID]; duplicate {
+			if prior != existing {
+				return CandidateEvidenceFile{}, fmt.Errorf("candidate evidence contains conflicting records for workflow run ID %s", existing.WorkflowRunID)
+			}
+			return CandidateEvidenceFile{}, fmt.Errorf("candidate evidence contains duplicate records for workflow run ID %s", existing.WorkflowRunID)
+		}
+		seenRuns[existing.WorkflowRunID] = existing
+	}
+
+	var snapshot Snapshot
+	if _, err := readJSON(snapshotPath, &snapshot); err != nil {
+		return CandidateEvidenceFile{}, err
+	}
+	if snapshot.SchemaVersion != snapshotSchemaVersion || snapshot.GatewayVersion != gatewayVersion {
+		return CandidateEvidenceFile{}, errors.New("snapshot does not match the requested gateway version")
+	}
+	var binding *SnapshotEntry
+	for i := range snapshot.Plugins {
+		if snapshot.Plugins[i].LogicalID != logicalID {
+			continue
+		}
+		if binding != nil {
+			return CandidateEvidenceFile{}, fmt.Errorf("snapshot contains duplicate plugin %s", logicalID)
+		}
+		binding = &snapshot.Plugins[i]
+	}
+	if binding == nil {
+		return CandidateEvidenceFile{}, fmt.Errorf("snapshot does not contain requested plugin %s", logicalID)
+	}
+	expectedSuffix := "/" + image + ":" + version
+	if binding.Version != version || binding.Image != image || !strings.HasSuffix(binding.OCIRef, expectedSuffix) ||
+		binding.Digest != candidate.Digest || binding.InputHash != candidate.InputHash ||
+		binding.SourceCommit != candidate.SourceCommit || binding.CandidateRef != candidate.CandidateRef {
+		return CandidateEvidenceFile{}, fmt.Errorf("candidate evidence and snapshot do not contain the requested %s/%s:%s public image binding", gatewayVersion, logicalID, version)
+	}
+
+	if existing, exists := seenRuns[record.WorkflowRunID]; exists {
+		if existing != record {
+			return CandidateEvidenceFile{}, fmt.Errorf("workflow run ID %s already records different emergency lineage", record.WorkflowRunID)
+		}
+		return evidence, nil
+	}
+	candidate.Lineage = append(candidate.Lineage, record)
+	evidence.Plugins[logicalID] = candidate
+	return evidence, nil
+}
+
+func validateEmergencyLineageRecord(record EmergencyLineage) error {
+	if !digestPattern.MatchString(record.Digest) {
+		return errors.New("digest must be a lowercase sha256 digest")
+	}
+	if !digestPattern.MatchString(record.InputHash) {
+		return errors.New("inputHash must be a lowercase sha256 digest")
+	}
+	if !commitPattern.MatchString(record.SourceCommit) {
+		return errors.New("sourceCommit must be a full lowercase Git commit")
+	}
+	if !workflowRunIDPattern.MatchString(record.WorkflowRunID) {
+		return errors.New("workflowRunId must be a positive decimal GitHub Actions run ID")
+	}
+	return nil
+}

--- a/tools/plugin-release/emergency_lineage_test.go
+++ b/tools/plugin-release/emergency_lineage_test.go
@@ -1,0 +1,165 @@
+// Copyright 2026 Higress Authors
+// Licensed under the Apache License, Version 2.0.
+
+package main
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestAppendEmergencyLineagePreservesCandidateEvidenceAndIsIdempotent(t *testing.T) {
+	evidencePath, snapshotPath, original, record := emergencyLineageFixture(t)
+	updated, err := appendEmergencyLineage(evidencePath, snapshotPath, "2.2.6", "demo", "1.2.3", "plugins/demo", record)
+	if err != nil {
+		t.Fatal(err)
+	}
+	candidate := updated.Plugins["demo"]
+	if candidate.CandidateRef != original.CandidateRef || candidate.Digest != original.Digest ||
+		candidate.SourceCommit != original.SourceCommit || candidate.InputHash != original.InputHash {
+		t.Fatalf("append changed immutable candidate evidence: before=%#v after=%#v", original, candidate)
+	}
+	if len(candidate.Lineage) != 1 || candidate.Lineage[0] != record {
+		t.Fatalf("emergency lineage was not appended exactly: %#v", candidate.Lineage)
+	}
+	if !reflect.DeepEqual(updated.Plugins["other"], CandidateEvidence{
+		CandidateRef: "registry.example/candidates/other@" + testDigest("other"),
+		Digest:       testDigest("other"), SourceCommit: strings.Repeat("c", 40), InputHash: testDigest("other-input"),
+	}) {
+		t.Fatalf("append changed unrelated candidate evidence: %#v", updated.Plugins["other"])
+	}
+
+	if err := writeCanonical(evidencePath, updated); err != nil {
+		t.Fatal(err)
+	}
+	retried, err := appendEmergencyLineage(evidencePath, snapshotPath, "2.2.6", "demo", "1.2.3", "plugins/demo", record)
+	if err != nil {
+		t.Fatalf("exact retry was not idempotent: %v", err)
+	}
+	if !reflect.DeepEqual(retried, updated) {
+		t.Fatalf("exact retry changed evidence:\nfirst=%#v\nretry=%#v", updated, retried)
+	}
+}
+
+func TestAppendEmergencyLineageRejectsMalformedCollisionAndBindingDrift(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		mutate func(t *testing.T, evidencePath, snapshotPath string, record *EmergencyLineage)
+		want   string
+	}{
+		{
+			name: "malformed-digest",
+			mutate: func(_ *testing.T, _, _ string, record *EmergencyLineage) {
+				record.Digest = "sha256:nope"
+			},
+			want: "digest must",
+		},
+		{
+			name: "malformed-run-id",
+			mutate: func(_ *testing.T, _, _ string, record *EmergencyLineage) {
+				record.WorkflowRunID = "run-42"
+			},
+			want: "workflowRunId",
+		},
+		{
+			name: "run-id-collision",
+			mutate: func(t *testing.T, evidencePath, _ string, record *EmergencyLineage) {
+				var evidence CandidateEvidenceFile
+				if _, err := readJSON(evidencePath, &evidence); err != nil {
+					t.Fatal(err)
+				}
+				candidate := evidence.Plugins["demo"]
+				candidate.Lineage = []EmergencyLineage{{
+					Digest: testDigest("other-emergency"), InputHash: record.InputHash,
+					SourceCommit: record.SourceCommit, WorkflowRunID: record.WorkflowRunID,
+				}}
+				evidence.Plugins["demo"] = candidate
+				if err := writeCanonical(evidencePath, evidence); err != nil {
+					t.Fatal(err)
+				}
+			},
+			want: "already records different",
+		},
+		{
+			name: "snapshot-version-drift",
+			mutate: func(t *testing.T, _, snapshotPath string, _ *EmergencyLineage) {
+				var snapshot Snapshot
+				if _, err := readJSON(snapshotPath, &snapshot); err != nil {
+					t.Fatal(err)
+				}
+				snapshot.Plugins[0].Version = "1.2.4"
+				if err := writeCanonical(snapshotPath, snapshot); err != nil {
+					t.Fatal(err)
+				}
+			},
+			want: "public image binding",
+		},
+		{
+			name: "candidate-digest-drift",
+			mutate: func(t *testing.T, evidencePath, _ string, _ *EmergencyLineage) {
+				var evidence CandidateEvidenceFile
+				if _, err := readJSON(evidencePath, &evidence); err != nil {
+					t.Fatal(err)
+				}
+				candidate := evidence.Plugins["demo"]
+				candidate.Digest = testDigest("drift")
+				candidate.CandidateRef = "registry.example/candidates/demo@" + candidate.Digest
+				evidence.Plugins["demo"] = candidate
+				if err := writeCanonical(evidencePath, evidence); err != nil {
+					t.Fatal(err)
+				}
+			},
+			want: "public image binding",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			evidencePath, snapshotPath, _, record := emergencyLineageFixture(t)
+			tc.mutate(t, evidencePath, snapshotPath, &record)
+			_, err := appendEmergencyLineage(evidencePath, snapshotPath, "2.2.6", "demo", "1.2.3", "plugins/demo", record)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("invalid lineage or binding was accepted, err=%v", err)
+			}
+		})
+	}
+}
+
+func emergencyLineageFixture(t *testing.T) (evidencePath, snapshotPath string, candidate CandidateEvidence, record EmergencyLineage) {
+	t.Helper()
+	root := t.TempDir()
+	digest := testDigest("candidate")
+	candidate = CandidateEvidence{
+		CandidateRef: "registry.example/candidates/demo@" + digest,
+		Digest:       digest,
+		SourceCommit: strings.Repeat("a", 40),
+		InputHash:    testDigest("candidate-input"),
+	}
+	evidence := CandidateEvidenceFile{Plugins: map[string]CandidateEvidence{
+		"demo": candidate,
+		"other": {
+			CandidateRef: "registry.example/candidates/other@" + testDigest("other"),
+			Digest:       testDigest("other"), SourceCommit: strings.Repeat("c", 40), InputHash: testDigest("other-input"),
+		},
+	}}
+	snapshot := Snapshot{
+		SchemaVersion: snapshotSchemaVersion, GatewayVersion: "2.2.6",
+		Plugins: []SnapshotEntry{{
+			LogicalID: "demo", Image: "plugins/demo", Version: "1.2.3",
+			OCIRef: "registry.example/plugins/demo:1.2.3", Digest: candidate.Digest,
+			InputHash: candidate.InputHash, SourceCommit: candidate.SourceCommit, CandidateRef: candidate.CandidateRef,
+		}},
+	}
+	evidencePath = root + "/evidence.json"
+	snapshotPath = root + "/snapshot.json"
+	if err := writeCanonical(evidencePath, evidence); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeCanonical(snapshotPath, snapshot); err != nil {
+		t.Fatal(err)
+	}
+	record = EmergencyLineage{
+		Digest: testDigest("emergency"), InputHash: testDigest("emergency-input"),
+		SourceCommit: strings.Repeat("b", 40), WorkflowRunID: "123456789",
+	}
+	return evidencePath, snapshotPath, candidate, record
+}

--- a/tools/plugin-release/go.mod
+++ b/tools/plugin-release/go.mod
@@ -1,3 +1,5 @@
 module github.com/higress-group/higress/tools/plugin-release
 
 go 1.24
+
+require github.com/tetratelabs/wazero v1.7.2

--- a/tools/plugin-release/go.sum
+++ b/tools/plugin-release/go.sum
@@ -1,0 +1,2 @@
+github.com/tetratelabs/wazero v1.7.2 h1:1+z5nXJNwMLPAWaTePFi49SSTL0IMx/i3Fg8Yc25GDc=
+github.com/tetratelabs/wazero v1.7.2/go.mod h1:ytl6Zuh20R/eROuyDaGPkp82O9C/DJfXAwJfQ3X6/7Y=

--- a/tools/plugin-release/main.go
+++ b/tools/plugin-release/main.go
@@ -10,7 +10,7 @@ import (
 
 func main() {
 	if len(os.Args) < 2 {
-		fatalf("usage: plugin-release <validate-catalog|validate-console-recovery|capture-bootstrap-evidence|bootstrap-snapshot|plan|apply-plan|render-snapshot|migration-preflight|verify-snapshot|semver-compare> [flags]")
+		fatalf("usage: plugin-release <validate-catalog|validate-console-recovery|capture-bootstrap-evidence|bootstrap-snapshot|plan|apply-plan|render-snapshot|migration-preflight|verify-snapshot|verify-pulled-plugin|append-emergency-lineage|semver-compare|emergency-input-hash> [flags]")
 	}
 	var err error
 	switch os.Args[1] {
@@ -32,6 +32,10 @@ func main() {
 		err = commandMigrationPreflight(os.Args[2:])
 	case "verify-snapshot":
 		err = commandVerify(os.Args[2:])
+	case "verify-pulled-plugin":
+		err = commandVerifyPulledPlugin(os.Args[2:])
+	case "append-emergency-lineage":
+		err = commandAppendEmergencyLineage(os.Args[2:])
 	case "semver-compare":
 		err = commandCompare(os.Args[2:])
 	case "emergency-input-hash":

--- a/tools/plugin-release/migration_test.go
+++ b/tools/plugin-release/migration_test.go
@@ -144,8 +144,10 @@ func TestMigrationPreflightBlocksOnlyOccupiedPlannedTags(t *testing.T) {
 	}
 }
 
-func TestMigrationPreflightAcceptsIdenticalPublicDigest(t *testing.T) {
+func TestMigrationPreflightAcceptsEmergencyDigestEqualToCandidateEvidence(t *testing.T) {
 	f := newMigrationFixture(t)
+	// The unified publication contract makes an emergency overwrite with the
+	// candidate inputs byte-identical, so this is already present, not blocked.
 	withManifestResolver(t, migrationResolver(t, map[string]ociManifest{
 		f.controlRef: {Digest: f.controlDigest},
 		f.demoRef:    {Digest: f.demoDigest, Annotations: map[string]string{"org.opencontainers.image.version": "1.0.1", "org.opencontainers.image.revision": f.sourceCommit, "io.higress.plugin.input-hash": f.demoInputHash}},

--- a/tools/plugin-release/model.go
+++ b/tools/plugin-release/model.go
@@ -159,10 +159,21 @@ type CandidateEvidenceFile struct {
 }
 
 type CandidateEvidence struct {
-	CandidateRef string `json:"candidateRef"`
-	Digest       string `json:"digest"`
-	SourceCommit string `json:"sourceCommit"`
-	InputHash    string `json:"inputHash"`
+	CandidateRef string             `json:"candidateRef"`
+	Digest       string             `json:"digest"`
+	SourceCommit string             `json:"sourceCommit"`
+	InputHash    string             `json:"inputHash"`
+	Lineage      []EmergencyLineage `json:"lineage,omitempty"`
+}
+
+// EmergencyLineage records a successful same-version emergency publication
+// without replacing the immutable candidate evidence that authorized the
+// original release.
+type EmergencyLineage struct {
+	Digest        string `json:"digest"`
+	InputHash     string `json:"inputHash"`
+	SourceCommit  string `json:"sourceCommit"`
+	WorkflowRunID string `json:"workflowRunId"`
 }
 
 // BootstrapEvidenceFile is deliberately separate from candidate evidence. A

--- a/tools/plugin-release/plugin_server_workflow_contract_test.go
+++ b/tools/plugin-release/plugin_server_workflow_contract_test.go
@@ -533,6 +533,21 @@ test "$3" = --format=%cI
 test "$4" = "$SOURCE_COMMIT"
 printf '%s\n' "$SOURCE_CREATED"
 `)
+	verifier := filepath.Join(bin, "plugin-release")
+	writeExecutableFixture(t, verifier, `#!/usr/bin/env bash
+set -euo pipefail
+printf 'verify:%s\n' "$*" >> "$OPERATIONS_LOG"
+test "$1" = verify-pulled-plugin
+config=''
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --config) config=$2; shift 2 ;;
+    *) shift ;;
+  esac
+done
+test "$(cat "$config")" = '{}'
+if [ "$ORAS_MODE" = strict-verifier-error ]; then exit 29; fi
+`)
 	writeExecutableFixture(t, filepath.Join(bin, "oras"), `#!/usr/bin/env bash
 set -euo pipefail
 printf 'oras:%s\n' "$*" >> "$OPERATIONS_LOG"
@@ -595,7 +610,15 @@ if [ "$1 $2" = "manifest fetch" ]; then
     config-title-mismatch) config_title=other.json ;;
     wasm-title-mismatch) layer_title=other.wasm ;;
   esac
+  if [ "${4:-}" = "--output" ]; then exec > "$5"; fi
   printf '{"schemaVersion":2,"mediaType":"%s","config":{"mediaType":"%s","digest":"%s","size":2},"annotations":{"org.opencontainers.image.created":"%s","org.opencontainers.image.revision":"%s","org.opencontainers.image.version":"%s","io.higress.plugin.input-hash":"%s"},"layers":[{"mediaType":"%s","digest":"%s","size":2,"annotations":{"org.opencontainers.image.title":"%s"}},{"mediaType":"%s","digest":"%s","size":%s,"annotations":{"org.opencontainers.image.title":"%s"}}%s]}\n' "$manifest_media" "$oci_config_media" "$oci_config_digest" "$created" "$revision" "$version" "$input_hash" "$config_media" "$config_digest" "$config_title" "$layer_media" "$layer_digest" "$WASM_SIZE" "$layer_title" "$extra_layer"
+  exit 0
+fi
+if [ "$1" = pull ]; then
+  test "$3" = --output
+  mkdir -p "$4"
+  if [ "$ORAS_MODE" = pulled-config-not-empty ]; then printf '%s' '{ }' > "$4/config.json"; else printf '%s' '{}' > "$4/config.json"; fi
+  if [ "$ORAS_MODE" = pulled-different-layer ]; then printf '%s' 'different pulled bytes' > "$4/plugin.wasm"; else cp "$WASM_PATH" "$4/plugin.wasm"; fi
   exit 0
 fi
 if [ "$1" = push ]; then
@@ -617,7 +640,7 @@ exit 2
 	buildContract := workflowShellContract(t, "prepare-plugin-release.yaml", "plugin-build-contract")
 	manifestContract := workflowShellContract(t, "prepare-plugin-release.yaml", "plugin-manifest-publish-contract")
 	publishContract := workflowShellContract(t, "prepare-plugin-release.yaml", "candidate-publish-contract")
-	script := "set -euo pipefail\n" + buildContract + manifestContract + publishContract + fmt.Sprintf("\ndigest=$(resolve_or_build_candidate %q go %q demo %q 1.2.3 %q)\nprintf '%%s\\n' \"$digest\"\n", candidate, source, sourceCommit, inputHash)
+	script := "set -euo pipefail\n" + buildContract + manifestContract + publishContract + fmt.Sprintf("\ndigest=$(resolve_or_build_candidate %q go %q demo %q 1.2.3 %q %q)\nprintf '%%s\\n' \"$digest\"\n", candidate, source, sourceCommit, inputHash, verifier)
 	cmd := exec.Command("bash", "-c", script)
 	cmd.Env = append(os.Environ(),
 		"PATH="+bin+":"+os.Getenv("PATH"),
@@ -721,24 +744,42 @@ exit 2
 	}
 }
 
-func TestPreparationReusesValidExistingCandidateWithoutRebuilding(t *testing.T) {
-	for _, mode := range []string{"identical", "valid-different-layer"} {
+func TestPreparationReusesOnlyCandidateMatchingDeterministicBuildAndPulledBlobs(t *testing.T) {
+	result := runCandidatePublishContract(t, "identical")
+	if result.err != nil {
+		t.Fatalf("valid candidate was not reused: %v\n%s", result.err, result.diagnostics)
+	}
+	want := "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc\n"
+	if result.output != want {
+		t.Fatalf("reused candidate digest = %q, want %q", result.output, want)
+	}
+	for _, required := range []string{"prepare\n", "test:test ./...\n", "build:-C plugins/wasm-go PLUGIN_NAME=demo build\n", "oras:pull ", "verify:verify-pulled-plugin "} {
+		if strings.Count(result.log, required) != 1 {
+			t.Fatalf("valid reuse did not execute exactly one %q operation:\n%s", required, result.log)
+		}
+	}
+	if strings.Contains(result.log, "oras:push ") {
+		t.Fatalf("valid reuse mutated the candidate tag:\n%s", result.log)
+	}
+	if strings.Count(result.log, "oras:manifest fetch ") != 2 || !strings.Contains(result.log, "@sha256:") {
+		t.Fatalf("reuse did not resolve descriptor then immutable manifest digest:\n%s", result.log)
+	}
+}
+
+func TestPreparationRejectsExistingCandidateWithDifferentOrInvalidPulledBytes(t *testing.T) {
+	for _, mode := range []string{"valid-different-layer", "pulled-different-layer", "pulled-config-not-empty", "strict-verifier-error"} {
 		t.Run(mode, func(t *testing.T) {
 			result := runCandidatePublishContract(t, mode)
-			if result.err != nil {
-				t.Fatalf("valid candidate was not reused: %v\n%s", result.err, result.diagnostics)
+			if result.err == nil {
+				t.Fatalf("poisoned candidate %s was reused: %s", mode, result.output)
 			}
-			want := "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc\n"
-			if result.output != want {
-				t.Fatalf("reused candidate digest = %q, want %q", result.output, want)
+			if result.output != "" || strings.Contains(result.log, "oras:push ") {
+				t.Fatalf("poisoned candidate %s returned evidence or mutated its tag: output=%q\n%s", mode, result.output, result.log)
 			}
-			for _, forbidden := range []string{"prepare\n", "test:", "build:", "oras:push "} {
-				if strings.Contains(result.log, forbidden) {
-					t.Fatalf("valid candidate performed %q instead of read-only reuse:\n%s", forbidden, result.log)
+			for _, required := range []string{"prepare\n", "test:test ./...\n", "build:-C plugins/wasm-go PLUGIN_NAME=demo build\n"} {
+				if strings.Count(result.log, required) != 1 {
+					t.Fatalf("poisoned candidate %s was not compared with one deterministic source build (%q):\n%s", mode, required, result.log)
 				}
-			}
-			if strings.Count(result.log, "oras:manifest fetch ") != 2 || !strings.Contains(result.log, "@sha256:") {
-				t.Fatalf("reuse did not resolve descriptor then immutable manifest digest:\n%s", result.log)
 			}
 		})
 	}

--- a/tools/plugin-release/plugin_server_workflow_contract_test.go
+++ b/tools/plugin-release/plugin_server_workflow_contract_test.go
@@ -119,6 +119,7 @@ func TestReleaseWorkflowsPairORASSetupMetadataWithPinnedCLI(t *testing.T) {
 	expectedCallers := map[string]int{
 		"prepare-plugin-release.yaml":            2,
 		"promote-plugin-release.yaml":            2,
+		"emergency-overwrite-plugin-tag.yaml":    2,
 		"build-plugin-server-from-snapshot.yaml": 1,
 		"authorize-higress-release-tag.yaml":     1,
 		"dispatch-standalone-release.yaml":       1,
@@ -524,6 +525,14 @@ printf 'build:%s\n' "$*" >> "$OPERATIONS_LOG"
 printf '%s' 'deterministic wasm fixture' > "$WASM_PATH"
 printf 'make fixture output\n'
 `)
+	writeExecutableFixture(t, filepath.Join(bin, "git"), `#!/bin/sh
+set -eu
+test "$1" = show
+test "$2" = -s
+test "$3" = --format=%cI
+test "$4" = "$SOURCE_COMMIT"
+printf '%s\n' "$SOURCE_CREATED"
+`)
 	writeExecutableFixture(t, filepath.Join(bin, "oras"), `#!/usr/bin/env bash
 set -euo pipefail
 printf 'oras:%s\n' "$*" >> "$OPERATIONS_LOG"
@@ -557,22 +566,36 @@ if [ "$1 $2" = "manifest fetch" ]; then
 		wrong-manifest-media) manifest_media=application/example ;;
   esac
   revision=$SOURCE_COMMIT
+  created=$SOURCE_CREATED
   version=$STABLE_VERSION
   input_hash=$INPUT_HASH
+  oci_config_media=application/vnd.unknown.config.v1+json
+  oci_config_digest=sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a
+  config_digest=sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a
+  config_media=application/vnd.module.wasm.config.v1+json
+  config_title=config.json
   layer_digest=$WASM_DIGEST
 	layer_media=application/vnd.module.wasm.content.layer.v1+wasm
+	layer_title=plugin.wasm
 	manifest_media=${manifest_media:-application/vnd.oci.image.manifest.v1+json}
-	layers=''
+	extra_layer=''
 	case "$ORAS_MODE" in
 	  annotation-mismatch) revision=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb ;;
+		created-mismatch) created=2026-02-03T04:05:06Z ;;
 		version-mismatch) version=9.9.9 ;;
 		input-hash-mismatch) input_hash=sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee ;;
 		valid-different-layer) layer_digest=sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee ;;
 		invalid-layer-digest) layer_digest=sha256:not-a-digest ;;
     layer-media-mismatch) layer_media=application/octet-stream ;;
-    layer-count-mismatch) layers=',{"mediaType":"application/vnd.module.wasm.content.layer.v1+wasm","digest":"sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"}' ;;
+    layer-count-mismatch) extra_layer=',{"mediaType":"application/octet-stream","digest":"sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff","size":9}' ;;
+    oci-config-media-mismatch) oci_config_media=application/vnd.oci.empty.v1+json ;;
+    oci-config-digest-mismatch) oci_config_digest=sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff ;;
+    config-media-mismatch) config_media=application/octet-stream ;;
+    config-digest-mismatch) config_digest=sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff ;;
+    config-title-mismatch) config_title=other.json ;;
+    wasm-title-mismatch) layer_title=other.wasm ;;
   esac
-  printf '{"schemaVersion":2,"mediaType":"%s","annotations":{"org.opencontainers.image.revision":"%s","org.opencontainers.image.version":"%s","io.higress.plugin.input-hash":"%s"},"layers":[{"mediaType":"%s","digest":"%s"}%s]}\n' "$manifest_media" "$revision" "$version" "$input_hash" "$layer_media" "$layer_digest" "$layers"
+  printf '{"schemaVersion":2,"mediaType":"%s","config":{"mediaType":"%s","digest":"%s","size":2},"annotations":{"org.opencontainers.image.created":"%s","org.opencontainers.image.revision":"%s","org.opencontainers.image.version":"%s","io.higress.plugin.input-hash":"%s"},"layers":[{"mediaType":"%s","digest":"%s","size":2,"annotations":{"org.opencontainers.image.title":"%s"}},{"mediaType":"%s","digest":"%s","size":%s,"annotations":{"org.opencontainers.image.title":"%s"}}%s]}\n' "$manifest_media" "$oci_config_media" "$oci_config_digest" "$created" "$revision" "$version" "$input_hash" "$config_media" "$config_digest" "$config_title" "$layer_media" "$layer_digest" "$WASM_SIZE" "$layer_title" "$extra_layer"
   exit 0
 fi
 if [ "$1" = push ]; then
@@ -592,8 +615,9 @@ exit 2
 	const manifestDigest = "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
 	const pushDigest = "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
 	buildContract := workflowShellContract(t, "prepare-plugin-release.yaml", "plugin-build-contract")
+	manifestContract := workflowShellContract(t, "prepare-plugin-release.yaml", "plugin-manifest-publish-contract")
 	publishContract := workflowShellContract(t, "prepare-plugin-release.yaml", "candidate-publish-contract")
-	script := "set -euo pipefail\n" + buildContract + publishContract + fmt.Sprintf("\ndigest=$(resolve_or_build_candidate %q go %q demo %q 1.2.3 %q)\nprintf '%%s\\n' \"$digest\"\n", candidate, source, sourceCommit, inputHash)
+	script := "set -euo pipefail\n" + buildContract + manifestContract + publishContract + fmt.Sprintf("\ndigest=$(resolve_or_build_candidate %q go %q demo %q 1.2.3 %q)\nprintf '%%s\\n' \"$digest\"\n", candidate, source, sourceCommit, inputHash)
 	cmd := exec.Command("bash", "-c", script)
 	cmd.Env = append(os.Environ(),
 		"PATH="+bin+":"+os.Getenv("PATH"),
@@ -603,9 +627,11 @@ exit 2
 		"ORAS_MANIFEST_DIGEST="+manifestDigest,
 		"ORAS_PUSH_DIGEST="+pushDigest,
 		"SOURCE_COMMIT="+sourceCommit,
+		"SOURCE_CREATED=2026-01-02T03:04:05Z",
 		"STABLE_VERSION=1.2.3",
 		"INPUT_HASH="+inputHash,
 		fmt.Sprintf("WASM_DIGEST=sha256:%x", wasmSum),
+		fmt.Sprintf("WASM_SIZE=%d", len(wasmBytes)),
 	)
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
@@ -616,6 +642,83 @@ exit 2
 		t.Fatal(readErr)
 	}
 	return candidateContractResult{output: stdout.String(), diagnostics: stderr.String(), log: string(logBytes), err: runErr}
+}
+
+func TestCandidateAndEmergencyUseIdenticalDeterministicManifestContract(t *testing.T) {
+	candidate := workflowShellContract(t, "prepare-plugin-release.yaml", "plugin-manifest-publish-contract")
+	emergency := workflowShellContract(t, "emergency-overwrite-plugin-tag.yaml", "plugin-manifest-publish-contract")
+	if candidate != emergency {
+		t.Fatal("candidate and emergency publication contracts are not byte-for-byte identical")
+	}
+
+	root := t.TempDir()
+	bin := filepath.Join(root, "bin")
+	if err := os.MkdirAll(bin, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	wasmPath := filepath.Join(root, "plugin.wasm")
+	if err := os.WriteFile(wasmPath, []byte("same deterministic wasm bytes"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	manifestPath := filepath.Join(root, "manifest.json")
+	writeExecutableFixture(t, filepath.Join(bin, "git"), `#!/bin/sh
+set -eu
+test "$1" = show
+test "$2" = -s
+test "$3" = --format=%cI
+test "$4" = "$SOURCE_COMMIT"
+printf '%s\n' "$SOURCE_CREATED"
+`)
+	writeExecutableFixture(t, filepath.Join(bin, "oras"), `#!/usr/bin/env bash
+set -euo pipefail
+if [ "$1" = push ]; then
+  test "$3" = "config.json:application/vnd.module.wasm.config.v1+json"
+  test "$4" = "plugin.wasm:application/vnd.module.wasm.content.layer.v1+wasm"
+  test "$5 $6" = "--image-spec v1.0"
+  test "$7 $8" = "--annotation org.opencontainers.image.created=$SOURCE_CREATED"
+  test "$(cat config.json)" = '{}'
+  config_digest="sha256:$(sha256sum config.json | awk '{print $1}')"
+  wasm_digest="sha256:$(sha256sum plugin.wasm | awk '{print $1}')"
+  config_size=$(wc -c < config.json); config_size=${config_size//[[:space:]]/}
+  wasm_size=$(wc -c < plugin.wasm); wasm_size=${wasm_size//[[:space:]]/}
+  jq -cn --arg created "$SOURCE_CREATED" --arg revision "$SOURCE_COMMIT" --arg version "$STABLE_VERSION" --arg input "$INPUT_HASH" --arg config "$config_digest" --arg wasm "$wasm_digest" --argjson configSize "$config_size" --argjson wasmSize "$wasm_size" '{schemaVersion:2,mediaType:"application/vnd.oci.image.manifest.v1+json",config:{mediaType:"application/vnd.unknown.config.v1+json",digest:$config,size:$configSize},annotations:{"org.opencontainers.image.created":$created,"org.opencontainers.image.revision":$revision,"org.opencontainers.image.version":$version,"io.higress.plugin.input-hash":$input},layers:[{mediaType:"application/vnd.module.wasm.config.v1+json",digest:$config,size:$configSize,annotations:{"org.opencontainers.image.title":"config.json"}},{mediaType:"application/vnd.module.wasm.content.layer.v1+wasm",digest:$wasm,size:$wasmSize,annotations:{"org.opencontainers.image.title":"plugin.wasm"}}]}' > "$ORAS_MANIFEST"
+  digest="sha256:$(sha256sum "$ORAS_MANIFEST" | awk '{print $1}')"
+  jq -cn --arg digest "$digest" '{digest:$digest}'
+  exit 0
+fi
+if [ "$1 $2" = "manifest fetch" ]; then
+  cat "$ORAS_MANIFEST"
+  exit 0
+fi
+echo "unexpected fake oras invocation: $*" >&2
+exit 2
+`)
+	const sourceCommit = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	const inputHash = "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	run := func(contract, ref string) string {
+		t.Helper()
+		_ = os.Remove(manifestPath)
+		script := "set -euo pipefail\n" + contract + fmt.Sprintf("\npublish_plugin_manifest %q %q %q 1.2.3 %q\n", ref, wasmPath, sourceCommit, inputHash)
+		cmd := exec.Command("bash", "-c", script)
+		cmd.Env = append(os.Environ(),
+			"PATH="+bin+":"+os.Getenv("PATH"),
+			"ORAS_MANIFEST="+manifestPath,
+			"SOURCE_COMMIT="+sourceCommit,
+			"SOURCE_CREATED=2026-01-02T03:04:05Z",
+			"STABLE_VERSION=1.2.3",
+			"INPUT_HASH="+inputHash,
+		)
+		output, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("manifest publication contract failed: %v\n%s", err, output)
+		}
+		return strings.TrimSpace(string(output))
+	}
+	candidateDigest := run(candidate, "registry.example.invalid/candidates/demo:content-addressed")
+	emergencyDigest := run(emergency, "registry.example.invalid/plugins/demo:1.2.3")
+	if !digestPattern.MatchString(candidateDigest) || emergencyDigest != candidateDigest {
+		t.Fatalf("identical candidate/emergency inputs produced %q and %q", candidateDigest, emergencyDigest)
+	}
 }
 
 func TestPreparationReusesValidExistingCandidateWithoutRebuilding(t *testing.T) {
@@ -675,8 +778,8 @@ func TestPreparationPushesOnceOnlyForStrictlyProvenCandidateAbsence(t *testing.T
 func TestPreparationCandidateLookupAndManifestMismatchesFailWithoutMutation(t *testing.T) {
 	modes := []string{
 		"auth", "ambiguous", "repository-missing", "wrong-acr-ref", "transport", "malformed-descriptor", "wrong-descriptor-media",
-		"manifest-error", "malformed-manifest", "wrong-manifest-media", "annotation-mismatch", "version-mismatch", "input-hash-mismatch",
-		"layer-count-mismatch", "layer-media-mismatch", "invalid-layer-digest",
+		"manifest-error", "malformed-manifest", "wrong-manifest-media", "annotation-mismatch", "created-mismatch", "version-mismatch", "input-hash-mismatch",
+		"layer-count-mismatch", "layer-media-mismatch", "invalid-layer-digest", "oci-config-media-mismatch", "oci-config-digest-mismatch", "config-media-mismatch", "config-digest-mismatch", "config-title-mismatch", "wasm-title-mismatch",
 	}
 	for _, mode := range modes {
 		t.Run(mode, func(t *testing.T) {
@@ -1160,7 +1263,7 @@ func TestPromotionBackfillsVersionTagAndJoinsMonotonicLatest(t *testing.T) {
 		`semver-compare --current "$old" --candidate "$version"`,
 		`latest alias conflict`,
 		`state=identical`,
-		`select(.preflight != "identical")`,
+		`select(.pullGate.status == "passed" and .preflight != "identical")`,
 	} {
 		if !strings.Contains(workflow, required) {
 			t.Fatalf("latest promotion lacks the monotonic complete-set contract %q", required)

--- a/tools/plugin-release/promotion_latest_contract_test.go
+++ b/tools/plugin-release/promotion_latest_contract_test.go
@@ -29,6 +29,7 @@ type latestContractPlugin struct {
 	// the version tag nor the latest alias for the plugin.
 	Blocked               bool
 	BlockedExistingDigest string
+	PullManifestMode      string
 }
 
 type latestContractResult struct {
@@ -204,6 +205,43 @@ func TestPromotionLatestContractDoesNotMutateBeforeCompletePreflight(t *testing.
 	assertNoLatestMutation(t, result.log)
 }
 
+func TestPromotionLatestPullGateJournalsFailureAndProcessesPassingPlugins(t *testing.T) {
+	result := runPromotionLatestContract(t, false, []latestContractPlugin{
+		{ID: "bad", Version: "1.0.0", Digest: testDigest("bad-manifest"), PullManifestMode: "incomplete"},
+		{ID: "good", Version: "2.0.0", Digest: testDigest("good-manifest")},
+	})
+	if result.err == nil || !strings.Contains(result.output, "public artifact pull gate(s) failed") {
+		t.Fatalf("partial pull gate did not fail visibly: err=%v\n%s", result.err, result.output)
+	}
+	if strings.Contains(result.log, "cp registry.example.invalid/plugins/bad@") || strings.Contains(result.log, "plugins/bad:latest") {
+		t.Fatalf("failed plugin's latest alias was copied:\n%s", result.log)
+	}
+	if !strings.Contains(result.log, "cp registry.example.invalid/plugins/good@") || !strings.Contains(result.log, "plugins/good:latest") {
+		t.Fatalf("passing plugin's latest alias was not processed:\n%s", result.log)
+	}
+	lastPull := strings.LastIndex(result.log, "pull registry.example.invalid/")
+	firstCopy := strings.Index(result.log, "cp registry.example.invalid/")
+	if lastPull < 0 || firstCopy < 0 || lastPull > firstCopy {
+		t.Fatalf("every remote public pull must finish before the first latest copy:\n%s", result.log)
+	}
+	if strings.Contains(result.log, "pull file://") {
+		t.Fatalf("pull gate used a local file reference:\n%s", result.log)
+	}
+	if result.journal["phase"] != "latest-partial" || result.journal["pullGateFailures"] != float64(1) {
+		t.Fatalf("failed pull gate did not produce a partial journal: %#v", result.journal)
+	}
+	entries := result.journal["entries"].([]any)
+	failed := entries[0].(map[string]any)
+	pullGate := failed["pullGate"].(map[string]any)
+	failedDigest, _ := failed["digest"].(string)
+	if failed["preflight"] != "pull-gate-failed" || !digestPattern.MatchString(failedDigest) || pullGate["status"] != "failed" || pullGate["digestRef"] != "registry.example.invalid/plugins/bad@"+failedDigest || !strings.Contains(pullGate["reason"].(string), "exactly two layers") {
+		t.Fatalf("failed digest/reason is not auditable: %#v", failed)
+	}
+	if strings.Contains(result.log, "push ") {
+		t.Fatalf("partial pull failure published a completion marker:\n%s", result.log)
+	}
+}
+
 func runPromotionLatestContract(t *testing.T, bootstrap bool, plugins []latestContractPlugin) latestContractResult {
 	t.Helper()
 	return runPromotionLatestContractFixture(t, bootstrap, false, plugins)
@@ -233,11 +271,55 @@ func runPromotionLatestContractFixture(t *testing.T, bootstrap, corruptEvidenceS
 	snapshot := map[string]any{"gatewayVersion": gateway, "plugins": []any{}}
 	registry := map[string]any{}
 	evidencePlugins := map[string]any{}
+	configBytes := []byte(`{}`)
+	wasmBytes := proxyWasmFixture()
+	configDigest := digestBytes(configBytes)
+	manifestDir := filepath.Join(root, "pulled-manifests")
+	if err := os.MkdirAll(manifestDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
 	for _, plugin := range plugins {
 		ref := "registry.example.invalid/plugins/" + plugin.ID + ":" + plugin.Version
 		latest := "registry.example.invalid/plugins/" + plugin.ID + ":latest"
+		sourceCommit := strings.Repeat("a", 40)
+		sourceCreated := "2026-01-02T03:04:05Z"
+		inputHash := testDigest("input-" + plugin.ID)
+		originalDigest := plugin.Digest
+		manifest := map[string]any{
+			"schemaVersion": 2,
+			"mediaType":     ociImageManifestMediaType,
+			"config": map[string]any{
+				"mediaType": "application/vnd.unknown.config.v1+json",
+				"digest":    configDigest,
+				"size":      len(configBytes),
+			},
+			"layers": []any{
+				pulledLayer(wasmConfigMediaType, "config.json", configBytes),
+				pulledLayer(wasmContentMediaType, "plugin.wasm", wasmBytes),
+			},
+			"annotations": map[string]any{
+				"org.opencontainers.image.created":  sourceCreated,
+				"org.opencontainers.image.revision": sourceCommit,
+				"org.opencontainers.image.version":  plugin.Version,
+				"io.higress.plugin.input-hash":      inputHash,
+			},
+		}
+		if plugin.PullManifestMode == "incomplete" {
+			manifest["layers"] = manifest["layers"].([]any)[:1]
+		}
+		manifestBytes := marshalLatestFixture(t, manifest)
+		plugin.Digest = digestBytes(manifestBytes)
+		if plugin.CurrentDigest == originalDigest {
+			plugin.CurrentDigest = plugin.Digest
+		}
+		manifestPath := filepath.Join(manifestDir, plugin.ID+".json")
+		if err := os.WriteFile(manifestPath, manifestBytes, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		digestRef := "registry.example.invalid/plugins/" + plugin.ID + "@" + plugin.Digest
 		snapshotEntry := map[string]any{
 			"logicalId": plugin.ID, "ociRef": ref, "digest": plugin.Digest, "version": plugin.Version,
+			"sourceCommit": sourceCommit, "inputHash": inputHash,
 		}
 		if plugin.Blocked {
 			snapshotEntry["migration"] = map[string]any{
@@ -249,6 +331,10 @@ func runPromotionLatestContractFixture(t *testing.T, bootstrap, corruptEvidenceS
 			registry[ref] = map[string]any{"digest": plugin.BlockedExistingDigest, "version": ""}
 		} else {
 			registry[ref] = map[string]any{"digest": plugin.Digest, "version": plugin.Version}
+			registry[digestRef] = map[string]any{
+				"digest": plugin.Digest, "version": plugin.Version, "sourceCommit": sourceCommit,
+				"inputHash": inputHash, "manifestPath": manifestPath,
+			}
 		}
 		snapshot["plugins"] = append(snapshot["plugins"].([]any), snapshotEntry)
 		if plugin.CurrentDigest != "" {
@@ -294,6 +380,23 @@ func runPromotionLatestContractFixture(t *testing.T, bootstrap, corruptEvidenceS
 	if err := os.WriteFile(statePath, marshalLatestFixture(t, registry), 0o600); err != nil {
 		t.Fatal(err)
 	}
+	pulledConfig := filepath.Join(root, "pulled-config.json")
+	pulledWasm := filepath.Join(root, "pulled-plugin.wasm")
+	if err := os.WriteFile(pulledConfig, configBytes, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(pulledWasm, wasmBytes, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	summaryPath := filepath.Join(root, "step-summary.md")
+	writeExecutableFixture(t, filepath.Join(bin, "git"), `#!/bin/sh
+set -eu
+test "$1" = show
+test "$2" = -s
+test "$3" = --format=%cI
+test "$4" = aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+printf '%s\n' "$SOURCE_CREATED"
+`)
 	writeExecutableFixture(t, filepath.Join(bin, "oras"), `#!/usr/bin/env bash
 set -euo pipefail
 printf '%s\n' "$*" >> "$ORAS_LOG"
@@ -311,6 +414,24 @@ if [ "$1 $2" = "manifest fetch" ]; then
     jq -cn --arg version "$(jq -r '.version // empty' <<<"$record")" '{annotations:{"org.opencontainers.image.version":$version}}'
     exit 0
   fi
+  if [ "${4:-}" = "--output" ]; then
+    output=$5
+    mkdir -p "$(dirname "$output")"
+    cp "$(jq -er .manifestPath <<<"$record")" "$output"
+    exit 0
+  fi
+fi
+if [ "$1" = pull ]; then
+  ref=$2
+  if ! jq -e --arg ref "$ref" '.[$ref]' "$ORAS_STATE" >/dev/null; then
+    echo "response status code 404: Not Found" >&2
+    exit 1
+  fi
+  test "${3:-}" = "--output"
+  mkdir -p "$4"
+  cp "$PULLED_CONFIG" "$4/config.json"
+  cp "$PULLED_WASM" "$4/plugin.wasm"
+  exit 0
 fi
 if [ "$1" = cp ]; then
   source=$2
@@ -343,6 +464,10 @@ exit 2
 		"PATH="+bin+":"+os.Getenv("PATH"),
 		"ORAS_LOG="+logPath,
 		"ORAS_STATE="+statePath,
+		"PULLED_CONFIG="+pulledConfig,
+		"PULLED_WASM="+pulledWasm,
+		"SOURCE_CREATED=2026-01-02T03:04:05Z",
+		"GITHUB_STEP_SUMMARY="+summaryPath,
 		"SNAPSHOT_PATH=plugins/release/snapshots/"+gateway+".json",
 		"SNAPSHOT_SHA256="+snapshotSHAHex,
 	)

--- a/tools/plugin-release/verify_pulled_plugin.go
+++ b/tools/plugin-release/verify_pulled_plugin.go
@@ -1,0 +1,304 @@
+// Copyright 2026 Higress Authors
+// Licensed under the Apache License, Version 2.0.
+
+package main
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"time"
+	"unicode/utf8"
+)
+
+const (
+	ociImageManifestMediaType = "application/vnd.oci.image.manifest.v1+json"
+	unknownConfigMediaType    = "application/vnd.unknown.config.v1+json"
+	emptyObjectDigest         = "sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a"
+	wasmConfigMediaType       = "application/vnd.module.wasm.config.v1+json"
+	wasmContentMediaType      = "application/vnd.module.wasm.content.layer.v1+wasm"
+)
+
+type pulledDescriptor struct {
+	MediaType   string            `json:"mediaType"`
+	Digest      string            `json:"digest"`
+	Size        int64             `json:"size"`
+	Annotations map[string]string `json:"annotations"`
+}
+
+type pulledPluginManifest struct {
+	SchemaVersion int                `json:"schemaVersion"`
+	MediaType     string             `json:"mediaType"`
+	Config        pulledDescriptor   `json:"config"`
+	Layers        []pulledDescriptor `json:"layers"`
+	Annotations   map[string]string  `json:"annotations"`
+}
+
+func commandVerifyPulledPlugin(args []string) error {
+	fs := flag.NewFlagSet("verify-pulled-plugin", flag.ContinueOnError)
+	manifestPath := fs.String("manifest", "", "raw digest-pinned OCI manifest")
+	configPath := fs.String("config", "", "pulled config.json layer")
+	wasmPath := fs.String("wasm", "", "pulled plugin.wasm layer")
+	digest := fs.String("digest", "", "expected manifest digest")
+	sourceCommit := fs.String("source-commit", "", "expected source revision")
+	sourceCreated := fs.String("source-created", "", "expected RFC3339 source commit time")
+	version := fs.String("version", "", "expected stable plugin version")
+	inputHash := fs.String("input-hash", "", "expected plugin input hash")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if *manifestPath == "" || *configPath == "" || *wasmPath == "" {
+		return errors.New("--manifest, --config, and --wasm are required")
+	}
+	return verifyPulledPlugin(*manifestPath, *configPath, *wasmPath, *digest, *sourceCommit, *sourceCreated, *version, *inputHash)
+}
+
+func verifyPulledPlugin(manifestPath, configPath, wasmPath, expectedDigest, expectedSource, expectedCreated, expectedVersion, expectedInputHash string) error {
+	if !digestPattern.MatchString(expectedDigest) {
+		return errors.New("--digest must be a lowercase sha256 digest")
+	}
+	if !commitPattern.MatchString(expectedSource) {
+		return errors.New("--source-commit must be a full lowercase Git commit")
+	}
+	if _, err := time.Parse(time.RFC3339, expectedCreated); err != nil {
+		return errors.New("--source-created must be an RFC3339 timestamp")
+	}
+	parsedVersion, err := parseSemver(expectedVersion)
+	if err != nil || parsedVersion.prerelease != "" {
+		return errors.New("--version must be stable SemVer")
+	}
+	if !digestPattern.MatchString(expectedInputHash) {
+		return errors.New("--input-hash must be a lowercase sha256 digest")
+	}
+
+	manifestBytes, err := os.ReadFile(manifestPath)
+	if err != nil {
+		return fmt.Errorf("read pulled manifest: %w", err)
+	}
+	manifestSum := sha256.Sum256(manifestBytes)
+	if got := "sha256:" + hex.EncodeToString(manifestSum[:]); got != expectedDigest {
+		return fmt.Errorf("pulled manifest digest %s does not match expected digest %s", got, expectedDigest)
+	}
+	var manifest pulledPluginManifest
+	if err := decodeSingleJSON(manifestBytes, &manifest); err != nil {
+		return fmt.Errorf("parse pulled manifest as a canonical OCI v1.0 schema 2 image manifest: %w", err)
+	}
+	if manifest.SchemaVersion != 2 || manifest.MediaType != ociImageManifestMediaType {
+		return errors.New("pulled manifest must be a canonical OCI v1.0 schema 2 image manifest")
+	}
+	if manifest.Config.MediaType != unknownConfigMediaType || manifest.Config.Digest != emptyObjectDigest || manifest.Config.Size != 2 || len(manifest.Config.Annotations) != 0 {
+		return errors.New("pulled manifest OCI config descriptor must identify the canonical empty JSON object")
+	}
+	if len(manifest.Annotations) != 4 ||
+		manifest.Annotations["org.opencontainers.image.created"] != expectedCreated ||
+		manifest.Annotations["org.opencontainers.image.revision"] != expectedSource ||
+		manifest.Annotations["org.opencontainers.image.version"] != expectedVersion ||
+		manifest.Annotations["io.higress.plugin.input-hash"] != expectedInputHash {
+		return errors.New("pulled manifest annotations do not match the deterministic source creation time, revision, version, and input hash")
+	}
+	if len(manifest.Layers) != 2 {
+		return fmt.Errorf("pulled manifest must contain exactly two layers, got %d", len(manifest.Layers))
+	}
+	configDescriptor, wasmDescriptor := manifest.Layers[0], manifest.Layers[1]
+	if configDescriptor.MediaType != wasmConfigMediaType || len(configDescriptor.Annotations) != 1 || configDescriptor.Annotations["org.opencontainers.image.title"] != "config.json" {
+		return errors.New("pulled manifest layer 0 must be the exactly titled config.json Wasm config layer")
+	}
+	if wasmDescriptor.MediaType != wasmContentMediaType || len(wasmDescriptor.Annotations) != 1 || wasmDescriptor.Annotations["org.opencontainers.image.title"] != "plugin.wasm" {
+		return errors.New("pulled manifest layer 1 must be the exactly titled plugin.wasm Wasm content layer")
+	}
+
+	configBytes, err := os.ReadFile(configPath)
+	if err != nil {
+		return fmt.Errorf("read pulled config.json: %w", err)
+	}
+	if err := verifyPulledLayer("config.json", configBytes, configDescriptor); err != nil {
+		return err
+	}
+	var configValue any
+	if err := decodeSingleJSON(configBytes, &configValue); err != nil {
+		return fmt.Errorf("pulled config.json is invalid JSON: %w", err)
+	}
+	if _, ok := configValue.(map[string]any); !ok {
+		return errors.New("pulled config.json must contain a JSON object")
+	}
+	if !bytes.Equal(configBytes, []byte(`{}`)) {
+		return errors.New("pulled config.json must be the canonical empty JSON object")
+	}
+
+	wasmBytes, err := os.ReadFile(wasmPath)
+	if err != nil {
+		return fmt.Errorf("read pulled plugin.wasm: %w", err)
+	}
+	if err := verifyPulledLayer("plugin.wasm", wasmBytes, wasmDescriptor); err != nil {
+		return err
+	}
+	if err := validateProxyWasmModule(wasmBytes); err != nil {
+		return fmt.Errorf("pulled plugin.wasm: %w", err)
+	}
+	return nil
+}
+
+func decodeSingleJSON(data []byte, value any) error {
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	decoder.UseNumber()
+	if err := decoder.Decode(value); err != nil {
+		return err
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); err != io.EOF {
+		if err == nil {
+			return errors.New("multiple JSON values")
+		}
+		return err
+	}
+	return nil
+}
+
+func verifyPulledLayer(name string, data []byte, descriptor pulledDescriptor) error {
+	if !digestPattern.MatchString(descriptor.Digest) {
+		return fmt.Errorf("%s layer descriptor has an invalid digest", name)
+	}
+	if descriptor.Size < 0 || int64(len(data)) != descriptor.Size {
+		return fmt.Errorf("%s size %d does not match layer descriptor size %d", name, len(data), descriptor.Size)
+	}
+	sum := sha256.Sum256(data)
+	if got := "sha256:" + hex.EncodeToString(sum[:]); got != descriptor.Digest {
+		return fmt.Errorf("%s digest %s does not match layer descriptor digest %s", name, got, descriptor.Digest)
+	}
+	return nil
+}
+
+func validateProxyWasmModule(data []byte) error {
+	if len(data) < 8 || !bytes.Equal(data[:4], []byte{0x00, 0x61, 0x73, 0x6d}) {
+		return errors.New("invalid WebAssembly magic")
+	}
+	if !bytes.Equal(data[4:8], []byte{0x01, 0x00, 0x00, 0x00}) {
+		return errors.New("unsupported WebAssembly binary version")
+	}
+	sectionRank := map[byte]int{1: 1, 2: 2, 3: 3, 4: 4, 5: 5, 13: 6, 6: 7, 7: 8, 8: 9, 9: 10, 12: 11, 10: 12, 11: 13}
+	seen := map[byte]bool{}
+	lastRank := 0
+	exportsSeen := false
+	required := map[string]bool{"proxy_on_vm_start": false, "proxy_on_configure": false}
+	abiMarker := false
+	for offset := 8; offset < len(data); {
+		sectionID := data[offset]
+		offset++
+		sectionSize, consumed, err := readWasmVarUint32(data[offset:])
+		if err != nil {
+			return fmt.Errorf("section %d size: %w", sectionID, err)
+		}
+		offset += consumed
+		if uint64(sectionSize) > uint64(len(data)-offset) {
+			return fmt.Errorf("section %d is truncated", sectionID)
+		}
+		end := offset + int(sectionSize)
+		if sectionID != 0 {
+			rank, ok := sectionRank[sectionID]
+			if !ok {
+				return fmt.Errorf("unsupported WebAssembly section id %d", sectionID)
+			}
+			if seen[sectionID] || rank <= lastRank {
+				return fmt.Errorf("WebAssembly section %d is duplicate or out of order", sectionID)
+			}
+			seen[sectionID], lastRank = true, rank
+		}
+		if sectionID == 7 {
+			exportsSeen = true
+			if err := parseProxyWasmExports(data[offset:end], required, &abiMarker); err != nil {
+				return err
+			}
+		}
+		offset = end
+	}
+	if !exportsSeen {
+		return errors.New("WebAssembly export section is missing")
+	}
+	for name, present := range required {
+		if !present {
+			return fmt.Errorf("required function export %q is missing", name)
+		}
+	}
+	if !abiMarker {
+		return errors.New("required proxy_abi_version_0_2_* function export is missing")
+	}
+	return nil
+}
+
+func parseProxyWasmExports(payload []byte, required map[string]bool, abiMarker *bool) error {
+	count, consumed, err := readWasmVarUint32(payload)
+	if err != nil {
+		return fmt.Errorf("export count: %w", err)
+	}
+	offset := consumed
+	seenNames := map[string]bool{}
+	for i := uint32(0); i < count; i++ {
+		nameLength, n, err := readWasmVarUint32(payload[offset:])
+		if err != nil {
+			return fmt.Errorf("export %d name length: %w", i, err)
+		}
+		offset += n
+		if uint64(nameLength) > uint64(len(payload)-offset) {
+			return fmt.Errorf("export %d name is truncated", i)
+		}
+		nameBytes := payload[offset : offset+int(nameLength)]
+		if !utf8.Valid(nameBytes) {
+			return fmt.Errorf("export %d name is not UTF-8", i)
+		}
+		name := string(nameBytes)
+		offset += int(nameLength)
+		if seenNames[name] {
+			return fmt.Errorf("duplicate WebAssembly export %q", name)
+		}
+		seenNames[name] = true
+		if offset >= len(payload) {
+			return fmt.Errorf("export %q descriptor is truncated", name)
+		}
+		kind := payload[offset]
+		offset++
+		if kind > 4 {
+			return fmt.Errorf("export %q has invalid kind %d", name, kind)
+		}
+		_, n, err = readWasmVarUint32(payload[offset:])
+		if err != nil {
+			return fmt.Errorf("export %q index: %w", name, err)
+		}
+		offset += n
+		if _, wanted := required[name]; wanted && kind == 0 {
+			required[name] = true
+		}
+		if strings.HasPrefix(name, "proxy_abi_version_0_2_") && len(name) > len("proxy_abi_version_0_2_") && kind == 0 {
+			*abiMarker = true
+		}
+	}
+	if offset != len(payload) {
+		return errors.New("WebAssembly export section has trailing bytes")
+	}
+	return nil
+}
+
+func readWasmVarUint32(data []byte) (uint32, int, error) {
+	var value uint32
+	for i := 0; i < 5; i++ {
+		if i >= len(data) {
+			return 0, 0, errors.New("truncated varuint32")
+		}
+		b := data[i]
+		if i == 4 && b&0xf0 != 0 {
+			return 0, 0, errors.New("varuint32 overflow")
+		}
+		value |= uint32(b&0x7f) << (7 * i)
+		if b&0x80 == 0 {
+			return value, i + 1, nil
+		}
+	}
+	return 0, 0, errors.New("varuint32 is too long")
+}

--- a/tools/plugin-release/verify_pulled_plugin.go
+++ b/tools/plugin-release/verify_pulled_plugin.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
@@ -15,7 +16,9 @@ import (
 	"os"
 	"strings"
 	"time"
-	"unicode/utf8"
+
+	"github.com/tetratelabs/wazero"
+	"github.com/tetratelabs/wazero/api"
 )
 
 const (
@@ -82,6 +85,11 @@ func verifyPulledPlugin(manifestPath, configPath, wasmPath, expectedDigest, expe
 	if err != nil {
 		return fmt.Errorf("read pulled manifest: %w", err)
 	}
+	// Hashing the fetched file is a digest check, not a re-serialization: oras
+	// 1.2.3, the version every release workflow pins, writes the manifest bytes
+	// the registry served verbatim (confirmed empirically against a production
+	// manifest whose fetched sha256 equalled its registry digest). An oras that
+	// ever reformatted its output would fail this comparison closed.
 	manifestSum := sha256.Sum256(manifestBytes)
 	if got := "sha256:" + hex.EncodeToString(manifestSum[:]); got != expectedDigest {
 		return fmt.Errorf("pulled manifest digest %s does not match expected digest %s", got, expectedDigest)
@@ -177,128 +185,47 @@ func verifyPulledLayer(name string, data []byte, descriptor pulledDescriptor) er
 }
 
 func validateProxyWasmModule(data []byte) error {
-	if len(data) < 8 || !bytes.Equal(data[:4], []byte{0x00, 0x61, 0x73, 0x6d}) {
-		return errors.New("invalid WebAssembly magic")
+	ctx := context.Background()
+	runtime := wazero.NewRuntimeWithConfig(ctx, wazero.NewRuntimeConfigInterpreter())
+	defer runtime.Close(ctx)
+
+	module, err := runtime.CompileModule(ctx, data)
+	if err != nil {
+		return fmt.Errorf("invalid WebAssembly module: %w", err)
 	}
-	if !bytes.Equal(data[4:8], []byte{0x01, 0x00, 0x00, 0x00}) {
-		return errors.New("unsupported WebAssembly binary version")
+	defer module.Close(ctx)
+
+	if len(module.ExportedMemories()) == 0 {
+		return errors.New("required exported memory is missing")
 	}
-	sectionRank := map[byte]int{1: 1, 2: 2, 3: 3, 4: 4, 5: 5, 13: 6, 6: 7, 7: 8, 8: 9, 9: 10, 12: 11, 10: 12, 11: 13}
-	seen := map[byte]bool{}
-	lastRank := 0
-	exportsSeen := false
-	required := map[string]bool{"proxy_on_vm_start": false, "proxy_on_configure": false}
-	abiMarker := false
-	for offset := 8; offset < len(data); {
-		sectionID := data[offset]
-		offset++
-		sectionSize, consumed, err := readWasmVarUint32(data[offset:])
-		if err != nil {
-			return fmt.Errorf("section %d size: %w", sectionID, err)
-		}
-		offset += consumed
-		if uint64(sectionSize) > uint64(len(data)-offset) {
-			return fmt.Errorf("section %d is truncated", sectionID)
-		}
-		end := offset + int(sectionSize)
-		if sectionID != 0 {
-			rank, ok := sectionRank[sectionID]
-			if !ok {
-				return fmt.Errorf("unsupported WebAssembly section id %d", sectionID)
-			}
-			if seen[sectionID] || rank <= lastRank {
-				return fmt.Errorf("WebAssembly section %d is duplicate or out of order", sectionID)
-			}
-			seen[sectionID], lastRank = true, rank
-		}
-		if sectionID == 7 {
-			exportsSeen = true
-			if err := parseProxyWasmExports(data[offset:end], required, &abiMarker); err != nil {
-				return err
-			}
-		}
-		offset = end
-	}
-	if !exportsSeen {
-		return errors.New("WebAssembly export section is missing")
-	}
-	for name, present := range required {
-		if !present {
+	exportedFunctions := module.ExportedFunctions()
+	callbackSignature := []api.ValueType{api.ValueTypeI32, api.ValueTypeI32}
+	callbackResult := []api.ValueType{api.ValueTypeI32}
+	for _, name := range []string{"proxy_on_vm_start", "proxy_on_configure"} {
+		definition, ok := exportedFunctions[name]
+		if !ok {
 			return fmt.Errorf("required function export %q is missing", name)
 		}
+		if !sameValueTypes(definition.ParamTypes(), callbackSignature) || !sameValueTypes(definition.ResultTypes(), callbackResult) {
+			return fmt.Errorf("required function export %q must have signature (i32,i32)->i32", name)
+		}
 	}
-	if !abiMarker {
-		return errors.New("required proxy_abi_version_0_2_* function export is missing")
+	for name, definition := range exportedFunctions {
+		if strings.HasPrefix(name, "proxy_abi_version_0_2_") && len(name) > len("proxy_abi_version_0_2_") && len(definition.ParamTypes()) == 0 && len(definition.ResultTypes()) == 0 {
+			return nil
+		}
 	}
-	return nil
+	return errors.New("required proxy_abi_version_0_2_* function export with signature ()->() is missing")
 }
 
-func parseProxyWasmExports(payload []byte, required map[string]bool, abiMarker *bool) error {
-	count, consumed, err := readWasmVarUint32(payload)
-	if err != nil {
-		return fmt.Errorf("export count: %w", err)
+func sameValueTypes(got, want []api.ValueType) bool {
+	if len(got) != len(want) {
+		return false
 	}
-	offset := consumed
-	seenNames := map[string]bool{}
-	for i := uint32(0); i < count; i++ {
-		nameLength, n, err := readWasmVarUint32(payload[offset:])
-		if err != nil {
-			return fmt.Errorf("export %d name length: %w", i, err)
-		}
-		offset += n
-		if uint64(nameLength) > uint64(len(payload)-offset) {
-			return fmt.Errorf("export %d name is truncated", i)
-		}
-		nameBytes := payload[offset : offset+int(nameLength)]
-		if !utf8.Valid(nameBytes) {
-			return fmt.Errorf("export %d name is not UTF-8", i)
-		}
-		name := string(nameBytes)
-		offset += int(nameLength)
-		if seenNames[name] {
-			return fmt.Errorf("duplicate WebAssembly export %q", name)
-		}
-		seenNames[name] = true
-		if offset >= len(payload) {
-			return fmt.Errorf("export %q descriptor is truncated", name)
-		}
-		kind := payload[offset]
-		offset++
-		if kind > 4 {
-			return fmt.Errorf("export %q has invalid kind %d", name, kind)
-		}
-		_, n, err = readWasmVarUint32(payload[offset:])
-		if err != nil {
-			return fmt.Errorf("export %q index: %w", name, err)
-		}
-		offset += n
-		if _, wanted := required[name]; wanted && kind == 0 {
-			required[name] = true
-		}
-		if strings.HasPrefix(name, "proxy_abi_version_0_2_") && len(name) > len("proxy_abi_version_0_2_") && kind == 0 {
-			*abiMarker = true
+	for i := range want {
+		if got[i] != want[i] {
+			return false
 		}
 	}
-	if offset != len(payload) {
-		return errors.New("WebAssembly export section has trailing bytes")
-	}
-	return nil
-}
-
-func readWasmVarUint32(data []byte) (uint32, int, error) {
-	var value uint32
-	for i := 0; i < 5; i++ {
-		if i >= len(data) {
-			return 0, 0, errors.New("truncated varuint32")
-		}
-		b := data[i]
-		if i == 4 && b&0xf0 != 0 {
-			return 0, 0, errors.New("varuint32 overflow")
-		}
-		value |= uint32(b&0x7f) << (7 * i)
-		if b&0x80 == 0 {
-			return value, i + 1, nil
-		}
-	}
-	return 0, 0, errors.New("varuint32 is too long")
+	return true
 }

--- a/tools/plugin-release/verify_pulled_plugin_test.go
+++ b/tools/plugin-release/verify_pulled_plugin_test.go
@@ -4,6 +4,7 @@
 package main
 
 import (
+	"bytes"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
@@ -148,12 +149,56 @@ func TestVerifyPulledPluginRejectsBadManifestBlobsAndWasm(t *testing.T) {
 			mutate: func(t *testing.T, manifestPath, _, wasmPath string) {
 				writePulledLayerAndDescriptor(t, manifestPath, wasmPath, append(proxyWasmFixture(), 7, 10, 1), 1)
 			},
-			want: "truncated",
+			want: "invalid WebAssembly module",
+		},
+		{
+			name: "out-of-range-export-index",
+			mutate: func(t *testing.T, manifestPath, _, wasmPath string) {
+				wasm := proxyWasmFixture()
+				marker := append([]byte("proxy_on_configure"), 0x00)
+				offset := bytes.Index(wasm, marker)
+				if offset < 0 {
+					t.Fatal("fixture lacks proxy_on_configure export")
+				}
+				wasm[offset+len(marker)] = 0x7f
+				writePulledLayerAndDescriptor(t, manifestPath, wasmPath, wasm, 1)
+			},
+			want: "invalid WebAssembly module",
+		},
+		{
+			name: "incompatible-callback-signature",
+			mutate: func(t *testing.T, manifestPath, _, wasmPath string) {
+				writePulledLayerAndDescriptor(t, manifestPath, wasmPath, proxyWasmModule(true, map[string]uint32{"proxy_on_vm_start": 1}, "proxy_on_vm_start", "proxy_on_configure", "proxy_abi_version_0_2_1"), 1)
+			},
+			want: "signature (i32,i32)->i32",
+		},
+		{
+			name: "incompatible-abi-signature",
+			mutate: func(t *testing.T, manifestPath, _, wasmPath string) {
+				writePulledLayerAndDescriptor(t, manifestPath, wasmPath, proxyWasmModule(true, map[string]uint32{"proxy_abi_version_0_2_1": 0}, "proxy_on_vm_start", "proxy_on_configure", "proxy_abi_version_0_2_1"), 1)
+			},
+			want: "signature ()->()",
+		},
+		{
+			name: "missing-exported-memory",
+			mutate: func(t *testing.T, manifestPath, _, wasmPath string) {
+				writePulledLayerAndDescriptor(t, manifestPath, wasmPath, proxyWasmModule(false, nil, "proxy_on_vm_start", "proxy_on_configure", "proxy_abi_version_0_2_1"), 1)
+			},
+			want: "exported memory",
+		},
+		{
+			name: "malformed-code",
+			mutate: func(t *testing.T, manifestPath, _, wasmPath string) {
+				wasm := proxyWasmFixture()
+				wasm[len(wasm)-1] = 0xff
+				writePulledLayerAndDescriptor(t, manifestPath, wasmPath, wasm, 1)
+			},
+			want: "invalid WebAssembly module",
 		},
 		{
 			name: "missing-required-export",
 			mutate: func(t *testing.T, manifestPath, _, wasmPath string) {
-				writePulledLayerAndDescriptor(t, manifestPath, wasmPath, proxyWasmWithExports("proxy_on_vm_start", "proxy_abi_version_0_2_1"), 1)
+				writePulledLayerAndDescriptor(t, manifestPath, wasmPath, proxyWasmModule(true, nil, "proxy_on_vm_start", "proxy_abi_version_0_2_1"), 1)
 			},
 			want: "proxy_on_configure",
 		},
@@ -266,16 +311,42 @@ func digestBytes(data []byte) string {
 }
 
 func proxyWasmFixture() []byte {
-	return proxyWasmWithExports("proxy_on_vm_start", "proxy_on_configure", "proxy_abi_version_0_2_1")
+	return proxyWasmModule(true, nil, "proxy_on_vm_start", "proxy_on_configure", "proxy_abi_version_0_2_1")
 }
 
-func proxyWasmWithExports(names ...string) []byte {
+func proxyWasmModule(exportMemory bool, typeOverrides map[string]uint32, names ...string) []byte {
 	module := []byte{0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00}
-	typePayload := []byte{0x01, 0x60, 0x00, 0x00}
+	// Type 0 is the Proxy-Wasm callback signature (i32,i32)->i32; type 1
+	// is the ABI marker signature ()->().
+	typePayload := []byte{0x02, 0x60, 0x02, 0x7f, 0x7f, 0x01, 0x7f, 0x60, 0x00, 0x00}
 	module = appendWasmSection(module, 1, typePayload)
-	functionPayload := append(wasmVarUint(uint32(len(names))), make([]byte, len(names))...)
+	functionPayload := wasmVarUint(uint32(len(names)))
+	functionTypes := make([]uint32, len(names))
+	for i, name := range names {
+		typeIndex := uint32(0)
+		if strings.HasPrefix(name, "proxy_abi_version_0_2_") {
+			typeIndex = 1
+		}
+		if override, ok := typeOverrides[name]; ok {
+			typeIndex = override
+		}
+		functionTypes[i] = typeIndex
+		functionPayload = append(functionPayload, wasmVarUint(typeIndex)...)
+	}
 	module = appendWasmSection(module, 3, functionPayload)
-	exportPayload := wasmVarUint(uint32(len(names)))
+	if exportMemory {
+		module = appendWasmSection(module, 5, []byte{0x01, 0x00, 0x01})
+	}
+	exportCount := len(names)
+	if exportMemory {
+		exportCount++
+	}
+	exportPayload := wasmVarUint(uint32(exportCount))
+	if exportMemory {
+		exportPayload = append(exportPayload, 0x06)
+		exportPayload = append(exportPayload, []byte("memory")...)
+		exportPayload = append(exportPayload, 0x02, 0x00)
+	}
 	for index, name := range names {
 		exportPayload = append(exportPayload, wasmVarUint(uint32(len(name)))...)
 		exportPayload = append(exportPayload, []byte(name)...)
@@ -284,8 +355,12 @@ func proxyWasmWithExports(names ...string) []byte {
 	}
 	module = appendWasmSection(module, 7, exportPayload)
 	codePayload := wasmVarUint(uint32(len(names)))
-	for range names {
-		codePayload = append(codePayload, 0x02, 0x00, 0x0b)
+	for _, typeIndex := range functionTypes {
+		if typeIndex == 0 {
+			codePayload = append(codePayload, 0x04, 0x00, 0x41, 0x01, 0x0b)
+		} else {
+			codePayload = append(codePayload, 0x02, 0x00, 0x0b)
+		}
 	}
 	return appendWasmSection(module, 10, codePayload)
 }

--- a/tools/plugin-release/verify_pulled_plugin_test.go
+++ b/tools/plugin-release/verify_pulled_plugin_test.go
@@ -1,0 +1,312 @@
+// Copyright 2026 Higress Authors
+// Licensed under the Apache License, Version 2.0.
+
+package main
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const (
+	pulledSource  = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	pulledCreated = "2026-01-02T03:04:05Z"
+	pulledInput   = "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	pulledVer     = "1.2.3"
+)
+
+func TestVerifyPulledPluginAcceptsStrictTwoLayerProxyWasm(t *testing.T) {
+	manifest, config, wasm, digest := writePulledPluginFixture(t)
+	if err := verifyPulledPlugin(manifest, config, wasm, digest, pulledSource, pulledCreated, pulledVer, pulledInput); err != nil {
+		t.Fatalf("valid pulled plugin was rejected: %v", err)
+	}
+}
+
+func TestVerifyPulledPluginRejectsBadManifestBlobsAndWasm(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		mutate func(t *testing.T, manifestPath, configPath, wasmPath string)
+		want   string
+	}{
+		{
+			name: "incomplete-manifest",
+			mutate: func(t *testing.T, manifestPath, _, _ string) {
+				mutatePulledManifest(t, manifestPath, func(manifest map[string]any) {
+					manifest["layers"] = manifest["layers"].([]any)[:1]
+				})
+			},
+			want: "exactly two layers",
+		},
+		{
+			name: "wrong-layer-order",
+			mutate: func(t *testing.T, manifestPath, _, _ string) {
+				mutatePulledManifest(t, manifestPath, func(manifest map[string]any) {
+					layers := manifest["layers"].([]any)
+					layers[0], layers[1] = layers[1], layers[0]
+				})
+			},
+			want: "layer 0",
+		},
+		{
+			name: "provenance-mismatch",
+			mutate: func(t *testing.T, manifestPath, _, _ string) {
+				mutatePulledManifest(t, manifestPath, func(manifest map[string]any) {
+					manifest["annotations"].(map[string]any)["org.opencontainers.image.version"] = "9.9.9"
+				})
+			},
+			want: "manifest annotations",
+		},
+		{
+			name: "unexpected-manifest-annotation",
+			mutate: func(t *testing.T, manifestPath, _, _ string) {
+				mutatePulledManifest(t, manifestPath, func(manifest map[string]any) {
+					manifest["annotations"].(map[string]any)["unexpected"] = "value"
+				})
+			},
+			want: "manifest annotations",
+		},
+		{
+			name: "oci-v1.1-artifact-type",
+			mutate: func(t *testing.T, manifestPath, _, _ string) {
+				mutatePulledManifest(t, manifestPath, func(manifest map[string]any) {
+					manifest["artifactType"] = "application/vnd.unknown.artifact.v1"
+				})
+			},
+			want: "canonical OCI v1.0",
+		},
+		{
+			name: "noncanonical-oci-config",
+			mutate: func(t *testing.T, manifestPath, _, _ string) {
+				mutatePulledManifest(t, manifestPath, func(manifest map[string]any) {
+					manifest["config"].(map[string]any)["mediaType"] = "application/vnd.oci.image.config.v1+json"
+				})
+			},
+			want: "canonical empty JSON object",
+		},
+		{
+			name: "unexpected-layer-descriptor-field",
+			mutate: func(t *testing.T, manifestPath, _, _ string) {
+				mutatePulledManifest(t, manifestPath, func(manifest map[string]any) {
+					manifest["layers"].([]any)[1].(map[string]any)["artifactType"] = "application/wasm"
+				})
+			},
+			want: "unknown field",
+		},
+		{
+			name: "config-is-not-object",
+			mutate: func(t *testing.T, manifestPath, configPath, _ string) {
+				writePulledLayerAndDescriptor(t, manifestPath, configPath, []byte(`[]`), 0)
+			},
+			want: "JSON object",
+		},
+		{
+			name: "config-is-not-canonical-empty-object",
+			mutate: func(t *testing.T, manifestPath, configPath, _ string) {
+				writePulledLayerAndDescriptor(t, manifestPath, configPath, []byte(`{ }`), 0)
+			},
+			want: "canonical empty JSON object",
+		},
+		{
+			name: "config-digest-mismatch",
+			mutate: func(t *testing.T, _, configPath, _ string) {
+				if err := os.WriteFile(configPath, []byte(`[]`), 0o600); err != nil {
+					t.Fatal(err)
+				}
+			},
+			want: "digest",
+		},
+		{
+			name: "wasm-size-mismatch",
+			mutate: func(t *testing.T, _, _, wasmPath string) {
+				if err := os.WriteFile(wasmPath, []byte("different"), 0o600); err != nil {
+					t.Fatal(err)
+				}
+			},
+			want: "size",
+		},
+		{
+			name: "wasm-digest-mismatch",
+			mutate: func(t *testing.T, _, _, wasmPath string) {
+				wasm, err := os.ReadFile(wasmPath)
+				if err != nil {
+					t.Fatal(err)
+				}
+				wasm[len(wasm)-1] ^= 0x01
+				if err := os.WriteFile(wasmPath, wasm, 0o600); err != nil {
+					t.Fatal(err)
+				}
+			},
+			want: "digest",
+		},
+		{
+			name: "truncated-wasm-section",
+			mutate: func(t *testing.T, manifestPath, _, wasmPath string) {
+				writePulledLayerAndDescriptor(t, manifestPath, wasmPath, append(proxyWasmFixture(), 7, 10, 1), 1)
+			},
+			want: "truncated",
+		},
+		{
+			name: "missing-required-export",
+			mutate: func(t *testing.T, manifestPath, _, wasmPath string) {
+				writePulledLayerAndDescriptor(t, manifestPath, wasmPath, proxyWasmWithExports("proxy_on_vm_start", "proxy_abi_version_0_2_1"), 1)
+			},
+			want: "proxy_on_configure",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			manifest, config, wasm, _ := writePulledPluginFixture(t)
+			tc.mutate(t, manifest, config, wasm)
+			manifestBytes, err := os.ReadFile(manifest)
+			if err != nil {
+				t.Fatal(err)
+			}
+			digest := digestBytes(manifestBytes)
+			err = verifyPulledPlugin(manifest, config, wasm, digest, pulledSource, pulledCreated, pulledVer, pulledInput)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("invalid pulled artifact was accepted or returned the wrong error: %v", err)
+			}
+		})
+	}
+}
+
+func writePulledPluginFixture(t *testing.T) (manifestPath, configPath, wasmPath, digest string) {
+	t.Helper()
+	root := t.TempDir()
+	manifestPath = filepath.Join(root, "manifest.json")
+	configPath = filepath.Join(root, "config.json")
+	wasmPath = filepath.Join(root, "plugin.wasm")
+	config := []byte(`{}`)
+	wasm := proxyWasmFixture()
+	if err := os.WriteFile(configPath, config, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(wasmPath, wasm, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	manifest := map[string]any{
+		"schemaVersion": 2,
+		"mediaType":     ociImageManifestMediaType,
+		"config": map[string]any{
+			"mediaType": "application/vnd.unknown.config.v1+json",
+			"digest":    digestBytes([]byte(`{}`)),
+			"size":      2,
+		},
+		"annotations": map[string]any{
+			"org.opencontainers.image.created":  pulledCreated,
+			"org.opencontainers.image.revision": pulledSource,
+			"org.opencontainers.image.version":  pulledVer,
+			"io.higress.plugin.input-hash":      pulledInput,
+		},
+		"layers": []any{
+			pulledLayer(wasmConfigMediaType, "config.json", config),
+			pulledLayer(wasmContentMediaType, "plugin.wasm", wasm),
+		},
+	}
+	data, err := json.Marshal(manifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(manifestPath, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return manifestPath, configPath, wasmPath, digestBytes(data)
+}
+
+func mutatePulledManifest(t *testing.T, path string, mutate func(map[string]any)) {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var manifest map[string]any
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		t.Fatal(err)
+	}
+	mutate(manifest)
+	data, err = json.Marshal(manifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func writePulledLayerAndDescriptor(t *testing.T, manifestPath, layerPath string, data []byte, layerIndex int) {
+	t.Helper()
+	if err := os.WriteFile(layerPath, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	mutatePulledManifest(t, manifestPath, func(manifest map[string]any) {
+		layer := manifest["layers"].([]any)[layerIndex].(map[string]any)
+		layer["digest"] = digestBytes(data)
+		layer["size"] = len(data)
+	})
+}
+
+func pulledLayer(mediaType, title string, data []byte) map[string]any {
+	return map[string]any{
+		"mediaType": mediaType,
+		"digest":    digestBytes(data),
+		"size":      len(data),
+		"annotations": map[string]any{
+			"org.opencontainers.image.title": title,
+		},
+	}
+}
+
+func digestBytes(data []byte) string {
+	sum := sha256.Sum256(data)
+	return "sha256:" + hex.EncodeToString(sum[:])
+}
+
+func proxyWasmFixture() []byte {
+	return proxyWasmWithExports("proxy_on_vm_start", "proxy_on_configure", "proxy_abi_version_0_2_1")
+}
+
+func proxyWasmWithExports(names ...string) []byte {
+	module := []byte{0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00}
+	typePayload := []byte{0x01, 0x60, 0x00, 0x00}
+	module = appendWasmSection(module, 1, typePayload)
+	functionPayload := append(wasmVarUint(uint32(len(names))), make([]byte, len(names))...)
+	module = appendWasmSection(module, 3, functionPayload)
+	exportPayload := wasmVarUint(uint32(len(names)))
+	for index, name := range names {
+		exportPayload = append(exportPayload, wasmVarUint(uint32(len(name)))...)
+		exportPayload = append(exportPayload, []byte(name)...)
+		exportPayload = append(exportPayload, 0x00)
+		exportPayload = append(exportPayload, wasmVarUint(uint32(index))...)
+	}
+	module = appendWasmSection(module, 7, exportPayload)
+	codePayload := wasmVarUint(uint32(len(names)))
+	for range names {
+		codePayload = append(codePayload, 0x02, 0x00, 0x0b)
+	}
+	return appendWasmSection(module, 10, codePayload)
+}
+
+func appendWasmSection(module []byte, id byte, payload []byte) []byte {
+	module = append(module, id)
+	module = append(module, wasmVarUint(uint32(len(payload)))...)
+	return append(module, payload...)
+}
+
+func wasmVarUint(value uint32) []byte {
+	var out []byte
+	for {
+		current := byte(value & 0x7f)
+		value >>= 7
+		if value != 0 {
+			current |= 0x80
+		}
+		out = append(out, current)
+		if value == 0 {
+			return out
+		}
+	}
+}


### PR DESCRIPTION
Implements S1 + S2 of Proposal #4634 (SPEC-4634001 + SPEC-4634002 + SPEC-4634003). S3 + S4 landed earlier as #4638.

## S1 — Single published layout (SPEC-4634001)
Prepare/candidate builds and emergency-overwrite now produce and publish the same 2-layer Envoy-loadable manifest (config.json + plugin.wasm, exact mediaTypes/titles): same source + inputHash yields the same digest through either channel, so a tag previously patched by an emergency overwrite no longer conflicts with a later promote preflight.

## S1b — Real pull verification before latest moves (SPEC-4634002)
New `verify-pulled-plugin` tool: remotely pulls the manifest + layers by digest from the public registry, verifies manifest byte-fidelity against the digest, the 2-layer structural contract, and compiles the wasm module (wazero) with export-signature inspection (`proxy_on_vm_start`, `proxy_on_configure`). Promote runs it before moving latest; failures block only the latest move while version tags stay immutable. Verification depth is compile+structural (documented); runtime Envoy smoke is a deferred future gate — SPEC v2 amendments drafted to match.

## S2 — Emergency channel alignment (SPEC-4634003)
- Evidence lineage: after a successful overwrite, a lineage record (digest, inputHash, sourceCommit, workflowRunId) is appended on a deterministic evidence branch and pushed via PR — idempotent by workflow run ID.
- Self-approval: the `authorize` job verifies the triggering actor holds maintain/admin permission (collaborators API, fail-closed), replacing the second-maintainer environment gate; the mutating `publish` job re-affirms the same check as its first step, closing the re-run-failed-jobs bypass.
- The loadability gate runs against the remotely pulled staged candidate BEFORE any stable-tag mutation.
- Staging tags are retained permanently as provenance (registries implement tag deletion as manifest deletion; oras 1.2.3 has no tag-only unlink) — documented, no cleanup attempted.

## Review trail
Independent multi-round review: Qwen3.8-Max review (3 P1 / 3 P2) → Ultimate adjudication (4 confirmed, 2 rejected) → fixes applied → Ultimate final review found one P0 (destructive staging-tag delete semantics) → replaced with retention policy → 3 sign-off rounds → **recommend merge, no remaining findings**. Focused suite green (101s); all three workflow YAMLs parse; DCO intact.

Implementation: Ultimate model agent (main implementation + validation-gap cleanup) + Qwen3.8-Max fix round + maintainer surgical fixes (retention policy, text alignment, artifact cleanup).
