### PR TITLE
feat: add model card runtime identity context

### DIFF
--- a/plugins/wasm-go/extensions/model-mapper/Makefile
+++ b/plugins/wasm-go/extensions/model-mapper/Makefile
@@ -1,2 +1,2 @@
 build-go:
-	GOOS=wasip1 GOARCH=wasm go build -buildmode=c-shared -o main.wasm main.go
+	GOOS=wasip1 GOARCH=wasm go build -buildmode=c-shared -o main.wasm .

--- a/plugins/wasm-go/extensions/model-mapper/main.go
+++ b/plugins/wasm-go/extensions/model-mapper/main.go
@@ -42,10 +42,31 @@ type Config struct {
 	defaultModel       string
 	enableOnPathSuffix []string
 	modelToHeader      string
+	// runtimeIdentity 仅由 APIG C1 的冻结 projection 下发；nil 时完整保留 legacy mapper 语义。
+	runtimeIdentity *runtimeIdentityRule
+	// runtimeTarget 与 runtimeTargetKey 是当前映射规则的唯一跨卡身份目标，禁止由请求模型名反推。
+	runtimeTarget    *runtimeIdentityTarget
+	runtimeTargetKey string
 }
 
 func parseConfig(json gjson.Result, config *Config) error {
+	runtimeIdentity, runtimeTarget, runtimeTargetKey, err := parseMapperRuntimeIdentity(
+		json.Get("modelRuntimeIdentity"),
+		json.Get("modelRuntimeIdentityTarget"),
+		json.Get("modelRuntimeIdentityTargetKey"),
+	)
+	if err != nil {
+		return err
+	}
+	config.runtimeIdentity = runtimeIdentity
+	config.runtimeTarget = runtimeTarget
+	config.runtimeTargetKey = runtimeTargetKey
 	config.modelKey = json.Get("modelKey").String()
+	if config.runtimeIdentity != nil {
+		// APIGO-CONTRACT: modelcard-runtime-identity
+		// strict parser 的模型字段必须来自同一冻结 rule，不能被 mapper 的 legacy 默认值覆盖。
+		config.modelKey = config.runtimeIdentity.Parser.ModelKey
+	}
 	if config.modelKey == "" {
 		config.modelKey = "model"
 	}
@@ -125,6 +146,9 @@ func parseConfig(json gjson.Result, config *Config) error {
 }
 
 func onHttpRequestHeaders(ctx wrapper.HttpContext, config Config) types.Action {
+	if config.runtimeIdentity != nil {
+		return onRuntimeIdentityRequestHeaders(ctx, config)
+	}
 	// Check path suffix
 	path, err := proxywasm.GetHttpRequestHeader(":path")
 	if err != nil {
@@ -160,6 +184,9 @@ func onHttpRequestHeaders(ctx wrapper.HttpContext, config Config) types.Action {
 }
 
 func onHttpRequestBody(ctx wrapper.HttpContext, config Config, body []byte) types.Action {
+	if config.runtimeIdentity != nil {
+		return handleRuntimeIdentityMapping(ctx, config, body)
+	}
 	if len(body) == 0 {
 		return types.ActionContinue
 	}
@@ -203,4 +230,133 @@ func onHttpRequestBody(ctx wrapper.HttpContext, config Config, body []byte) type
 	}
 
 	return types.ActionContinue
+}
+
+// onRuntimeIdentityRequestHeaders 为 strict mapper 配置准备唯一允许的 JSON Body，并阻止 legacy suffix 规则降级。
+// 输入约束：runtimeIdentity/runtimeTarget 已由同一发布快照完整验证；客户端 Header 不是身份来源。
+// 输出语义：合法请求只进入 Body 检查；是否执行映射及 DisableReroute 必须等 Body 中的 Auto/Direct 事实确定后再决定。
+// 边界场景：reserved Auto 在 ai-auto-router 建立 seq=1 前必须无副作用透传；普通 mapper/fallback 仍要求已有 context。
+func onRuntimeIdentityRequestHeaders(ctx wrapper.HttpContext, config Config) types.Action {
+	if config.runtimeIdentity == nil || config.runtimeTarget == nil {
+		return rejectRuntimeIdentityRequest(ctx, "invalid_runtime_identity_config")
+	}
+	if !ctx.HasRequestBody() {
+		return rejectRuntimeIdentityRequest(ctx, "body_required")
+	}
+	contentType, err := proxywasm.GetHttpRequestHeader("content-type")
+	if err != nil || !strings.Contains(strings.ToLower(contentType), "application/json") {
+		return rejectRuntimeIdentityRequest(ctx, "json_body_required")
+	}
+	ctx.SetRequestBodyBufferLimit(DefaultMaxBodyBytes)
+	return types.HeaderStopIteration
+}
+
+// handleRuntimeIdentityMapping 在 Body/Header 改写全部成功后，提交 mapper 或 fallback 的下一代可信身份。
+// 输入约束：existing context 必须由上游 Direct/Auto writer 写入且与当前冻结 rule 同 scope/revision；target 只能来自 compiler closure。
+// 输出语义：跨卡写入 sequence+1，同卡仅改写表示而保持 sequence；任一冲突或 hostcall 失败均在上游前拒绝。
+// 边界场景：不得通过旧模型名、service matcher 或客户端字段恢复身份，避免同名 ModelCard 的错误授权继承。
+func handleRuntimeIdentityMapping(ctx wrapper.HttpContext, config Config, body []byte) types.Action {
+	rule := config.runtimeIdentity
+	target := config.runtimeTarget
+	if rule == nil || target == nil || len(body) == 0 || !json.Valid(body) {
+		return rejectRuntimeIdentityRequest(ctx, "invalid_json_body")
+	}
+	modelValue := gjson.GetBytes(body, rule.Parser.ModelKey)
+	if !modelValue.Exists() || modelValue.Type != gjson.String || strings.TrimSpace(modelValue.String()) == "" {
+		return rejectRuntimeIdentityRequest(ctx, "model_selector_required")
+	}
+	existing, err := loadResolvedModelContext()
+	if err != nil {
+		return rejectRuntimeIdentityRequest(ctx, "context_read_failed")
+	}
+	oldModel := modelValue.String()
+	if existing == nil && isReservedAutoSelector(rule, oldModel) && mapsModelToPassthrough(config, oldModel) {
+		// APIGO-CONTRACT: modelcard-runtime-identity
+		// Auto 的首次可信身份只能由掌握最终 dispatched candidate 的 ai-auto-router 建立。
+		// 此处既不禁用 reroute，也不改 Body/Header/property，避免 attached ModelMapper 在 seq=1 前截断 Auto 链路。
+		return types.ActionContinue
+	}
+	if reason := validateResolvedModelContextForRule(existing, rule); reason != "" {
+		return rejectRuntimeIdentityRequest(ctx, reason)
+	}
+
+	newModel := mappedModel(config, oldModel)
+	// APIGO-CONTRACT: modelcard-runtime-identity
+	// 每条 strict mapper/fallback rule 都只能实际改写到 compiler 已解析的 target，避免运行期把字符串映射成另一张卡。
+	if newModel != target.UpstreamModelName {
+		return rejectRuntimeIdentityRequest(ctx, "target_model_mismatch")
+	}
+	// APIGO-CONTRACT: modelcard-runtime-identity
+	// 只有已经确认要执行的严格跨卡规则才能冻结当前路由；Auto passthrough 已在上方无副作用返回。
+	ctx.DisableReroute()
+	if config.modelToHeader != "" {
+		if err = proxywasm.ReplaceHttpRequestHeader(config.modelToHeader, newModel); err != nil {
+			return rejectRuntimeIdentityRequest(ctx, "model_rewrite_failed")
+		}
+	}
+	if newModel != oldModel {
+		if err = proxywasm.RemoveHttpRequestHeader("content-length"); err != nil {
+			return rejectRuntimeIdentityRequest(ctx, "request_prepare_failed")
+		}
+		updatedBody, rewriteErr := sjson.SetBytes(body, rule.Parser.ModelKey, newModel)
+		if rewriteErr != nil {
+			return rejectRuntimeIdentityRequest(ctx, "model_rewrite_failed")
+		}
+		if err = proxywasm.ReplaceHttpRequestBody(updatedBody); err != nil {
+			return rejectRuntimeIdentityRequest(ctx, "model_rewrite_failed")
+		}
+	}
+	// APIGO-CONTRACT: modelcard-runtime-identity
+	// 无论映射是否改写模型文本，都以当前冻结 target 覆盖执行 cluster。这样跨卡 fallback
+	// 与同卡表示改写均不会继承客户端伪造或前一跳残留的 x-envoy-target-cluster。
+	if err = proxywasm.ReplaceHttpRequestHeader(runtimeIdentityTargetClusterHeader, target.TargetCluster); err != nil {
+		return rejectRuntimeIdentityRequest(ctx, "target_cluster_rewrite_failed")
+	}
+	if existing.ResolvedModelCardID == target.ModelCardID {
+		return types.ActionContinue
+	}
+	source := "mapper"
+	if strings.HasPrefix(config.runtimeTargetKey, "fallback:") {
+		source = "fallback"
+	}
+	if err = writeResolvedModelContext(rule, *target, existing.TransitionSeq+1, source); err != nil {
+		return rejectRuntimeIdentityRequest(ctx, "context_write_failed")
+	}
+	return types.ActionContinue
+}
+
+// mappedModel 按 legacy 相同的 exact、prefix、default 顺序计算当前映射结果。
+// 输入约束：config 已由 parseConfig 排序 prefix；oldModel 来自合法 JSON string。
+// 输出语义：没有映射时返回原模型；显式空 target 保持空值，供 Auto passthrough 判定区分默认改写。
+// 边界场景：本函数只计算字符串结果，不改 Header/Body/context。
+func mappedModel(config Config, oldModel string) string {
+	newModel := config.defaultModel
+	if newModel == "" {
+		newModel = oldModel
+	}
+	if mapped, ok := config.exactModelMapping[oldModel]; ok {
+		return mapped
+	}
+	for _, mapping := range config.prefixModelMapping {
+		if strings.HasPrefix(oldModel, mapping.Prefix) {
+			return mapping.Target
+		}
+	}
+	return newModel
+}
+
+// mapsModelToPassthrough 确认 reserved Auto 命中了服务端显式下发的空 exact/prefix 保护规则。
+// 输入约束：调用方已确认 selector 位于 ReservedAutoSelectors；普通 `*` 默认映射不构成 Auto 保护。
+// 输出语义：仅首个实际命中的 exact/prefix target 为空时返回 true。
+// 边界场景：缺少保护规则或非空目标保持严格拒绝，不能借 Auto 名义绕过真实 mapper transition。
+func mapsModelToPassthrough(config Config, model string) bool {
+	if target, ok := config.exactModelMapping[model]; ok {
+		return target == ""
+	}
+	for _, mapping := range config.prefixModelMapping {
+		if strings.HasPrefix(model, mapping.Prefix) {
+			return mapping.Target == ""
+		}
+	}
+	return false
 }

--- a/plugins/wasm-go/extensions/model-mapper/main_test.go
+++ b/plugins/wasm-go/extensions/model-mapper/main_test.go
@@ -490,3 +490,240 @@ func TestOnHttpRequestBody_ModelMapping(t *testing.T) {
 		})
 	})
 }
