### PR TITLE
fix: correct Gateway API parent references in InferencePool status

### DIFF
--- a/changes/inferencepool-gateway-api-parentref.md
+++ b/changes/inferencepool-gateway-api-parentref.md
@@ -1,0 +1,31 @@
+<!--
+Copyright 2026 alibaba
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# Fix Gateway API parent references in InferencePool status
+
+Use the Gateway API group and kind (`gateway.networking.k8s.io/Gateway`) in
+`InferencePool.status.parents[].parentRef`. Normal reconciliation corrects legacy
+`networking.istio.io/Gateway` references for the same Gateway without leaving
+duplicate entries.
+
+Add regression coverage for the complete parent identity (`group`, `kind`,
+`namespace`, and `name`), same- and cross-namespace references, legacy status
+correction, and deduplication across repeated reconciliation.
+
+References: [Bug #4658](https://github.com/higress-group/higress/issues/4658),
+[Proposal #4659](https://github.com/higress-group/higress/issues/4659),
+[Design #4661](https://github.com/higress-group/higress/issues/4661), and
+[SPEC-4659001](https://github.com/higress-group/higress/issues/4659#issuecomment-5582077984).

--- a/pkg/ingress/kube/gateway/istio/inferencepool_collection.go
+++ b/pkg/ingress/kube/gateway/istio/inferencepool_collection.go
@@ -349,8 +349,8 @@ func calculateSingleParentStatus(
 	// Build the final status
 	return inferencev1.ParentStatus{
 		ParentRef: inferencev1.ParentReference{
-			Group:     (*inferencev1.Group)(&gvk.Gateway.Group),
-			Kind:      inferencev1.Kind(gvk.Gateway.Kind),
+			Group:     (*inferencev1.Group)(&gvk.KubernetesGateway.Group),
+			Kind:      inferencev1.Kind(gvk.KubernetesGateway.Kind),
 			Namespace: inferencev1.Namespace(gatewayParent.Namespace),
 			Name:      inferencev1.ObjectName(gatewayParent.Name),
 		},

--- a/pkg/ingress/kube/gateway/istio/inferencepool_status_test.go
+++ b/pkg/ingress/kube/gateway/istio/inferencepool_status_test.go
@@ -69,8 +69,7 @@ func TestInferencePoolStatusReconciliation(t *testing.T) {
 			targetPool: NewInferencePool("test-pool", InNamespace(DefaultTestNS)),
 			expectations: func(t *testing.T, status *inferencev1.InferencePoolStatus) {
 				require.Len(t, status.Parents, 1, "Expected one parent reference")
-				assert.Equal(t, "main-gateway", string(status.Parents[0].ParentRef.Name))
-				assert.Equal(t, DefaultTestNS, string(status.Parents[0].ParentRef.Namespace))
+				assertGatewayParentRef(t, status.Parents[0].ParentRef, DefaultTestNS, "main-gateway")
 				assertConditionContains(t, status.Parents[0].Conditions, metav1.Condition{
 					Type:    string(inferencev1.InferencePoolConditionAccepted),
 					Status:  metav1.ConditionTrue,
@@ -240,8 +239,7 @@ func TestInferencePoolStatusReconciliation(t *testing.T) {
 			targetPool: NewInferencePool("test-pool", InNamespace(AppTestNS)),
 			expectations: func(t *testing.T, status *inferencev1.InferencePoolStatus) {
 				require.Len(t, status.Parents, 1, "Expected one parent reference")
-				assert.Equal(t, "main-gateway", string(status.Parents[0].ParentRef.Name))
-				assert.Equal(t, GatewayTestNS, string(status.Parents[0].ParentRef.Namespace))
+				assertGatewayParentRef(t, status.Parents[0].ParentRef, GatewayTestNS, "main-gateway")
 			},
 		},
 		{
@@ -255,8 +253,7 @@ func TestInferencePoolStatusReconciliation(t *testing.T) {
 			targetPool: NewInferencePool("test-pool", InNamespace(DefaultTestNS)),
 			expectations: func(t *testing.T, status *inferencev1.InferencePoolStatus) {
 				require.Len(t, status.Parents, 1, "Expected one parent reference")
-				assert.Equal(t, "main-gateway", string(status.Parents[0].ParentRef.Name))
-				assert.Equal(t, GatewayTestNS, string(status.Parents[0].ParentRef.Namespace))
+				assertGatewayParentRef(t, status.Parents[0].ParentRef, GatewayTestNS, "main-gateway")
 			},
 		},
 		{
@@ -486,6 +483,85 @@ func TestInferencePoolStatusReconciliation(t *testing.T) {
 			tc.expectations(t, poolStatus)
 		})
 	}
+}
+
+func TestInferencePoolStatusCorrectsLegacyGatewayParent(t *testing.T) {
+	testCases := []struct {
+		name   string
+		groups []string
+	}{
+		{name: "legacy parent", groups: []string{"networking.istio.io"}},
+		{name: "legacy and correct parents", groups: []string{"networking.istio.io", "gateway.networking.k8s.io"}},
+		{name: "correct and legacy parents", groups: []string{"gateway.networking.k8s.io", "networking.istio.io"}},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			stop := test.NewStop(t)
+			services := krt.NewStaticCollection[*corev1.Service](nil,
+				[]*corev1.Service{NewService("endpoint-picker")}, krt.WithStop(stop))
+			gateways := krt.NewStaticCollection[*gateway.Gateway](nil,
+				[]*gateway.Gateway{
+					NewGateway("main-gateway", WithGatewayClass("higress")),
+					NewGateway("other-gateway", WithGatewayClass("other-class")),
+				}, krt.WithStop(stop))
+			routes := []*gateway.HTTPRoute{
+				NewHTTPRoute("test-route",
+					WithParentRefAndStatus("main-gateway", DefaultTestNS, IstioController),
+					WithRouteParentCondition(string(gateway.RouteConditionAccepted), metav1.ConditionTrue, "Accepted", "Accepted"),
+					WithBackendRef("test-pool", DefaultTestNS)),
+			}
+			pool := NewInferencePool("test-pool",
+				WithParentStatus("other-gateway", DefaultTestNS, WithAcceptedConditions()))
+			pool.Generation = 1
+			otherParent := *pool.Status.Parents[0].DeepCopy()
+			for _, group := range tc.groups {
+				WithParentStatus("main-gateway", DefaultTestNS, WithAcceptedConditions())(pool)
+				parent := &pool.Status.Parents[len(pool.Status.Parents)-1]
+				parentGroup := inferencev1.Group(group)
+				parent.ParentRef.Group = &parentGroup
+				parent.ParentRef.Kind = "Gateway"
+			}
+
+			// Feed each result back as persisted status to exercise repeated reconciliation.
+			for round := 0; round < 3; round++ {
+				result := calculateInferencePoolStatus(pool, findGatewayParents(pool, routes), services, gateways, routes)
+				require.Len(t, result.Parents, 2, "Expected one managed parent and the other controller's parent in round %d", round)
+				assert.Contains(t, result.Parents, otherParent, "Other controller's status must remain unchanged")
+				var managedParents []inferencev1.ParentStatus
+				for _, parent := range result.Parents {
+					if parent.ParentRef.Name == "main-gateway" {
+						managedParents = append(managedParents, parent)
+					}
+				}
+				require.Len(t, managedParents, 1, "Expected one parent for the managed Gateway in round %d", round)
+				parent := managedParents[0]
+				assertGatewayParentRef(t, parent.ParentRef, DefaultTestNS, "main-gateway")
+				require.Len(t, parent.Conditions, 2)
+				for _, condition := range parent.Conditions {
+					assert.Equal(t, metav1.ConditionTrue, condition.Status)
+					assert.Equal(t, pool.Generation, condition.ObservedGeneration)
+				}
+				assertConditionContains(t, parent.Conditions, metav1.Condition{
+					Type:   string(inferencev1.InferencePoolConditionAccepted),
+					Reason: string(inferencev1.InferencePoolReasonAccepted),
+				})
+				assertConditionContains(t, parent.Conditions, metav1.Condition{
+					Type:   string(inferencev1.InferencePoolConditionResolvedRefs),
+					Reason: string(inferencev1.InferencePoolReasonResolvedRefs),
+				})
+				pool.Status = *result.DeepCopy()
+			}
+		})
+	}
+}
+
+func assertGatewayParentRef(t *testing.T, ref inferencev1.ParentReference, namespace, name string) {
+	t.Helper()
+	require.NotNil(t, ref.Group)
+	assert.Equal(t, "gateway.networking.k8s.io", string(*ref.Group))
+	assert.Equal(t, "Gateway", string(ref.Kind))
+	assert.Equal(t, namespace, string(ref.Namespace))
+	assert.Equal(t, name, string(ref.Name))
 }
 
 func assertConditionContains(t *testing.T, conditions []metav1.Condition, expected metav1.Condition, msgAndArgs ...interface{}) {


### PR DESCRIPTION
## I. Summary

Higress 为 Gateway API Gateway 生成 InferencePool 父状态时，误用了 Istio Gateway 的 API group，导致 parentRef.group 为 networking.istio.io。严格按完整父对象身份匹配状态的消费者因此无法采纳该 parent 的条件。

本次将 Group/Kind 改为 gvk.KubernetesGateway.Group/Kind，Namespace/Name 继续取实际关联的 Gateway。复用现有状态替换与去重逻辑，在正常协调时纠正本缺陷产生的旧引用，并补齐完整身份、旧/正确引用并存和重复协调的回归测试。

实际 Kind 升级验证确认：保留原资源和旧状态，仅切换控制器镜像即可纠正引用；两个场景中正确引用均为一条，旧错误引用为零。无需新增配置或迁移步骤。

## II. Related issue

Fixes #4658

- [Proposal #4659](https://github.com/higress-group/higress/issues/4659)
- [Design #4661](https://github.com/higress-group/higress/issues/4661)
- [SPEC-4659001](https://github.com/higress-group/higress/issues/4659#issuecomment-5582077984)
- [TASK-4661001：实现与回归测试](https://github.com/higress-group/higress/issues/4661#issuecomment-5583040668)
- [TASK-4661002：Kind 运行验证](https://github.com/higress-group/higress/issues/4661#issuecomment-5583043963)

## III. Change type

- [x] Bug fix
- [ ] Feature or enhancement
- [ ] Documentation or configuration only
- [ ] Refactoring, tests, or maintenance

## IV. Agent participation and issue-spec gate

参照 [agent-assisted contribution policy](https://github.com/higress-group/higress/blob/main/docs/developers/agent-assisted-contributions.md)。以下保留官方模板的声明字段。

- [ ] **No agent participation:** This PR is human-only.
- [ ] **Trivial agent-use exception:** Agent use was limited to spelling, punctuation, whitespace, or formatting with no substantive choice or behavioral effect; the explanation is below.
- [ ] **Verified maintainer/administrator exception:** Material agent participation occurred, and authenticated gh verification confirmed a role_name of maintain or admin on higress-group/higress, and the verified login matches this PR's GitHub author; record the required evidence and rationale below.
- [x] **Material agent participation:** An AI or coding agent materially participated in analysis, design, implementation, testing, or PR preparation.

- [ ] **Before implementation began:** A Higress maintainer had approved the Proposal and Design Issues, and authorized implementation TASKs linked the work to the applicable SPECs.
- [x] **Before verification began:** The Design contained a concrete Verification Plan.
- [x] **Before requesting maintainer review or acceptance:** Applicable implementation and verification TASKs were done with exact commands, results, evidence links, and hashes.

- [ ] Complete: all three timed obligations above were satisfied.
- [x] Noncompliant: one or more obligations were not satisfied; explain below.
- [ ] Verified exception: material agent participation used the verified-maintainer/administrator exception; provide the required evidence and rationale below.
- [ ] N/A because the PR is human-only or qualifies for the trivial exception.

**Gate-status explanation (or N/A):**

原实现及早期探索性验证发生于维护者明确批准 Proposal/Design 之前，未满足“实施前获批”的时序要求。维护者于 2026-09-09 明确批准 Proposal/Design、确认 SPEC 并授权两个 TASK，允许保留已有探索性实现，同时要求如实披露提前实施情况；批准不追溯生效。

本轮在该批准之后从公开 fork 新 clone，准确检出当前单提交 875bbb9f19316c242304361ae55b804d840e3e04，使用记录的子模块和官方 prebuild，实际重新执行两条规定测试、有效单元 RED、构建和完整 Kind 验证。Design 已在验证前包含具体 Verification Plan；两个 TASK 现已完成并回填命令、结果、公开证据和哈希。整体声明仍为 Noncompliant，不将本轮重新验证表述为对原审批时序的追认。

回填后执行 issue-spec status --repo higress-group/higress --proposal 4659 --design 4661 --json，退出 0；识别到 1 个 confirmed SPEC、2 个 done TASK，traceability.ok=true，errors/warnings 均为空，unknown=0。仍有未匹配英文模板章节名的 info 级提示；此 CLI 结果不代替维护者审批或判断证据质量。

**Trivial-exception explanation (or N/A):**

N/A。AI 参与了实质分析、实现、测试和 PR 材料准备，不属于拼写或格式修正。

**Verified maintainer/administrator exception evidence (or N/A):**

N/A。本贡献不主张维护者/管理员豁免；以下身份核验类别均不适用。

- This PR's number or URL: N/A，未申请维护者/管理员身份豁免。
- Authenticated gh login: N/A，不以该身份主张规范豁免。
- Canonical-repository role_name: N/A，不主张 maintain/admin 权限。
- Actual PR author from gh pr view: N/A，未申请维护者/管理员身份豁免。
- Login/author match: N/A，未使用身份豁免流程。
- Token override attestation: N/A，未运行用于申请该豁免的身份核验流程。
- Bypass rationale: N/A，未申请绕过规划门禁。
- Maintainer live validation: N/A，未申请身份豁免。

**Approved Proposal Issue URL (or N/A with explanation):**

https://github.com/higress-group/higress/issues/4659

**Approved Design Issue URL (or N/A with explanation):**

https://github.com/higress-group/higress/issues/4661

**Maintainer approval link(s) (or N/A with explanation):**

- [Proposal 批准及 SPEC 确认](https://github.com/higress-group/higress/issues/4659#issuecomment-5599220134)
- [Design 批准、TASK 授权与提前实施时间线说明](https://github.com/higress-group/higress/issues/4661#issuecomment-5599224908)
- [维护者在原错误报告中的补充说明](https://github.com/higress-group/higress/issues/4658#issuecomment-5599228216)

**Authorized implementation TASK link(s) (or N/A with explanation):**

[TASK-4661001，done](https://github.com/higress-group/higress/issues/4661#issuecomment-5583040668)，授权依据为上述 Design 审批记录。

**Verification Plan and verification TASK/evidence link(s) (or N/A with explanation):**

- Verification Plan：[Design #4661 的“运行验证计划”](https://github.com/higress-group/higress/issues/4661)
- [TASK-4661002，done](https://github.com/higress-group/higress/issues/4661#issuecomment-5583043963)
- [公开证据包，固定版本](https://gist.github.com/yuefanxiao/98cfdc0e5a74962f45d2181b58366d6f/ea4e6d83a136e7ff2f676a8d9b3c6ba5b92f07e9)
- artifact-manifest.json SHA-256：48d52947d2ec67a4c36242c4e49b885c6237485ee2f474f2bd14b7f3f9269eb4。manifest 包含全部分片哈希，各原始文件亦有独立哈希；已从公网下载并逐文件核对。

## V. Testing and verification

**Test and deterministic rerun commands (or N/A with explanation):**

[本轮固定版本公开证据](https://gist.github.com/yuefanxiao/98cfdc0e5a74962f45d2181b58366d6f/ea4e6d83a136e7ff2f676a8d9b3c6ba5b92f07e9)提供 REPRODUCE.md、复跑脚本、固定输入及逐文件哈希。它记录从新 clone、子模块与官方 prebuild、源码审计到测试、构建、Kind 和清理的完整步骤。实际 argv、cwd、环境覆盖、UTC 起止时间、退出码和原始输出均在 commands/ 与 execution-commands.jsonl。

在 875bbb9 的干净源码根目录完成依赖准备后，使用新建且初始不存在的 GOCACHE，实际依序执行：

~~~sh
export GOMAXPROCS=3
export GOFLAGS='-mod=readonly -p=3'
export GOWORK=off
export GOCACHE="$REPRO/go-cache-final"
go test ./pkg/ingress/kube/gateway/... -count=1
go test ./pkg/ingress/kube/gateway/istio -run '^TestInferencePool' -count=1
~~~

两条均退出 0。全部 Gateway 包于 2026-09-09 12:09:19–12:10:37 UTC 执行，随后定向测试亦通过。对照组仅在独立未修复基线 worktree 临时覆盖来自 875bbb9 的回归测试：单元命令退出 1，6 个失败子用例、2 个顶层测试、12 次错误全为 expected gateway.networking.k8s.io / actual networking.istio.io，编译与测试执行完成；覆盖已恢复且基线干净。

以下入口使用同一证据包中的脚本；REPRO、SOURCE、BASELINE、KIND_BIN 分别是新证据目录、准确修复提交的干净源码目录、独立基线 worktree 和 Kind 0.30.0 路径。完整前置条件、记录包装命令和清理见 REPRODUCE.md。

~~~sh
python3 "$REPRO/unit_red.py" --source "$SOURCE" --baseline "$BASELINE"
python3 "$REPRO/build_images.py" --source "$SOURCE" --baseline "$BASELINE"
python3 "$REPRO/runtime_flow.py" prepare --source "$SOURCE" --kind "$KIND_BIN"
python3 "$REPRO/run_runtime.py" --source "$SOURCE" --kind "$KIND_BIN"
python3 "$REPRO/summarize_verification.py" --source "$SOURCE"
~~~

run_runtime.py 顺序完成基线、保留旧状态升级、两次重启、新建资源和专用集群清理；基线预期错误由脚本单独断言。关键原始日志哈希如下，其他全部文件哈希见证据 manifest 与分片。

| 执行记录 | 退出码 | 原始 .log SHA-256 |
| --- | --- | --- |
| final-gateway-empty-cache | 0 | 5f0462525c6407bdd912768a1fed99bfc881275a54b4aec084dc7a9890922c7a |
| final-targeted | 0 | 3249337a89b52085e2e25738d8ea253bb519090631f48d56b5519204063ecc4f |
| final-unit-red | 1 | 5ee8228f4539a48b1d8bc5f4708abe0d9a295d74bde1f2baec1fc98ed31a62db |
| baseline-correct-assertion | 1 | bb13e45cc91d4f1f647876bc283c6ea6620330c24c803af9553803ad0b82d98f |
| upgraded-verify | 0 | 3e56f69679bf53623d40e4afa5cac2f9ff6df831b60839331a28c02de3fb54c9 |
| restart-1-verify | 0 | 2b0800e44861368ae4a06e5c4074eade9c5ec3deab5f032ef7c297636bc7b584 |
| restart-2-verify | 0 | 8b25879d8bf8a35e62ff5876940430c5046f91f294a8f95e562a0ab4d37eab67 |
| clean-fixed-verify | 0 | 09e3be4bf32038007f4295cc2276afee8906d791df09a8c7cb01331322f637ef |
| cleanup-kind | 0 | cf62c5d6cdb96e94429915a49dbd5b6f0d86dbb595738030189694c0264c5115 |
| cleanup-containers | 0 | e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855 |

**Environment and configuration (or N/A with explanation):**

macOS 26.2 ARM64、Go 1.26.0、OrbStack Docker context、Helm 4.1.1、Kind 0.30.0、Kubernetes 1.34.0、Gateway API CRD 1.5.0、GIE CRD 1.4.0；完整实际版本见 environment.json。专用集群 higress-parentref-4659 使用独立 kubeconfig，启用 Gateway API、Inference Extension 和状态写回。

两组使用相同 chart、CRD、辅助镜像及清单，Helm values 仅 controller.tag 不同；场景覆盖同命名空间与跨命名空间关联，并提供有效 endpointPickerRef Service。节点镜像固定为 docker.m.daocloud.io/kindest/node@sha256:7416a61b42b1662ca6ca89f02028ac133a309a2a30ba309614e8ec94d976dc5a。

**Exact tested revision, version, image tag/digest, manifests, and values (or N/A with explanation):**

当前交付和本轮实际受测源码均为 [875bbb9f19316c242304361ae55b804d840e3e04](https://github.com/yuefanxiao/higress/commit/875bbb9f19316c242304361ae55b804d840e3e04)，相对 dc0999326b1a8df4269c13d0cf6ee2b725259f6e 仅一个提交，包含修复、回归测试和 changes 说明。Author、Committer 与 Signed-off-by 均为 yuefanxiao <74059346+yuefanxiao@users.noreply.github.com>，GitHub 已正确关联。

本轮从公开 fork 新 clone 后 detached 到该 SHA，五个记录的 Go 子模块和实际 external 副本中 8,962 个跟踪文件逐一与 Git blob 一致。测试前和构建后均审计通过；实际 go import/replace 路径指向本轮干净目录中的 external/istio。原执行记录是本轮新生成的记录。

- 基线源码：dc0999326b1a8df4269c13d0cf6ee2b725259f6e。
- 修复源码：875bbb9f19316c242304361ae55b804d840e3e04。
- 基线镜像 tag：localhost/higress/higress:parentref-4658-baseline-20260909；imageID：sha256:d83471487dfcb88fe51d563ecf58771cb26883d7201130e667ab24d9aac9095b。
- 修复镜像 tag：localhost/higress/higress:parentref-4658-fixed-20260909；imageID：sha256:7e91d647ef1f67cd8c94dc3192e7ec55534e3e25c8e9370f8f776f02988dbdd2。
- 修复二进制 SHA-256：4c917debe0cccd607ab18b590fc9d7e6fe92dd87dd58182128a7e9edb68ead93；实际内嵌 vcs.revision=875bbb9f19316c242304361ae55b804d840e3e04、vcs.modified=false。
- 基线二进制 SHA-256：c1134a3d6f8c652d50e4baf9b58a48400a533e1c2f3ed2c9cac896d24e0e9be8；无内嵌 VCS 字段，来源由干净基线前后审计、实际构建命令及归档哈希绑定。
- Pilot/Gateway 辅助镜像均为 v2.2.4，固定 registry digest、平台 imageID 和归档哈希见 image-identities.json；构建基础镜像固定在所附 Dockerfile 中。
- CRD、values、fixtures、渲染后的安装清单及其哈希见 inputs/、harness/、input-sha256.json、commands/*-manifest.log。

实际 Pod 的 core/pilot/gateway imageID 已与本轮构建归档逐一匹配；归档内 config、revision 标签和实际二进制层哈希亦已直接核对。公开文本包不含约 1.8 GB 的镜像归档及二进制，提供产物哈希与固定源码重建方法。

**Baseline reproduction evidence for bug fixes (or N/A with explanation):**

[固定证据包](https://gist.github.com/yuefanxiao/98cfdc0e5a74962f45d2181b58366d6f/ea4e6d83a136e7ff2f676a8d9b3c6ba5b92f07e9)中的 runtime/baseline/ 和 runtime/baseline-correct-assertion/。

两个场景都已被目标 Gateway 接受，条件与 observedGeneration 正常；正确完整身份断言退出 1，只有两处 parentRef.group=networking.istio.io 错误，其他前置错误为空。未就绪、超时、下载故障和构建失败没有被记作缺陷复现。

**Fixed-version verification evidence for bug fixes (or N/A with explanation):**

verification-summary.json 汇总本轮五阶段交叉检查，passed=true。runtime/upgraded/、restart-1/、restart-2/、clean-fixed/ 提供原始状态、前后实例及断言；commands/ 提供执行记录与指标。

升级和两次重启保留原资源 UID/spec，显式绑定前序/当前不同 Pod UID、容器启动时间和读取状态前的精确 InferenceExtension 同步日志。各 Pool 正确引用=1、旧错误引用=0；新建轮次七个命名空间资源 UID 全部更换，同/跨命名空间场景均通过。各阶段检查 Accepted/ResolvedRefs 和 observedGeneration，状态收敛超时为 180 秒。没有手工修补 status。

全部运行阶段于 2026-09-09 12:18:50–12:20:20 UTC 完成。专用 Kind 删除成功，对应标签容器为零，清理命令退出 0。

**Wasm source revision and SHA-256 (or N/A with explanation):**

N/A。本次修改 Go 控制面的父状态生成逻辑，未修改或构建 Wasm 模块。

## VI. Special notes for reviewers

维护者要求的准确提交可复现性已提供直接实跑证据：875bbb9 的干净检出、记录的依赖、两条测试、构建产物与实际运行 Pod 可以逐项对应。没有额外未提交的产品补丁或依赖修改。该 head 的两个 Go 文件和依赖相对此前 0846dc1 没有变化，增加了 changes 说明；本次没有复现维护者原环境的 kube.InferencePoolEndpointPicker* 缺符号错误。原失败环境的实际根因仍未知，不能据此声称已定位或修复其环境。

独立代码规范复核覆盖基线到 875bbb9 的三个文件；本轮独立运行证据复核关闭了此前“合并提交后未重新实跑”的 P2，未发现新阻断项。报告见 final-standards-review.md 和 final-independent-review.md。公开包及 TASK 另已回读验证。

日志来源限制：runtime/{upgraded,restart-1,restart-2}-logs/controller.log 的 deployment 日志命令分别选中了旧基线 Pod、旧基线 Pod、上次 fixed Pod，不能称为当轮新 Pod 的全容器日志。当轮当前 higress-core 日志在 runtime/<phase>/controller-sync.log，已绑定 Pod、containerID、启动时间与读取前后身份；指标来自明确的当前 Pod。重启阶段证明新实例完成计算且引用正确，不宣称 resourceVersion 未变时发生了新 PATCH。

修复未改变条件计算、API/CRD、配置项或消费者匹配策略。依赖错误 group 的临时兼容逻辑可能需要调整，回退控制器镜像也可能重新写出错误引用。证据仅确认父引用生成与正常协调纠正，不覆盖 GPU、真实模型推理、生产或下游 RPO，不将状态缺陷扩大为推理数据面或模型工作负载不可用。

上游 CI/Codecov 与维护者最终审阅尚待完成。

## VII. AI coding disclosure

**Tool(s) used (or N/A):**

OpenAI Codex，含只读评审代理。

### Prompts or instructions

按 [Design #4661](https://github.com/higress-group/higress/issues/4661) 及其两个 TASK，以最小改动修复父引用，补齐回归测试和 Kind 验证。

### AI-assisted work summary

AI 参与分析、代码/测试、验证及 PR 准备。修复限于父引用常量，验证限于控制面；提前实施的披露见第 IV 节。
