### PR TITLE
docs: fix typo and punctuation in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 [![CNCF Sandbox](https://img.shields.io/badge/CNCF-Sandbox-30638E?logo=linuxfoundation&logoColor=white)](https://www.cncf.io/projects/)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/12667/badge)](https://www.bestpractices.dev/projects/12667)
 
-<a href="https://trendshift.io/repositories/26458" target="_blank"><img src="https://trendshift.io/api/badge/repositories/26458" alt="higress-group%2Fhigress | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/></a> <a href="https://www.producthunt.com/posts/higress?embed=true&utm_source=badge-featured&utm_medium=badge&utm_souce=badge-higress" target="_blank"><img src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=951287&theme=light&t=1745492822283" alt="Higress - Global&#0032;APIs&#0032;as&#0032;MCP&#0032;powered&#0032;by&#0032;AI&#0032;Gateway | Product Hunt" style="width: 250px; height: 54px;" width="250" height="54" /></a>
+<a href="https://trendshift.io/repositories/26458" target="_blank"><img src="https://trendshift.io/api/badge/repositories/26458" alt="higress-group%2Fhigress | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/></a> <a href="https://www.producthunt.com/posts/higress?embed=true&utm_source=badge-featured&utm_medium=badge&utm_source=badge-higress" target="_blank"><img src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=951287&theme=light&t=1745492822283" alt="Higress - Global&#0032;APIs&#0032;as&#0032;MCP&#0032;powered&#0032;by&#0032;AI&#0032;Gateway | Product Hunt" style="width: 250px; height: 54px;" width="250" height="54" /></a>
 
 </div>
 
@@ -226,8 +226,8 @@ Higress would not be possible without the valuable open-source work of projects 
 
 - Higress Console: https://github.com/higress-group/higress-console
 - Higress Standalone: https://github.com/higress-group/higress-standalone
-- Higress Plugin Server：https://github.com/higress-group/plugin-server
-- Higress Wasm Plugin Golang SDK：https://github.com/higress-group/wasm-go
+- Higress Plugin Server: https://github.com/higress-group/plugin-server
+- Higress Wasm Plugin Golang SDK: https://github.com/higress-group/wasm-go
 
 ### Contributors
 


### PR DESCRIPTION
## I. Summary
Fix `utm_souce` → `utm_source` typo in the Product Hunt badge URL, and normalize fullwidth colons to ASCII colons in the Related Repositories section of README.md.

## II. Related issue
N/A

## III. Change type
- [x] Documentation or configuration only

## IV. Agent participation and issue-spec gate
- [x] Trivial agent-use exception (spelling, punctuation, whitespace, or formatting only)

Agent assistance was limited to locating and applying spelling and punctuation fixes. No substantive choices or behavioral changes were made. The changes are purely typographical corrections.

AI-assisted work summary:
- Prompt: "Fix typos and punctuation issues in README.md"
- Work performed: Located and corrected `utm_souce` → `utm_source`, and replaced fullwidth colons (：) with ASCII colons (:) for consistency in the Related Repositories section.