+
+// strictRuntimeIdentityTarget 构造含完整唯一 Service/Cluster 闭包的测试 ModelCard target。
+// 输入约束：参数均为控制面冻结字段，函数只供本文件的 strict fixture 使用。
+// 输出语义：返回与 C1 下发 JSON 形状一致的完整 target，确保测试不会退化为仅 Provider/model 校验。
+// 边界场景：Service/Cluster 从 ModelCardID 派生仅是测试数据，生产选择始终来自 APIGO projection。
+func strictRuntimeIdentityTarget(modelCardID, provider, upstreamModelName string) runtimeIdentityTarget {
+	return runtimeIdentityTarget{
+		ModelCardID:       modelCardID,
+		Provider:          provider,
+		UpstreamModelName: upstreamModelName,
+		ServiceID:         "service-" + modelCardID,
+		TargetCluster:     "outbound|443||" + modelCardID + ".internal",
+	}
+}
+
+// strictRuntimeIdentityMapperConfig 构造一条由控制面冻结的 mapper/fallback 严格规则。
+// 该 fixture 同时保留源卡和目标卡于 closure，确保测试覆盖跨卡与同卡两种 transition 语义。
+func strictRuntimeIdentityMapperConfig(t *testing.T, targetKey string, target runtimeIdentityTarget, mappingTarget string) []byte {
+	t.Helper()
+	return strictRuntimeIdentityMapperConfigWithClosure(
+		t,
+		targetKey,
+		target,
+		map[string]string{"source-model": mappingTarget},
+		map[string]runtimeIdentityTarget{
+			"card-a":           strictRuntimeIdentityTarget("card-a", "provider-a", "source-model"),
+			target.ModelCardID: target,
+		},
+	)
+}
+
+// strictRuntimeIdentityMapperConfigWithClosure 构造可指定映射和完整冻结闭包的 strict mapper 配置。
+// 输入约束：mappings 的每个最终模型必须与 target.UpstreamModelName 一致；closure 要覆盖当前与目标卡。
+// 输出语义：返回可直接用于 Proxy-Wasm component host 的同一 revision 配置。
+// 边界情况：该 helper 只服务组件级序列断言，真实 Envoy redirect 重入仍由独立集成验证承担。
+func strictRuntimeIdentityMapperConfigWithClosure(
+	t *testing.T,
+	targetKey string,
+	target runtimeIdentityTarget,
+	mappings map[string]string,
+	closure map[string]runtimeIdentityTarget,
+) []byte {
+	t.Helper()
+	raw, err := json.Marshal(map[string]any{
+		"modelKey":      "model",
+		"modelToHeader": "x-higress-llm-model-final",
+		"modelMapping":  mappings,
+		"modelRuntimeIdentity": map[string]any{
+			"mode":           runtimeIdentityMode,
+			"configRevision": "revision-1",
+			"scope": map[string]any{
+				"gatewayId": "gw-1", "apiId": "api-1", "routeId": "route-1", "dataPlaneRouteName": "route-name-1",
+			},
+			"parser":                map[string]any{"source": runtimeIdentityJSONBody, "modelKey": "model"},
+			"reservedAutoSelectors": []string{"auto", "auto/*"},
+			"targetClosure":         closure,
+		},
+		"modelRuntimeIdentityTarget":    target,
+		"modelRuntimeIdentityTargetKey": targetKey,
+	})
+	require.NoError(t, err)
+	return raw
+}
+
+// TestRuntimeIdentityMapperDefersReservedAuto 验证 attached ModelMapper 在 Auto 最终候选 writer 之前保持完全无副作用。
+func TestRuntimeIdentityMapperDefersReservedAuto(t *testing.T) {
+	test.RunTest(t, func(t *testing.T) {
+		target := strictRuntimeIdentityTarget("card-b", "provider-b", "target-model")
+		host, status := test.NewTestHost(strictRuntimeIdentityMapperConfigWithClosure(
+			t,
+			"mapper:policy-1:0",
+			target,
+			map[string]string{"*": "target-model", "auto": "", "auto/*": ""},
+			map[string]runtimeIdentityTarget{
+				"card-a": strictRuntimeIdentityTarget("card-a", "provider-a", "source-model"),
+				"card-b": target,
+			},
+		))
+		defer host.Reset()
+		require.Equal(t, types.OnPluginStartStatusOK, status)
+
+		headers := [][2]string{
+			{":authority", "example.com"}, {":path", "/v1/chat/completions"}, {":method", "POST"},
+			{"content-type", "application/json"}, {"content-length", "42"}, {"x-higress-llm-model-final", "unchanged"},
+		}
+		require.Equal(t, types.HeaderStopIteration, host.CallOnHttpRequestHeaders(headers))
+		body := []byte(`{"model":"auto/provider-a"}`)
+		require.Equal(t, types.ActionContinue, host.CallOnHttpRequestBody(body))
+		require.JSONEq(t, string(body), string(host.GetRequestBody()))
+		value, found := getHeader(host.GetRequestHeaders(), "x-higress-llm-model-final")
+		require.True(t, found)
+		require.Equal(t, "unchanged", value)
+		_, found = getHeader(host.GetRequestHeaders(), "content-length")
+		require.True(t, found)
+		_, err := host.GetProperty([]string{resolvedModelContextProperty})
+		require.Error(t, err)
+	})
+}
+
+// setStrictMapperContext 写入仅能由上游 Direct/Auto writer 建立的 request-lifespan 身份。
+func setStrictMapperContext(t *testing.T, host test.TestHost, modelCardID, provider, upstreamModel string, sequence int64, revision string) {
+	t.Helper()
+	raw, err := json.Marshal(resolvedModelContext{
+		SchemaVersion:       resolvedModelContextSchemaVersion,
+		GatewayID:           "gw-1",
+		APIID:               "api-1",
+		RouteID:             "route-1",
+		ConfigRevision:      revision,
+		ResolvedModelCardID: modelCardID,
+		TransitionSeq:       sequence,
+		Source:              "direct",
+	})
+	require.NoError(t, err)
+	require.NoError(t, host.SetProperty([]string{resolvedModelContextProperty}, raw))
+}
+
+// TestRuntimeIdentityMapperTransition 验证 mapper/fallback 只在完整改写成功后以目标卡提交下一代 context。
+func TestRuntimeIdentityMapperTransition(t *testing.T) {
+	test.RunTest(t, func(t *testing.T) {
+		for _, testCase := range []struct {
+			name      string
+			targetKey string
+			source    string
+		}{
+			{name: "mapper cross card", targetKey: "mapper:policy-1:0", source: "mapper"},
+			{name: "fallback cross card", targetKey: "fallback:route-1:0", source: "fallback"},
+		} {
+			t.Run(testCase.name, func(t *testing.T) {
+				target := strictRuntimeIdentityTarget("card-b", "provider-b", "target-model")
+				host, status := test.NewTestHost(strictRuntimeIdentityMapperConfig(t, testCase.targetKey, target, target.UpstreamModelName))
+				defer host.Reset()
+				require.Equal(t, types.OnPluginStartStatusOK, status)
+				setStrictMapperContext(t, host, "card-a", "provider-a", "source-model", 1, "revision-1")
+
+				require.Equal(t, types.HeaderStopIteration, host.CallOnHttpRequestHeaders([][2]string{
+					{":authority", "example.com"}, {":path", "/v1/chat/completions"}, {":method", "POST"}, {"content-type", "application/json"}, {"content-length", "99"}, {runtimeIdentityTargetClusterHeader, "client-spoofed-cluster"},
+				}))
+				require.Equal(t, types.ActionContinue, host.CallOnHttpRequestBody([]byte(`{"model":"source-model"}`)))
+				require.Equal(t, "target-model", gjson.GetBytes(host.GetRequestBody(), "model").String())
+				raw, err := host.GetProperty([]string{resolvedModelContextProperty})
+				require.NoError(t, err)
+				var context resolvedModelContext
+				require.NoError(t, json.Unmarshal(raw, &context))
+				require.Equal(t, resolvedModelContextSchemaVersion, int(gjson.GetBytes(raw, "schemaVersion").Int()))
+				require.Equal(t, "route-1", gjson.GetBytes(raw, "routeId").String())
+				require.False(t, gjson.GetBytes(raw, "scope").Exists())
+				require.Equal(t, "card-b", context.ResolvedModelCardID)
+				require.Equal(t, int64(2), context.TransitionSeq)
+				require.Equal(t, testCase.source, context.Source)
+				clusterHeader, found := getHeader(host.GetRequestHeaders(), runtimeIdentityTargetClusterHeader)
+				require.True(t, found)
+				require.Equal(t, target.TargetCluster, clusterHeader)
+			})
+		}
+	})
+}
+
+// TestRuntimeIdentityMapperSameCardAndConflict 验证同卡表示改写不伪造 generation，缺失或混 revision context 一律拒绝。
+func TestRuntimeIdentityMapperSameCardAndConflict(t *testing.T) {
+	test.RunTest(t, func(t *testing.T) {
+		t.Run("same card keeps generation", func(t *testing.T) {
+			target := strictRuntimeIdentityTarget("card-a", "provider-a", "source-model")
+			host, status := test.NewTestHost(strictRuntimeIdentityMapperConfig(t, "mapper:policy-1:0", target, target.UpstreamModelName))
+			defer host.Reset()
+			require.Equal(t, types.OnPluginStartStatusOK, status)
+			setStrictMapperContext(t, host, "card-a", "provider-a", "source-model", 4, "revision-1")
+			host.CallOnHttpRequestHeaders([][2]string{{":authority", "example.com"}, {":path", "/v1/chat/completions"}, {":method", "POST"}, {"content-type", "application/json"}, {"content-length", "99"}})
+			require.Equal(t, types.ActionContinue, host.CallOnHttpRequestBody([]byte(`{"model":"source-model"}`)))
+			raw, err := host.GetProperty([]string{resolvedModelContextProperty})
+			require.NoError(t, err)
+			var context resolvedModelContext
+			require.NoError(t, json.Unmarshal(raw, &context))
+			require.Equal(t, int64(4), context.TransitionSeq)
+			require.Equal(t, "direct", context.Source)
+		})
+
+		for _, testCase := range []struct {
+			name        string
+			withContext bool
+			revision    string
+		}{
+			{name: "missing context"},
+			{name: "mixed revision", withContext: true, revision: "revision-old"},
+		} {
+			t.Run(testCase.name, func(t *testing.T) {
+				target := strictRuntimeIdentityTarget("card-b", "provider-b", "target-model")
+				host, status := test.NewTestHost(strictRuntimeIdentityMapperConfig(t, "mapper:policy-1:0", target, target.UpstreamModelName))
+				defer host.Reset()
+				require.Equal(t, types.OnPluginStartStatusOK, status)
+				if testCase.withContext {
+					setStrictMapperContext(t, host, "card-a", "provider-a", "source-model", 1, testCase.revision)
+				}
+				host.CallOnHttpRequestHeaders([][2]string{{":authority", "example.com"}, {":path", "/v1/chat/completions"}, {":method", "POST"}, {"content-type", "application/json"}, {"content-length", "99"}})
+				require.Equal(t, types.ActionPause, host.CallOnHttpRequestBody([]byte(`{"model":"source-model"}`)))
+			})
+		}
+	})
+}
+
+// TestRuntimeIdentityMapperSequenceABA 验证跨卡回切会继续递增 generation，不能把第一次 A 的身份当作当前 A 复用。
+func TestRuntimeIdentityMapperSequenceABA(t *testing.T) {
+	test.RunTest(t, func(t *testing.T) {
+		cardA := strictRuntimeIdentityTarget("card-a", "provider-a", "source-model")
+		cardB := strictRuntimeIdentityTarget("card-b", "provider-b", "target-model")
+		closure := map[string]runtimeIdentityTarget{"card-a": cardA, "card-b": cardB}
+		headers := [][2]string{{":authority", "example.com"}, {":path", "/v1/chat/completions"}, {":method", "POST"}, {"content-type", "application/json"}}
+
+		// 第一段模拟 Direct 后的 mapper A -> B；property 字节会作为 redirect 重新进入下一段的唯一上下文输入。
+		first, status := test.NewTestHost(strictRuntimeIdentityMapperConfigWithClosure(
+			t, "mapper:policy-1:0", cardB, map[string]string{"source-model": "target-model"}, closure,
+		))
+		require.Equal(t, types.OnPluginStartStatusOK, status)
+		setStrictMapperContext(t, first, "card-a", "provider-a", "source-model", 1, "revision-1")
+		require.Equal(t, types.HeaderStopIteration, first.CallOnHttpRequestHeaders(headers))
+		require.Equal(t, types.ActionContinue, first.CallOnHttpRequestBody([]byte(`{"model":"source-model"}`)))
+		raw, err := first.GetProperty([]string{resolvedModelContextProperty})
+		require.NoError(t, err)
+		require.Equal(t, "card-b", gjson.GetBytes(raw, "resolvedModelCardId").String())
+		require.Equal(t, int64(2), gjson.GetBytes(raw, "transitionSeq").Int())
+		first.Reset()
+
+		// 第二段模拟同一请求在 shadow route 上回切 B -> A；这里不声称模拟真实 Envoy stream，只验证序列化 property 合同。
+		second, status := test.NewTestHost(strictRuntimeIdentityMapperConfigWithClosure(
+			t, "mapper:policy-1:1", cardA, map[string]string{"target-model": "source-model"}, closure,
+		))
+		defer second.Reset()
+		require.Equal(t, types.OnPluginStartStatusOK, status)
+		require.NoError(t, second.SetProperty([]string{resolvedModelContextProperty}, raw))
+		require.Equal(t, types.HeaderStopIteration, second.CallOnHttpRequestHeaders(headers))
+		require.Equal(t, types.ActionContinue, second.CallOnHttpRequestBody([]byte(`{"model":"target-model"}`)))
+		raw, err = second.GetProperty([]string{resolvedModelContextProperty})
+		require.NoError(t, err)
+		require.Equal(t, "card-a", gjson.GetBytes(raw, "resolvedModelCardId").String())
+		require.Equal(t, int64(3), gjson.GetBytes(raw, "transitionSeq").Int())
+		require.Equal(t, "mapper", gjson.GetBytes(raw, "source").String())
+	})
+}

--- a/plugins/wasm-go/extensions/model-mapper/runtime_identity.go
+++ b/plugins/wasm-go/extensions/model-mapper/runtime_identity.go
@@ -1,0 +1,200 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/higress-group/proxy-wasm-go-sdk/proxywasm"
+	"github.com/higress-group/proxy-wasm-go-sdk/proxywasm/types"
+	"github.com/higress-group/wasm-go/pkg/wrapper"
+	"github.com/tidwall/gjson"
+)
+
+const (
+	resolvedModelContextProperty      = "apig_resolved_model_context_v1"
+	resolvedModelContextSchemaVersion = 1
+	runtimeIdentityMode               = "ChooseModelV1"
+	runtimeIdentityJSONBody           = "json_body"
+	// runtimeIdentityTargetClusterHeader 是严格 DynamicClusterHeader Route 的受控执行目标。
+	// mapper/fallback 在发生或确认切换后必须覆盖它，不能继续使用请求进入时的 Header。
+	runtimeIdentityTargetClusterHeader = "x-envoy-target-cluster"
+)
+
+// runtimeIdentityScope 定义 mapper 只能消费的冻结请求作用域。
+type runtimeIdentityScope struct {
+	GatewayID          string `json:"gatewayId"`
+	APIID              string `json:"apiId"`
+	RouteID            string `json:"routeId"`
+	DataPlaneRouteName string `json:"dataPlaneRouteName"`
+}
+
+// runtimeIdentityParser 是控制面登记的 Body selector parser。
+type runtimeIdentityParser struct {
+	Source                     string `json:"source"`
+	ModelKey                   string `json:"modelKey"`
+	MinimumDataPlaneCapability string `json:"minimumDataPlaneCapability,omitempty"`
+}
+
+// runtimeIdentityTarget 表示一张冻结主执行 ModelCard 及其唯一 Service/Cluster 执行目标。
+type runtimeIdentityTarget struct {
+	ModelCardID       string `json:"modelCardId"`
+	Provider          string `json:"provider"`
+	UpstreamModelName string `json:"upstreamModelName"`
+	ServiceID         string `json:"serviceId"`
+	TargetCluster     string `json:"targetCluster"`
+}
+
+// runtimeIdentityRule 保存当前规则的 revision、scope 和可切换 target closure。
+type runtimeIdentityRule struct {
+	Mode                  string                           `json:"mode"`
+	ConfigRevision        string                           `json:"configRevision"`
+	Scope                 runtimeIdentityScope             `json:"scope"`
+	Parser                runtimeIdentityParser            `json:"parser"`
+	ReservedAutoSelectors []string                         `json:"reservedAutoSelectors"`
+	TargetClosure         map[string]runtimeIdentityTarget `json:"targetClosure"`
+}
+
+// resolvedModelContext 是 model-router/auto/mapper 之间唯一可信的 request-lifespan 身份载体。
+type resolvedModelContext struct {
+	SchemaVersion       int    `json:"schemaVersion"`
+	GatewayID           string `json:"gatewayId"`
+	APIID               string `json:"apiId"`
+	RouteID             string `json:"routeId"`
+	ConfigRevision      string `json:"configRevision"`
+	ResolvedModelCardID string `json:"resolvedModelCardId"`
+	TransitionSeq       int64  `json:"transitionSeq"`
+	Source              string `json:"source"`
+}
+
+// parseMapperRuntimeIdentity 解析 ModelMapper 的严格 rule 和对应 compiler target。
+// 输入约束：三个字段都只能由控制面 projection 写入；出现其中一个而缺另一个视为损坏配置。
+// 输出语义：legacy 配置返回 nil；新模式返回同一 revision 内已验证 target 与稳定规则键。
+// 边界场景：不允许根据 modelMapping 或 service matcher 反推 target，避免跨 Provider 同名模型错绑。
+func parseMapperRuntimeIdentity(rawRule, rawTarget, rawTargetKey gjson.Result) (*runtimeIdentityRule, *runtimeIdentityTarget, string, error) {
+	if !rawRule.Exists() && !rawTarget.Exists() && !rawTargetKey.Exists() {
+		return nil, nil, "", nil
+	}
+	if !rawRule.Exists() || !rawTarget.Exists() || !rawTargetKey.Exists() {
+		return nil, nil, "", errors.New("model runtime identity transition config is incomplete")
+	}
+	var rule runtimeIdentityRule
+	if err := json.Unmarshal([]byte(rawRule.Raw), &rule); err != nil {
+		return nil, nil, "", fmt.Errorf("decode model runtime identity: %w", err)
+	}
+	var target runtimeIdentityTarget
+	if err := json.Unmarshal([]byte(rawTarget.Raw), &target); err != nil {
+		return nil, nil, "", fmt.Errorf("decode model runtime identity target: %w", err)
+	}
+	targetKey := strings.TrimSpace(rawTargetKey.String())
+	if rule.Mode != runtimeIdentityMode || rule.ConfigRevision == "" || rule.Scope.GatewayID == "" || rule.Scope.APIID == "" || rule.Scope.RouteID == "" || rule.Scope.DataPlaneRouteName == "" || rule.Parser.Source != runtimeIdentityJSONBody || rule.Parser.ModelKey == "" || len(rule.TargetClosure) == 0 || !validRuntimeIdentityTarget(target) {
+		return nil, nil, "", errors.New("model runtime identity transition config is invalid")
+	}
+	if targetKey == "" || (!strings.HasPrefix(targetKey, "mapper:") && !strings.HasPrefix(targetKey, "fallback:")) {
+		return nil, nil, "", errors.New("model runtime identity transition key is invalid")
+	}
+	closure, exists := rule.TargetClosure[target.ModelCardID]
+	if !exists || !sameRuntimeIdentityTarget(closure, target) {
+		return nil, nil, "", errors.New("model runtime identity target is outside closure")
+	}
+	return &rule, &target, targetKey, nil
+}
+
+// validRuntimeIdentityTarget 校验 target 的不可省略身份字段和执行闭包。
+func validRuntimeIdentityTarget(target runtimeIdentityTarget) bool {
+	return strings.TrimSpace(target.ModelCardID) != "" && strings.TrimSpace(target.Provider) != "" && strings.TrimSpace(target.UpstreamModelName) != "" && strings.TrimSpace(target.ServiceID) != "" && strings.TrimSpace(target.TargetCluster) != ""
+}
+
+// sameRuntimeIdentityTarget 判断两个 target 是否表达同一卡、同一上游模型和同一执行目标。
+func sameRuntimeIdentityTarget(left, right runtimeIdentityTarget) bool {
+	return left.ModelCardID == right.ModelCardID && left.Provider == right.Provider && left.UpstreamModelName == right.UpstreamModelName && left.ServiceID == right.ServiceID && left.TargetCluster == right.TargetCluster
+}
+
+// isReservedAutoSelector 判断当前 Body 字面量是否属于控制面冻结的 Auto exact/prefix 空间。
+// 输入约束：rule 来自完整 strict 配置；selector 是 parser 已确认的非空字符串，仅用于决定是否延后首次身份写入。
+// 输出语义：exact 相等或命中以 `*` 结尾的前缀时返回 true；普通 Direct selector 返回 false。
+// 边界场景：本函数不把 Auto 字面量解释为 ModelCard，也不允许它覆盖已存在 context。
+func isReservedAutoSelector(rule *runtimeIdentityRule, selector string) bool {
+	if rule == nil {
+		return false
+	}
+	for _, reserved := range rule.ReservedAutoSelectors {
+		if reserved == selector {
+			return true
+		}
+		if strings.HasSuffix(reserved, "*") && strings.HasPrefix(selector, strings.TrimSuffix(reserved, "*")) {
+			return true
+		}
+	}
+	return false
+}
+
+// loadResolvedModelContext 从 Envoy property 读取已有身份，拒绝损坏值。
+func loadResolvedModelContext() (*resolvedModelContext, error) {
+	raw, err := proxywasm.GetProperty([]string{resolvedModelContextProperty})
+	if err != nil {
+		if errors.Is(err, types.ErrorStatusNotFound) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	if len(raw) == 0 {
+		return nil, errors.New("resolved model context is empty")
+	}
+	var context resolvedModelContext
+	if err := json.Unmarshal(raw, &context); err != nil {
+		return nil, err
+	}
+	return &context, nil
+}
+
+// validateResolvedModelContextForRule 确认 mapper 只接受当前 scope/revision 的上游身份。
+func validateResolvedModelContextForRule(context *resolvedModelContext, rule *runtimeIdentityRule) string {
+	if context == nil {
+		return "missing_context"
+	}
+	if context.SchemaVersion != resolvedModelContextSchemaVersion {
+		return "unsupported_context_version"
+	}
+	if context.ConfigRevision != rule.ConfigRevision {
+		return "context_revision_mismatch"
+	}
+	if context.GatewayID != rule.Scope.GatewayID || context.APIID != rule.Scope.APIID || context.RouteID != rule.Scope.RouteID {
+		return "context_scope_mismatch"
+	}
+	if context.TransitionSeq < 1 || context.Source == "" {
+		return "invalid_context_generation"
+	}
+	if _, exists := rule.TargetClosure[context.ResolvedModelCardID]; !exists {
+		return "context_target_not_in_closure"
+	}
+	return ""
+}
+
+// writeResolvedModelContext 用新的 target 和递增 sequence 提交 mapper/fallback 切换。
+func writeResolvedModelContext(rule *runtimeIdentityRule, target runtimeIdentityTarget, sequence int64, source string) error {
+	raw, err := json.Marshal(resolvedModelContext{
+		SchemaVersion:       resolvedModelContextSchemaVersion,
+		GatewayID:           rule.Scope.GatewayID,
+		APIID:               rule.Scope.APIID,
+		RouteID:             rule.Scope.RouteID,
+		ConfigRevision:      rule.ConfigRevision,
+		ResolvedModelCardID: target.ModelCardID,
+		TransitionSeq:       sequence,
+		Source:              source,
+	})
+	if err != nil {
+		return err
+	}
+	return proxywasm.SetProperty([]string{resolvedModelContextProperty}, raw)
+}
+
+// rejectRuntimeIdentityRequest 发出稳定错误，不记录 Body、模型名或凭据。
+func rejectRuntimeIdentityRequest(ctx wrapper.HttpContext, reason string) types.Action {
+	ctx.DontReadResponseBody()
+	body, _ := json.Marshal(map[string]any{"error": map[string]string{"type": "model_runtime_identity_error", "code": reason}})
+	_ = proxywasm.SendHttpResponse(http.StatusBadRequest, [][2]string{{"content-type", "application/json"}}, body, -1)
+	return types.ActionPause
+}

--- a/plugins/wasm-go/extensions/model-router/Makefile
+++ b/plugins/wasm-go/extensions/model-router/Makefile
@@ -1,2 +1,2 @@
 build-go:
-	GOOS=wasip1 GOARCH=wasm go build -buildmode=c-shared -o main.wasm main.go
+	GOOS=wasip1 GOARCH=wasm go build -buildmode=c-shared -o main.wasm .

--- a/plugins/wasm-go/extensions/model-router/main.go
+++ b/plugins/wasm-go/extensions/model-router/main.go
@@ -29,6 +29,7 @@ func main() {}
 func init() {
 	wrapper.SetCtx(
 		"model-router",
+		wrapper.PrePluginStartOrReload[ModelRouterConfig](ensureRuntimeIdentityRequestProperty),
 		wrapper.ParseConfig(parseConfig),
 		wrapper.ProcessRequestHeaders(onHttpRequestHeaders),
 		wrapper.ProcessRequestBody(onHttpRequestBody),
@@ -48,14 +49,30 @@ type ModelRouterConfig struct {
 	modelToHeader         string
 	enableOnPathSuffix    []string
 	keepOriginalModelName bool
+	// strictRuntimeIdentityOnly 标识该 WasmPlugin 是 C1 为单个 API 独立下发的 strict carrier。
+	// 未命中 strict route 时必须 no-op，不能回落为全局 legacy model-router 并影响其他 API。
+	strictRuntimeIdentityOnly bool
 	// Auto routing configuration
 	enableAutoRouting bool
 	autoRoutingRules  []AutoRoutingRule
 	defaultModel      string
+	// runtimeIdentity 仅由 APIG C1 严格规则下发；nil 代表完整保留 legacy model-router 行为。
+	runtimeIdentity *runtimeIdentityRule
 }
 
 func parseConfig(json gjson.Result, config *ModelRouterConfig) error {
+	runtimeIdentity, err := parseRuntimeIdentityRule(json.Get("modelRuntimeIdentity"))
+	if err != nil {
+		return err
+	}
+	config.runtimeIdentity = runtimeIdentity
+	config.strictRuntimeIdentityOnly = json.Get("strictRuntimeIdentityOnly").Bool()
 	config.modelKey = json.Get("modelKey").String()
+	if config.runtimeIdentity != nil {
+		// APIGO-CONTRACT: modelcard-runtime-identity
+		// strict parser 的 modelKey 只能从已发布 rule 获得，不能被共享 legacy 配置或客户请求覆盖。
+		config.modelKey = config.runtimeIdentity.Parser.ModelKey
+	}
 	if config.modelKey == "" {
 		config.modelKey = "model"
 	}
@@ -118,6 +135,16 @@ func parseConfig(json gjson.Result, config *ModelRouterConfig) error {
 }
 
 func onHttpRequestHeaders(ctx wrapper.HttpContext, config ModelRouterConfig) types.Action {
+	if config.runtimeIdentity != nil {
+		return onRuntimeIdentityRequestHeaders(ctx, config)
+	}
+	if config.strictRuntimeIdentityOnly {
+		// APIGO-CONTRACT: modelcard-runtime-identity
+		// 独立 strict carrier 只能处理自身 `_match_route_` 命中的规则；未命中时不读取 Body，
+		// 让原 model-router 和其它 legacy 插件保持原有全局语义。
+		ctx.DontReadRequestBody()
+		return types.ActionContinue
+	}
 	path, err := proxywasm.GetHttpRequestHeader(":path")
 	if err != nil {
 		return types.ActionContinue
@@ -150,6 +177,12 @@ func onHttpRequestHeaders(ctx wrapper.HttpContext, config ModelRouterConfig) typ
 }
 
 func onHttpRequestBody(ctx wrapper.HttpContext, config ModelRouterConfig, body []byte) types.Action {
+	if config.runtimeIdentity != nil {
+		return handleRuntimeIdentityJSONBody(ctx, config, body)
+	}
+	if config.strictRuntimeIdentityOnly {
+		return types.ActionContinue
+	}
 	contentType, err := proxywasm.GetHttpRequestHeader("content-type")
 	if err != nil {
 		return types.ActionContinue
@@ -161,6 +194,97 @@ func onHttpRequestBody(ctx wrapper.HttpContext, config ModelRouterConfig, body [
 		return handleMultipartBody(ctx, config, body, contentType)
 	}
 
+	return types.ActionContinue
+}
+
+// onRuntimeIdentityRequestHeaders 为 strict Body parser 开启缓冲，并在无 Body/非 JSON 时在任何上游前拒绝。
+// 输入约束：config.runtimeIdentity 已通过控制面配置校验；该分支不使用 path suffix 或 Header 选择模型。
+// 输出语义：合法 JSON Body 返回 HeaderStopIteration，非法请求立即本地拒绝，legacy 分支保持原行为。
+// 边界场景：C1 不支持 multipart、WebSocket 或无 Body，不能因路径恰好命中旧 suffix 而回落到 legacy parser。
+func onRuntimeIdentityRequestHeaders(ctx wrapper.HttpContext, config ModelRouterConfig) types.Action {
+	if !ctx.HasRequestBody() {
+		return rejectRuntimeIdentityRequest(ctx, "body_required")
+	}
+	contentType, err := proxywasm.GetHttpRequestHeader("content-type")
+	if err != nil || !strings.Contains(strings.ToLower(contentType), "application/json") {
+		return rejectRuntimeIdentityRequest(ctx, "json_body_required")
+	}
+	if err := proxywasm.RemoveHttpRequestHeader("content-length"); err != nil {
+		return rejectRuntimeIdentityRequest(ctx, "request_prepare_failed")
+	}
+	ctx.SetRequestBodyBufferLimit(DefaultMaxBodyBytes)
+	return types.HeaderStopIteration
+}
+
+// handleRuntimeIdentityJSONBody 以精确 selector map 建立 Direct context，或把保留 Auto selector 交给最终候选 writer。
+// 输入约束：body 来自 strict header 分支缓冲，model 字段只能是 parser.modelKey 对应的非空 JSON string。
+// 输出语义：Direct 成功后改写为 target 上游模型并写 seq=1 property；已有合法 context 再入时保持不变；Auto 不在此处伪造身份。
+// 边界场景：任何 selector/context/property 失败都在上游前 local reject，客户端字段不会覆盖已有可信 context。
+func handleRuntimeIdentityJSONBody(ctx wrapper.HttpContext, config ModelRouterConfig, body []byte) types.Action {
+	rule := config.runtimeIdentity
+	if rule == nil || !json.Valid(body) {
+		return rejectRuntimeIdentityRequest(ctx, "invalid_json_body")
+	}
+	selectorValue := gjson.GetBytes(body, rule.Parser.ModelKey)
+	if !selectorValue.Exists() || selectorValue.Type != gjson.String || strings.TrimSpace(selectorValue.String()) == "" {
+		return rejectRuntimeIdentityRequest(ctx, "model_selector_required")
+	}
+	selector := selectorValue.String()
+	existing, err := loadResolvedModelContext()
+	if err != nil {
+		return rejectRuntimeIdentityRequest(ctx, "context_read_failed")
+	}
+	if existing != nil {
+		if reason := validateResolvedModelContextForRule(existing, rule); reason != "" {
+			return rejectRuntimeIdentityRequest(ctx, reason)
+		}
+		return types.ActionContinue
+	}
+	if isReservedAutoSelector(rule, selector) {
+		return types.ActionContinue
+	}
+	target, exists := rule.SelectorTargets[selector]
+	if !exists {
+		return rejectRuntimeIdentityRequest(ctx, "unknown_model_selector")
+	}
+	updatedBody, err := sjson.SetBytes(body, rule.Parser.ModelKey, target.UpstreamModelName)
+	if err != nil {
+		return rejectRuntimeIdentityRequest(ctx, "model_rewrite_failed")
+	}
+	// APIGO-CONTRACT: modelcard-runtime-identity
+	// Direct selector 通常比实际 upstream model 更长；改写 Body 后必须移除旧 Content-Length，
+	// 由 Envoy 按新 body 重新计算，避免下游等待过长请求体并返回 400。
+	if selector != target.UpstreamModelName {
+		if err = proxywasm.RemoveHttpRequestHeader("content-length"); err != nil {
+			return rejectRuntimeIdentityRequest(ctx, "request_prepare_failed")
+		}
+	}
+	if err = proxywasm.ReplaceHttpRequestBody(updatedBody); err != nil {
+		return rejectRuntimeIdentityRequest(ctx, "model_rewrite_failed")
+	}
+	if config.modelToHeader != "" {
+		if err = proxywasm.ReplaceHttpRequestHeader(config.modelToHeader, target.UpstreamModelName); err != nil {
+			return rejectRuntimeIdentityRequest(ctx, "model_rewrite_failed")
+		}
+	}
+	if config.addProviderHeader != "" {
+		// APIGO-CONTRACT: modelcard-runtime-identity
+		// strict Direct 的 Provider 必须直接取自已冻结 target，不能从可能包含多个斜杠的 selector 或 modelName 反推。
+		// 该服务端重写头只承载目标 Provider 的协议/插件投影；strict 主 Route 已由 Path 唯一命中，
+		// 实际上游由同一冻结 target 的 x-envoy-target-cluster 决定，不能再借 Header 选择后端。
+		if err = proxywasm.ReplaceHttpRequestHeader(config.addProviderHeader, target.Provider); err != nil {
+			return rejectRuntimeIdentityRequest(ctx, "model_rewrite_failed")
+		}
+	}
+	// APIGO-CONTRACT: modelcard-runtime-identity
+	// strict Direct 必须用同一冻结 target 覆盖 DynamicClusterHeader 的执行 cluster；即使客户端
+	// 已携带同名 Header 也不能保留，避免命中 Path 后绕开当前 ModelCard 的 Service 授权边界。
+	if err = proxywasm.ReplaceHttpRequestHeader(runtimeIdentityTargetClusterHeader, target.TargetCluster); err != nil {
+		return rejectRuntimeIdentityRequest(ctx, "target_cluster_rewrite_failed")
+	}
+	if err = writeResolvedModelContext(rule, target, 1, "direct"); err != nil {
+		return rejectRuntimeIdentityRequest(ctx, "context_write_failed")
+	}
 	return types.ActionContinue
 }
 

--- a/plugins/wasm-go/extensions/model-router/main_test.go
+++ b/plugins/wasm-go/extensions/model-router/main_test.go
@@ -81,6 +81,14 @@ func TestParseConfig(t *testing.T) {
 			require.Equal(t, "x-mod", cfg.modelToHeader)
 			require.Equal(t, []string{"/foo", "/bar"}, cfg.enableOnPathSuffix)
 		})
+
+		t.Run("strict-only carrier is marked as no-op outside a strict rule", func(t *testing.T) {
+			var cfg ModelRouterConfig
+			err := parseConfig(gjson.Parse(`{"strictRuntimeIdentityOnly":true}`), &cfg)
+			require.NoError(t, err)
+			require.True(t, cfg.strictRuntimeIdentityOnly)
+			require.Nil(t, cfg.runtimeIdentity)
+		})
 	})
 }
 
@@ -144,6 +152,19 @@ func TestOnHttpRequestHeaders(t *testing.T) {
 			newHeaders := host.GetRequestHeaders()
 			_, found := getHeader(newHeaders, "content-length")
 			require.False(t, found, "content-length should not be removed for unsupported content-type")
+		})
+
+		t.Run("strict-only global carrier does not activate legacy suffix handling", func(t *testing.T) {
+			host, status := test.NewTestHost([]byte(`{"strictRuntimeIdentityOnly":true}`))
+			defer host.Reset()
+			require.Equal(t, types.OnPluginStartStatusOK, status)
+
+			action := host.CallOnHttpRequestHeaders([][2]string{
+				{":authority", "example.com"}, {":path", "/v1/chat/completions"}, {":method", "POST"}, {"content-type", "application/json"}, {"content-length", "123"},
+			})
+			require.Equal(t, types.ActionContinue, action)
+			_, found := getHeader(host.GetRequestHeaders(), "content-length")
+			require.True(t, found, "strict-only global config must not buffer a legacy request body")
 		})
 	})
 }

--- a/plugins/wasm-go/extensions/model-router/runtime_identity.go
+++ b/plugins/wasm-go/extensions/model-router/runtime_identity.go
@@ -1,0 +1,280 @@
+package main
+
+import (
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/higress-group/proxy-wasm-go-sdk/proxywasm"
+	"github.com/higress-group/proxy-wasm-go-sdk/proxywasm/types"
+	"github.com/higress-group/wasm-go/pkg/wrapper"
+	"github.com/tidwall/gjson"
+)
+
+const (
+	resolvedModelContextProperty      = "apig_resolved_model_context_v1"
+	resolvedModelContextSchemaVersion = 1
+	runtimeIdentityMode               = "ChooseModelV1"
+	runtimeIdentityJSONBody           = "json_body"
+	// runtimeIdentityTargetClusterHeader 是 strict DynamicClusterHeader Route 的唯一上游选择头。
+	// Direct/Auto/Mapper 都必须由冻结 target 覆盖它，不能保留客户端传入值。
+	runtimeIdentityTargetClusterHeader = "x-envoy-target-cluster"
+	// runtimeIdentityRequestPropertyDeclarationContextKey 防止同一个 Wasm 根上下文重复声明同一 property。
+	// 每个严格 carrier 都有独立根上下文，因此该标记只在自身的重载生命周期内生效。
+	runtimeIdentityRequestPropertyDeclarationContextKey = "model-router-runtime-identity-request-property-declared"
+)
+
+// runtimeIdentityScope 定义控制面冻结到数据面的单条 ModelCard 选择作用域。
+type runtimeIdentityScope struct {
+	GatewayID          string `json:"gatewayId"`
+	APIID              string `json:"apiId"`
+	RouteID            string `json:"routeId"`
+	DataPlaneRouteName string `json:"dataPlaneRouteName"`
+}
+
+// runtimeIdentityParser 定义当前 strict route 唯一允许的请求 Body 选择器来源。
+type runtimeIdentityParser struct {
+	Source                     string `json:"source"`
+	ModelKey                   string `json:"modelKey"`
+	MinimumDataPlaneCapability string `json:"minimumDataPlaneCapability,omitempty"`
+}
+
+// runtimeIdentityTarget 表示已在控制面解析完成的实际 ModelCard 身份、上游表现形式和执行目标。
+type runtimeIdentityTarget struct {
+	ModelCardID       string `json:"modelCardId"`
+	Provider          string `json:"provider"`
+	UpstreamModelName string `json:"upstreamModelName"`
+	ServiceID         string `json:"serviceId"`
+	TargetCluster     string `json:"targetCluster"`
+}
+
+// runtimeIdentityRule 是 model-router 新模式的不可变选择器和闭包配置。
+type runtimeIdentityRule struct {
+	Mode                  string                           `json:"mode"`
+	ConfigRevision        string                           `json:"configRevision"`
+	Scope                 runtimeIdentityScope             `json:"scope"`
+	Parser                runtimeIdentityParser            `json:"parser"`
+	SelectorTargets       map[string]runtimeIdentityTarget `json:"selectorTargets"`
+	ReservedAutoSelectors []string                         `json:"reservedAutoSelectors"`
+	TargetClosure         map[string]runtimeIdentityTarget `json:"targetClosure"`
+}
+
+// resolvedModelContext 是跨内置插件传播的 request-lifespan 可信身份，而不是客户端可写 Header。
+type resolvedModelContext struct {
+	SchemaVersion       int    `json:"schemaVersion"`
+	GatewayID           string `json:"gatewayId"`
+	APIID               string `json:"apiId"`
+	RouteID             string `json:"routeId"`
+	ConfigRevision      string `json:"configRevision"`
+	ResolvedModelCardID string `json:"resolvedModelCardId"`
+	TransitionSeq       int64  `json:"transitionSeq"`
+	Source              string `json:"source"`
+}
+
+// ensureRuntimeIdentityRequestProperty 在 strict 配置的 Wasm 根上下文预声明 context 为 DownstreamRequest 生命周期。
+// 输入约束：调用时正处于 OnPluginStart/Reload，配置仅来自控制面；普通 legacy 配置不得触发 foreign function。
+// 输出语义：Direct 写入与后续 internal redirect 重入共享同一 request FilterState；声明失败使插件启动失败，避免退回 FilterChain 生命周期。
+// 边界场景：该声明属于当前 model-router 根上下文；Auto 的首次 writer 由 ai-auto-router 在其独立根上下文作同类声明，二者不共享 declaration map。
+func ensureRuntimeIdentityRequestProperty(ctx wrapper.PluginContext) error {
+	raw, err := proxywasm.GetPluginConfiguration()
+	if err != nil {
+		if errors.Is(err, types.ErrorStatusNotFound) {
+			return nil
+		}
+		return fmt.Errorf("read runtime identity plugin configuration: %w", err)
+	}
+	if !gjson.ValidBytes(raw) || !runtimeIdentityConfigRequiresRequestProperty(gjson.ParseBytes(raw)) {
+		return nil
+	}
+	if ctx.GetContext(runtimeIdentityRequestPropertyDeclarationContextKey) != nil {
+		return nil
+	}
+	if err := declareRuntimeIdentityRequestProperty(); err != nil {
+		return err
+	}
+	ctx.SetContext(runtimeIdentityRequestPropertyDeclarationContextKey, true)
+	return nil
+}
+
+// runtimeIdentityConfigRequiresRequestProperty 判断全局或 route-scoped 配置是否可能由本插件首次写入严格身份。
+// 输入约束：raw 必须是已通过 JSON 语法校验的 plugin config；只检查控制面字段，不读取请求输入。
+// 输出语义：存在 object 形态的 modelRuntimeIdentity 时返回 true，其他 legacy 配置保持 false。
+// 边界场景：仅有 strictRuntimeIdentityOnly 而没有 rule 时不声明，避免空 carrier 对不支持 foreign function 的历史链路产生副作用。
+func runtimeIdentityConfigRequiresRequestProperty(raw gjson.Result) bool {
+	if raw.Get("modelRuntimeIdentity").IsObject() {
+		return true
+	}
+	for _, rule := range raw.Get("_rules_").Array() {
+		if rule.Get("modelRuntimeIdentity").IsObject() {
+			return true
+		}
+	}
+	return false
+}
+
+// declareRuntimeIdentityRequestProperty 以 Envoy declare_property 协议注册可变 Bytes request property。
+// 输入约束：只能从对应 identity writer 的 PluginContext 启动回调调用；属性名为跨插件固定协议，不能由配置覆盖。
+// 输出语义：成功后该根上下文的首次 SetProperty 创建 DownstreamRequest FilterState，能跨 internal redirect 保留。
+// 边界场景：显式写入 Bytes=0 与 DownstreamRequest=1，避免依赖 Envoy 默认 FilterChain 生命周期；hostcall 失败必须向上返回并阻止 strict 插件启用。
+func declareRuntimeIdentityRequestProperty() error {
+	payload := runtimeIdentityRequestPropertyDeclarationPayload()
+	if _, err := proxywasm.CallForeignFunction("declare_property", payload); err != nil {
+		return fmt.Errorf("declare runtime identity request property: %w", err)
+	}
+	return nil
+}
+
+// runtimeIdentityRequestPropertyDeclarationPayload 编码 Envoy DeclarePropertyArguments 的最小 protobuf wire payload。
+// 输入约束：property 名称和枚举值均为本协议常量，不接收运行时外部输入。
+// 输出语义：payload 表示 name、mutable、Bytes 和 DownstreamRequest，可直接传给 declare_property。
+// 边界场景：protobuf 的默认字段也显式编码 Bytes=0，确保协议读取方不会把类型解释为字符串或默认生命周期。
+func runtimeIdentityRequestPropertyDeclarationPayload() []byte {
+	payload := make([]byte, 0, len(resolvedModelContextProperty)+8)
+	payload = append(payload, 0x0a)
+	payload = binary.AppendUvarint(payload, uint64(len(resolvedModelContextProperty)))
+	payload = append(payload, resolvedModelContextProperty...)
+	payload = append(payload, 0x18, 0x00) // type = Bytes
+	payload = append(payload, 0x28, 0x01) // span = DownstreamRequest
+	return payload
+}
+
+// parseRuntimeIdentityRule 解析并验证控制面下发的 strict identity rule。
+// 输入约束：raw 仅来自服务端 rule config；缺失字段或任意未闭合 target 都视为配置错误。
+// 输出语义：不存在字段返回 nil；存在时返回可用于 Body resolver 的不可变规则。
+// 边界场景：不接受 Header/query/path 推断，避免客户端输入绕过 frozen selector map。
+func parseRuntimeIdentityRule(raw gjson.Result) (*runtimeIdentityRule, error) {
+	if !raw.Exists() || strings.TrimSpace(raw.Raw) == "" || raw.Raw == "null" {
+		return nil, nil
+	}
+	var rule runtimeIdentityRule
+	if err := json.Unmarshal([]byte(raw.Raw), &rule); err != nil {
+		return nil, fmt.Errorf("decode model runtime identity: %w", err)
+	}
+	if rule.Mode != runtimeIdentityMode || strings.TrimSpace(rule.ConfigRevision) == "" || rule.Scope.GatewayID == "" || rule.Scope.APIID == "" || rule.Scope.RouteID == "" || rule.Scope.DataPlaneRouteName == "" {
+		return nil, errors.New("model runtime identity scope or revision is incomplete")
+	}
+	if rule.Parser.Source != runtimeIdentityJSONBody || strings.TrimSpace(rule.Parser.ModelKey) == "" {
+		return nil, errors.New("model runtime identity parser is unsupported")
+	}
+	if len(rule.SelectorTargets) == 0 || len(rule.TargetClosure) == 0 {
+		return nil, errors.New("model runtime identity targets are empty")
+	}
+	for selector, target := range rule.SelectorTargets {
+		if strings.TrimSpace(selector) == "" || !validRuntimeIdentityTarget(target) {
+			return nil, errors.New("model runtime identity selector target is invalid")
+		}
+		if closure, exists := rule.TargetClosure[target.ModelCardID]; !exists || !sameRuntimeIdentityTarget(closure, target) {
+			return nil, errors.New("model runtime identity selector is outside target closure")
+		}
+	}
+	for modelCardID, target := range rule.TargetClosure {
+		if modelCardID == "" || modelCardID != target.ModelCardID || !validRuntimeIdentityTarget(target) {
+			return nil, errors.New("model runtime identity closure target is invalid")
+		}
+	}
+	return &rule, nil
+}
+
+// validRuntimeIdentityTarget 校验身份 target 的最小不可变字段。
+func validRuntimeIdentityTarget(target runtimeIdentityTarget) bool {
+	return strings.TrimSpace(target.ModelCardID) != "" && strings.TrimSpace(target.Provider) != "" && strings.TrimSpace(target.UpstreamModelName) != "" && strings.TrimSpace(target.ServiceID) != "" && strings.TrimSpace(target.TargetCluster) != ""
+}
+
+// sameRuntimeIdentityTarget 判断两个 target 是否表达同一张卡、模型表现形式和执行目标。
+func sameRuntimeIdentityTarget(left, right runtimeIdentityTarget) bool {
+	return left.ModelCardID == right.ModelCardID && left.Provider == right.Provider && left.UpstreamModelName == right.UpstreamModelName && left.ServiceID == right.ServiceID && left.TargetCluster == right.TargetCluster
+}
+
+// loadResolvedModelContext 读取只由内置插件写入的 request-lifespan 身份 property。
+// 输入约束：调用点不得从 Header、Body 或 wrapper Context 合成替代 context。
+// 输出语义：property 未写入时返回 nil；编码损坏或 hostcall 失败返回错误，调用方必须 fail closed。
+// 边界场景：空字节不是合法 context，防止清除态被误解为无上下文并重新选择模型。
+func loadResolvedModelContext() (*resolvedModelContext, error) {
+	raw, err := proxywasm.GetProperty([]string{resolvedModelContextProperty})
+	if err != nil {
+		if errors.Is(err, types.ErrorStatusNotFound) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	if len(raw) == 0 {
+		return nil, errors.New("resolved model context is empty")
+	}
+	var context resolvedModelContext
+	if err := json.Unmarshal(raw, &context); err != nil {
+		return nil, fmt.Errorf("decode resolved model context: %w", err)
+	}
+	return &context, nil
+}
+
+// validateResolvedModelContextForRule 校验已有 context 能否在当前 strict route 再入时继续使用。
+// 输入约束：context 必须来自 loadResolvedModelContext；rule 是当前请求匹配的控制面冻结配置。
+// 输出语义：返回空字符串表示上下文可保留；非空为稳定低基数拒绝原因。
+// 边界场景：任何 scope/revision/target 差异都拒绝，绝不根据当前 Body 的模型字段覆盖已有可信身份。
+func validateResolvedModelContextForRule(context *resolvedModelContext, rule *runtimeIdentityRule) string {
+	if context == nil || rule == nil {
+		return "missing_context"
+	}
+	if context.SchemaVersion != resolvedModelContextSchemaVersion {
+		return "unsupported_context_version"
+	}
+	if context.ConfigRevision != rule.ConfigRevision {
+		return "context_revision_mismatch"
+	}
+	if context.GatewayID != rule.Scope.GatewayID || context.APIID != rule.Scope.APIID || context.RouteID != rule.Scope.RouteID {
+		return "context_scope_mismatch"
+	}
+	if context.TransitionSeq < 1 || context.Source == "" {
+		return "invalid_context_generation"
+	}
+	if _, exists := rule.TargetClosure[context.ResolvedModelCardID]; !exists {
+		return "context_target_not_in_closure"
+	}
+	return ""
+}
+
+// writeResolvedModelContext 将一次成功 Direct 选择写入请求生命周期 property。
+// 输入约束：target 已从当前 rule 的精确 selector map 获取，所有 Body/Header 改写已成功。
+// 输出语义：成功时后续 mapper/auto/ai-proxy 可读取 seq=1 的同一身份；失败由调用方拒绝请求。
+// 边界场景：不写入客户端 Header，也不保留 selector 原文，避免 canonical/alias 文本成为身份来源。
+func writeResolvedModelContext(rule *runtimeIdentityRule, target runtimeIdentityTarget, sequence int64, source string) error {
+	context := resolvedModelContext{
+		SchemaVersion:       resolvedModelContextSchemaVersion,
+		GatewayID:           rule.Scope.GatewayID,
+		APIID:               rule.Scope.APIID,
+		RouteID:             rule.Scope.RouteID,
+		ConfigRevision:      rule.ConfigRevision,
+		ResolvedModelCardID: target.ModelCardID,
+		TransitionSeq:       sequence,
+		Source:              source,
+	}
+	raw, err := json.Marshal(context)
+	if err != nil {
+		return err
+	}
+	return proxywasm.SetProperty([]string{resolvedModelContextProperty}, raw)
+}
+
+// isReservedAutoSelector 判断 selector 是否必须交给 ai-auto-router 在最终候选后建立 identity。
+func isReservedAutoSelector(rule *runtimeIdentityRule, selector string) bool {
+	for _, reserved := range rule.ReservedAutoSelectors {
+		if reserved == selector {
+			return true
+		}
+		if strings.HasSuffix(reserved, "*") && strings.HasPrefix(selector, strings.TrimSuffix(reserved, "*")) {
+			return true
+		}
+	}
+	return false
+}
+
+// rejectRuntimeIdentityRequest 返回不携带 Body、凭据或 selector 内容的稳定本地错误。
+func rejectRuntimeIdentityRequest(ctx wrapper.HttpContext, reason string) types.Action {
+	ctx.DontReadResponseBody()
+	body, _ := json.Marshal(map[string]any{"error": map[string]string{"type": "model_runtime_identity_error", "code": reason}})
+	_ = proxywasm.SendHttpResponse(http.StatusBadRequest, [][2]string{{"content-type", "application/json"}}, body, -1)
+	return types.ActionPause
+}

--- a/plugins/wasm-go/extensions/model-router/runtime_identity_test.go
+++ b/plugins/wasm-go/extensions/model-router/runtime_identity_test.go
@@ -1,0 +1,377 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/higress-group/proxy-wasm-go-sdk/proxywasm"
+	"github.com/higress-group/proxy-wasm-go-sdk/proxywasm/proxytest"
+	"github.com/higress-group/proxy-wasm-go-sdk/proxywasm/types"
+	"github.com/higress-group/wasm-go/pkg/test"
+	"github.com/higress-group/wasm-go/pkg/wrapper"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+// runtimeIdentityTestHost 为旧 wasm-go test helper 补齐 strict 插件启动所需的 declare_property foreign function。
+// 输入约束：只在 Go-mode 单元测试中使用；每个实例独占一个 proxytest Host，不能跨用例复用。
+// 输出语义：保留现有 Header/Body/property 断言能力，并记录 strict property declaration 的 wire payload。
+// 边界场景：该夹具不模拟 Envoy internal redirect 的真实 FilterState 生命周期，真实链路由独立 Envoy 验证覆盖。
+type runtimeIdentityTestHost struct {
+	proxytest.HostEmulator
+	currentContextID uint32
+	contextActive    bool
+	declarationCalls [][]byte
+	reset            func()
+}
+
+// newRuntimeIdentityTestHost 创建已注册 declare_property 的 strict 单元测试宿主。
+// 输入约束：config 必须是完整 strict ModelRouter JSON；调用方在断言结束后必须调用 Reset 释放全局 mock host。
+// 输出语义：返回已执行 OnPluginStart 的宿主，且每次 declaration payload 都被保留以验证 wire 协议。
+// 边界场景：每次重建 VM context，避免其它 legacy 单测 Reset SDK 全局状态后让 strict 用例依赖执行顺序；foreign function 返回一个占位字节以适配旧 proxytest 的非空返回缓冲实现，生产 Envoy 不依赖该返回值。
+func newRuntimeIdentityTestHost(t *testing.T, config []byte) (*runtimeIdentityTestHost, types.OnPluginStartStatus) {
+	t.Helper()
+	wrapper.SetCtx(
+		"model-router",
+		wrapper.PrePluginStartOrReload[ModelRouterConfig](ensureRuntimeIdentityRequestProperty),
+		wrapper.ParseConfig(parseConfig),
+		wrapper.ProcessRequestHeaders(onHttpRequestHeaders),
+		wrapper.ProcessRequestBody(onHttpRequestBody),
+		wrapper.WithRebuildMaxMemBytes[ModelRouterConfig](200*1024*1024),
+	)
+	vmContext := proxywasm.GetVMContext()
+	require.NotNil(t, vmContext, "runtime identity test VM context must be initialized by wrapper.SetCtx")
+	host, reset := proxytest.NewHostEmulator(
+		proxytest.NewEmulatorOption().
+			WithPluginConfiguration(config).
+			WithVMContext(vmContext),
+	)
+	result := &runtimeIdentityTestHost{HostEmulator: host, reset: reset}
+	host.RegisterForeignFunction("declare_property", func(payload []byte) []byte {
+		result.declarationCalls = append(result.declarationCalls, append([]byte(nil), payload...))
+		return []byte{0}
+	})
+	// 旧 wrapper 在插件启动日志路径读取 get_log_level；该返回值不属于本协议，但必须在宿主启动前提供。
+	host.RegisterForeignFunction("get_log_level", func([]byte) []byte { return []byte{0, 0, 0, 0} })
+	status := host.StartPlugin()
+	require.NoError(t, result.SetRouteName("test-route-default"))
+	require.NoError(t, result.SetProperty([]string{"cluster_name"}, []byte("test-cluster-default")))
+	require.NoError(t, result.SetProperty([]string{"x_request_id"}, []byte("test-request-id-default")))
+	return result, status
+}
+
+// SetRouteName 设置 wrapper `_match_route_` 所读取的 route_name property。
+// 输入约束：routeName 是测试固定字符串，不能在已开始的 HTTP context 中模拟生产重新路由。
+// 输出语义：后续创建的 HTTP context 读取该路由名并选择对应 strict `_rules_` entry。
+// 边界场景：property 写入失败直接返回，让用例以 require 失败而不是产生错误的 rule 命中结论。
+func (h *runtimeIdentityTestHost) SetRouteName(routeName string) error {
+	return h.SetProperty([]string{"route_name"}, []byte(routeName))
+}
+
+// CallOnHttpRequestHeaders 在当前或新建 HTTP context 上执行请求头回调。
+// 输入约束：headers 必须先于 Body 调用，以保持 strict parser 的缓冲生命周期与真实插件一致。
+// 输出语义：返回插件 action，并保留同一 context 供后续 Body 与 property 断言使用。
+// 边界场景：夹具不自动跨请求复用 context，避免一次用例的 property 被误认作新请求状态。
+func (h *runtimeIdentityTestHost) CallOnHttpRequestHeaders(headers [][2]string) types.Action {
+	if !h.contextActive {
+		h.currentContextID = h.InitializeHttpContext()
+		h.contextActive = true
+	}
+	return h.HostEmulator.CallOnRequestHeaders(h.currentContextID, headers, false)
+}
+
+// CallOnHttpRequestBody 在当前 HTTP context 上执行最终 Body 回调。
+// 输入约束：调用前必须完成 Header 回调；Body 由 proxytest 模拟为 end-of-stream。
+// 输出语义：返回插件 action，供 Direct 选择、拒绝和重入路径断言。
+// 边界场景：未初始化 context 时直接 panic，防止测试绕过 strict Header parser 而得到不可信的结论。
+func (h *runtimeIdentityTestHost) CallOnHttpRequestBody(body []byte) types.Action {
+	if !h.contextActive {
+		panic("runtime identity test must call request headers before request body")
+	}
+	return h.HostEmulator.CallOnRequestBody(h.currentContextID, body, true)
+}
+
+// GetRequestBody 返回当前 HTTP context 被插件改写后的请求 Body。
+// 输入约束：只应在至少一次 Header 回调之后读取。
+// 输出语义：Direct rewrite 断言读取当前流，而不是测试输入副本。
+// 边界场景：context 未初始化视为测试顺序错误，避免零值 context 被当成真实请求。
+func (h *runtimeIdentityTestHost) GetRequestBody() []byte {
+	if !h.contextActive {
+		panic("runtime identity test request context is not initialized")
+	}
+	return h.HostEmulator.GetCurrentRequestBody(h.currentContextID)
+}
+
+// GetRequestHeaders 返回当前 HTTP context 被插件改写后的请求头。
+// 输入约束：只应在 Header/Body 回调后的同一请求中读取。
+// 输出语义：供 strict modelToHeader 的投影断言使用。
+// 边界场景：不从全局 Host 状态拼装 Header，避免相邻用例交叉污染。
+func (h *runtimeIdentityTestHost) GetRequestHeaders() [][2]string {
+	if !h.contextActive {
+		panic("runtime identity test request context is not initialized")
+	}
+	return h.HostEmulator.GetCurrentRequestHeaders(h.currentContextID)
+}
+
+// Reset 关闭当前 HTTP context 并释放该用例注册的全局 proxy-wasm mock host。
+// 输入约束：每个测试宿主只能 Reset 一次；调用方通常通过 defer 保证释放。
+// 输出语义：清除 SDK VM state，避免下一条严格配置继承本用例的 property 或 foreign function。
+// 边界场景：HTTP context 未创建时仅释放 root host，仍然是合法的启动失败清理路径。
+func (h *runtimeIdentityTestHost) Reset() {
+	if h.contextActive {
+		h.CompleteHttpContext(h.currentContextID)
+		h.contextActive = false
+	}
+	h.reset()
+}
+
+// TestRuntimeIdentityRequestPropertyDeclaration 验证 strict 检测和 Envoy declare_property wire 协议没有退回默认 FilterChain span。
+func TestRuntimeIdentityRequestPropertyDeclaration(t *testing.T) {
+	t.Run("strict config detection", func(t *testing.T) {
+		require.False(t, runtimeIdentityConfigRequiresRequestProperty(gjson.Parse(`{"modelKey":"model"}`)))
+		require.True(t, runtimeIdentityConfigRequiresRequestProperty(gjson.Parse(`{"modelRuntimeIdentity":{}}`)))
+		require.True(t, runtimeIdentityConfigRequiresRequestProperty(gjson.Parse(`{"_rules_":[{"modelRuntimeIdentity":{}}]}`)))
+	})
+	t.Run("downstream request bytes payload", func(t *testing.T) {
+		want := append([]byte{0x0a, byte(len(resolvedModelContextProperty))}, []byte(resolvedModelContextProperty)...)
+		want = append(want, 0x18, 0x00, 0x28, 0x01)
+		require.True(t, bytes.Equal(want, runtimeIdentityRequestPropertyDeclarationPayload()))
+	})
+}
+
+func strictModelRouterConfig(t *testing.T) []byte {
+	t.Helper()
+	return strictModelRouterConfigWithRule(t, strictModelRouterRule())
+}
+
+// strictModelRouterConfigWithRule 将指定冻结 rule 包装成 model-router 的最小 strict 配置。
+// 输入约束：rule 必须满足生产 parser 的完整性要求，调用方可仅在自身测试内修改其副本。
+// 输出语义：返回不含 legacy 路由猜测字段的独立 strict 配置。
+// 边界情况：这只模拟单插件的配置消费，不能替代真实 Envoy filter-chain 验证。
+func strictModelRouterConfigWithRule(t *testing.T, rule map[string]any) []byte {
+	t.Helper()
+	raw, err := json.Marshal(map[string]any{
+		"modelToHeader":        "x-higress-llm-model",
+		"addProviderHeader":    "x-higress-llm-provider",
+		"modelRuntimeIdentity": rule,
+	})
+	require.NoError(t, err)
+	return raw
+}
+
+// strictModelRouterRule 返回由 APIGO control-plane 下发到单个 strict rule 的冻结身份字段。
+// 责任：让直接配置与 `_rules_` 载体测试复用同一份真实 C1 输入，避免两套 fixture 漂移。
+// 输入约束：返回 map 仅供测试 JSON 序列化使用，调用方不得在一个用例中改写后复用于其它用例。
+// 输出语义：包含 Direct 选择所需的 route scope、body parser、selector target 和闭包。
+// 边界场景：`modelToHeader` 属于 rule 外层字段，因为 Higress wrapper 会对每条 `_rules_` entry 独立执行 parseConfig。
+func strictModelRouterRule() map[string]any {
+	return map[string]any{
+		"mode":           "ChooseModelV1",
+		"configRevision": "revision-1",
+		"scope": map[string]any{
+			"gatewayId": "gw-1", "apiId": "api-1", "routeId": "route-1", "dataPlaneRouteName": "route-name-1",
+		},
+		"parser": map[string]any{"source": "json_body", "modelKey": "model"},
+		"selectorTargets": map[string]any{
+			"provider/model": map[string]any{"modelCardId": "card-1", "provider": "provider", "upstreamModelName": "model", "serviceId": "service-1", "targetCluster": "outbound|443||provider.internal"},
+		},
+		"reservedAutoSelectors": []string{"auto", "auto/*"},
+		"targetClosure": map[string]any{
+			"card-1": map[string]any{"modelCardId": "card-1", "provider": "provider", "upstreamModelName": "model", "serviceId": "service-1", "targetCluster": "outbound|443||provider.internal"},
+		},
+	}
+}
+
+// strictModelRouterCarrierConfig 构造 APIGO 专有 strict carrier 的实际 WasmPlugin 配置形态。
+// 责任：验证全局层只有 strict-only 开关、route 匹配和模型 Header 规则字段均落在单条 `_rules_` entry。
+// 输入约束：route 名必须与冻结 rule scope 的 dataPlaneRouteName 一致，否则 wrapper 不会选择该 rule。
+// 输出语义：返回可直接喂给 Higress test host 的 JSON 配置。
+// 边界场景：全局没有 legacy `modelToHeader` 或路径后缀，因此未命中 route 不能触发 body 缓冲或 legacy model-router 行为。
+func strictModelRouterCarrierConfig(t *testing.T) []byte {
+	t.Helper()
+	raw, err := json.Marshal(map[string]any{
+		"strictRuntimeIdentityOnly": true,
+		"_rules_": []map[string]any{{
+			"_match_route_":        []string{"route-name-1"},
+			"modelToHeader":        "x-higress-llm-model",
+			"addProviderHeader":    "x-higress-llm-provider",
+			"modelRuntimeIdentity": strictModelRouterRule(),
+		}},
+	})
+	require.NoError(t, err)
+	return raw
+}
+
+// TestRuntimeIdentityDirectSelection 验证 Direct 只使用 frozen selector map，并把唯一卡身份写入 property。
+func TestRuntimeIdentityDirectSelection(t *testing.T) {
+	test.RunGoTest(t, func(t *testing.T) {
+		for _, testCase := range []struct {
+			name     string
+			selector string
+			rule     map[string]any
+		}{
+			{name: "canonical selector", selector: "provider/model", rule: strictModelRouterRule()},
+			{
+				name:     "explicit alias selector",
+				selector: "model-alias",
+				rule: func() map[string]any {
+					rule := strictModelRouterRule()
+					selectors := rule["selectorTargets"].(map[string]any)
+					// 便捷别名是否可用由 APIGO compiler 决定；数据面仅按已冻结的精确字面量表查找。
+					selectors["model-alias"] = selectors["provider/model"]
+					return rule
+				}(),
+			},
+		} {
+			t.Run(testCase.name, func(t *testing.T) {
+				host, status := newRuntimeIdentityTestHost(t, strictModelRouterConfigWithRule(t, testCase.rule))
+				defer host.Reset()
+				require.Equal(t, types.OnPluginStartStatusOK, status)
+				require.Equal(t, [][]byte{runtimeIdentityRequestPropertyDeclarationPayload()}, host.declarationCalls)
+
+				require.Equal(t, types.HeaderStopIteration, host.CallOnHttpRequestHeaders([][2]string{
+					{":authority", "example.com"}, {":path", "/any/path"}, {":method", "POST"}, {"content-type", "application/json"}, {"content-length", "99"}, {runtimeIdentityTargetClusterHeader, "client-spoofed-cluster"},
+				}))
+				require.Equal(t, types.ActionContinue, host.CallOnHttpRequestBody([]byte(`{"model":"`+testCase.selector+`"}`)))
+				require.Equal(t, "model", gjson.GetBytes(host.GetRequestBody(), "model").String())
+				// selector 改写为不同长度的 upstream model 后，不得继续携带请求入站时的旧长度。
+				_, hasContentLength := getHeader(host.GetRequestHeaders(), "content-length")
+				require.False(t, hasContentLength)
+				// APIGO-CONTRACT: modelcard-runtime-identity
+				// 客户端传入的 cluster 不能穿透 Direct writer；只有 selector target 中同 revision 的目标可写入 Route。
+				clusterHeader, found := getHeader(host.GetRequestHeaders(), runtimeIdentityTargetClusterHeader)
+				require.True(t, found)
+				require.Equal(t, "outbound|443||provider.internal", clusterHeader)
+
+				raw, err := host.GetProperty([]string{resolvedModelContextProperty})
+				require.NoError(t, err)
+				var context resolvedModelContext
+				require.NoError(t, json.Unmarshal(raw, &context))
+				require.Equal(t, resolvedModelContextSchemaVersion, int(gjson.GetBytes(raw, "schemaVersion").Int()))
+				require.Equal(t, "gw-1", gjson.GetBytes(raw, "gatewayId").String())
+				require.False(t, gjson.GetBytes(raw, "scope").Exists())
+				require.False(t, gjson.GetBytes(raw, "version").Exists())
+				require.Equal(t, "card-1", context.ResolvedModelCardID)
+				require.Equal(t, int64(1), context.TransitionSeq)
+				require.Equal(t, "direct", context.Source)
+			})
+		}
+	})
+}
+
+// TestRuntimeIdentityDedicatedCarrierRule 验证专有 carrier 的 `_rules_` entry 能被 wrapper 正确选择并保留 strict-only 隔离。
+func TestRuntimeIdentityDedicatedCarrierRule(t *testing.T) {
+	test.RunGoTest(t, func(t *testing.T) {
+		host, status := newRuntimeIdentityTestHost(t, strictModelRouterCarrierConfig(t))
+		defer host.Reset()
+		require.Equal(t, types.OnPluginStartStatusOK, status)
+		require.NoError(t, host.SetRouteName("route-name-1"))
+
+		require.Equal(t, types.HeaderStopIteration, host.CallOnHttpRequestHeaders([][2]string{
+			{":authority", "example.com"}, {":path", "/any/path"}, {":method", "POST"}, {"content-type", "application/json"}, {"content-length", "99"},
+		}))
+		require.Equal(t, types.ActionContinue, host.CallOnHttpRequestBody([]byte(`{"model":"provider/model"}`)))
+		// Header 与 Body 都使用冻结 target 的 upstreamModelName；可信身份只通过 stream property 传播。
+		header, found := getHeader(host.GetRequestHeaders(), "x-higress-llm-model")
+		require.True(t, found)
+		require.Equal(t, "model", header)
+		providerHeader, found := getHeader(host.GetRequestHeaders(), "x-higress-llm-provider")
+		require.True(t, found)
+		require.Equal(t, "provider", providerHeader)
+		clusterHeader, found := getHeader(host.GetRequestHeaders(), runtimeIdentityTargetClusterHeader)
+		require.True(t, found)
+		require.Equal(t, "outbound|443||provider.internal", clusterHeader)
+
+		raw, err := host.GetProperty([]string{resolvedModelContextProperty})
+		require.NoError(t, err)
+		require.Equal(t, "card-1", gjson.GetBytes(raw, "resolvedModelCardId").String())
+	})
+}
+
+// TestRuntimeIdentityRejectsUnknownOrSpoofedContext 验证客户端 selector 和损坏 property 都不会被静默接受。
+func TestRuntimeIdentityRejectsUnknownOrSpoofedContext(t *testing.T) {
+	test.RunGoTest(t, func(t *testing.T) {
+		t.Run("unknown selector", func(t *testing.T) {
+			host, status := newRuntimeIdentityTestHost(t, strictModelRouterConfig(t))
+			defer host.Reset()
+			require.Equal(t, types.OnPluginStartStatusOK, status)
+			host.CallOnHttpRequestHeaders([][2]string{{":authority", "example.com"}, {":path", "/any"}, {":method", "POST"}, {"content-type", "application/json"}})
+			require.Equal(t, types.ActionPause, host.CallOnHttpRequestBody([]byte(`{"model":"untrusted"}`)))
+		})
+
+		t.Run("malformed property", func(t *testing.T) {
+			host, status := newRuntimeIdentityTestHost(t, strictModelRouterConfig(t))
+			defer host.Reset()
+			require.Equal(t, types.OnPluginStartStatusOK, status)
+			require.NoError(t, host.SetProperty([]string{resolvedModelContextProperty}, []byte(`not-json`)))
+			host.CallOnHttpRequestHeaders([][2]string{{":authority", "example.com"}, {":path", "/any"}, {":method", "POST"}, {"content-type", "application/json"}})
+			require.Equal(t, types.ActionPause, host.CallOnHttpRequestBody([]byte(`{"model":"provider/model"}`)))
+		})
+	})
+}
+
+// TestRuntimeIdentityLiteralSelectorAndReentry 验证 slash selector 不拆段，并且 fallback 重入不会重置已有 generation。
+func TestRuntimeIdentityLiteralSelectorAndReentry(t *testing.T) {
+	test.RunGoTest(t, func(t *testing.T) {
+		t.Run("slash selector remains one literal", func(t *testing.T) {
+			rule := strictModelRouterRule()
+			selectorTargets := rule["selectorTargets"].(map[string]any)
+			targetClosure := rule["targetClosure"].(map[string]any)
+			delete(selectorTargets, "provider/model")
+			selectorTargets["provider/model/with/slash"] = map[string]any{
+				"modelCardId": "card-slash", "provider": "provider", "upstreamModelName": "model/with/slash", "serviceId": "service-slash", "targetCluster": "outbound|443||provider-slash.internal",
+			}
+			delete(targetClosure, "card-1")
+			targetClosure["card-slash"] = map[string]any{
+				"modelCardId": "card-slash", "provider": "provider", "upstreamModelName": "model/with/slash", "serviceId": "service-slash", "targetCluster": "outbound|443||provider-slash.internal",
+			}
+
+			host, status := newRuntimeIdentityTestHost(t, strictModelRouterConfigWithRule(t, rule))
+			defer host.Reset()
+			require.Equal(t, types.OnPluginStartStatusOK, status)
+			require.Equal(t, types.HeaderStopIteration, host.CallOnHttpRequestHeaders(runtimeIdentityTestHeaders()))
+			require.Equal(t, types.ActionContinue, host.CallOnHttpRequestBody([]byte(`{"model":"provider/model/with/slash"}`)))
+			require.Equal(t, "model/with/slash", gjson.GetBytes(host.GetRequestBody(), "model").String())
+
+			raw, err := host.GetProperty([]string{resolvedModelContextProperty})
+			require.NoError(t, err)
+			require.Equal(t, "card-slash", gjson.GetBytes(raw, "resolvedModelCardId").String())
+		})
+
+		t.Run("valid reentry preserves previous generation", func(t *testing.T) {
+			host, status := newRuntimeIdentityTestHost(t, strictModelRouterConfig(t))
+			defer host.Reset()
+			require.Equal(t, types.OnPluginStartStatusOK, status)
+			context, err := json.Marshal(resolvedModelContext{
+				SchemaVersion:       resolvedModelContextSchemaVersion,
+				GatewayID:           "gw-1",
+				APIID:               "api-1",
+				RouteID:             "route-1",
+				ConfigRevision:      "revision-1",
+				ResolvedModelCardID: "card-1",
+				TransitionSeq:       2,
+				Source:              "fallback",
+			})
+			require.NoError(t, err)
+			require.NoError(t, host.SetProperty([]string{resolvedModelContextProperty}, context))
+
+			require.Equal(t, types.HeaderStopIteration, host.CallOnHttpRequestHeaders(runtimeIdentityTestHeaders()))
+			require.Equal(t, types.ActionContinue, host.CallOnHttpRequestBody([]byte(`{"model":"model"}`)))
+			raw, err := host.GetProperty([]string{resolvedModelContextProperty})
+			require.NoError(t, err)
+			require.Equal(t, int64(2), gjson.GetBytes(raw, "transitionSeq").Int())
+			require.Equal(t, "fallback", gjson.GetBytes(raw, "source").String())
+		})
+	})
+}
+
+// runtimeIdentityTestHeaders 返回 strict JSON Body 路径所需的最小请求头。
+// 输入约束：调用方随后必须提供 JSON Body；该 helper 不模拟真实 Envoy 路由或 internal redirect。
+// 输出语义：返回新的切片，避免不同 TestHost 共享可变 header。
+// 边界情况：content-length 故意省略，交由插件在 Header 阶段按真实行为处理。
+func runtimeIdentityTestHeaders() [][2]string {
+	return [][2]string{
+		{":authority", "example.com"}, {":path", "/v1/chat/completions"}, {":method", "POST"}, {"content-type", "application/json"},
+	}
+}


### PR DESCRIPTION
## Summary

- add trusted ModelCard runtime identity context handling to model-router and model-mapper
- validate request scope, config revision, target closure, model representation, and target cluster/service consistency
- add focused unit tests for runtime identity transitions and rejection paths

## Testing

- Pre-production integration validation was completed for the corresponding plugin release flow.
- Focused local Go test was not recorded in this submission environment; GitHub checks should provide the authoritative build/test result.

## Related

- Source branch: `feature/20260820_30850545_unify-modelcard-runtime-identity_1`
- Target branch: `main`