### PR TITLE
feat: [plugins] model-router plugin add agent loop affinity || feat: [plugins] model-router plugin add agent affinity loop

### DIFF
--- a/plugins/wasm-go/extensions/model-router/README.md
+++ b/plugins/wasm-go/extensions/model-router/README.md
@@ -11,6 +11,7 @@
 | `enableOnPathSuffix` | array of string | 选填                    | ["/completions","/embeddings","/images/generations","/audio/speech","/fine_tuning/jobs","/moderations","/image-synthesis","/video-synthesis","/rerank","/messages"] | 只对这些特定路径后缀的请求生效，可以配置为 "*" 以匹配所有路径 |
 | `keepOriginalModelName` | bool         | 选填                    | false                    | 配合 `addProviderHeader` 使用，设为 true 时仍提取 provider 写入 header，但不改写请求体中的 model 字段 |
 | `autoRouting`        | object          | 选填                    | -                        | 自动路由配置，详见下方说明                            |
+| `redis`        | object          | 选填                    | -                        | 自动路由agent模式下需要的redis配置                            |
 
 ### autoRouting 配置
 
@@ -19,6 +20,15 @@
 | `enable`       | bool            | 必填     | false  | 是否启用自动路由功能                                         |
 | `defaultModel` | string          | 选填     | -      | 当没有规则匹配时使用的默认模型                               |
 | `rules`        | array of object | 选填     | -      | 路由规则数组，按顺序匹配                                     |
+| `agentMode`        | bool | 选填     | -      | 是否启用agent优化模式                                    |
+
+### redis配置
+| 名称           | 数据类型        | 填写要求 | 默认值 | 描述                                                         |
+| -------------- | --------------- | -------- | ------ | ------------------------------------------------------------ |
+| `service_name` | string          | 选填     | -      | redis的static service name                               |
+| `service_port`        | array of object | 选填     | -      | redis需要的port                                     |
+| `timeout`        | int | 选填     | -      | 超时时间                                   |
+
 
 ### rules 配置
 
@@ -137,17 +147,27 @@ keepOriginalModelName: true
 
 ```yaml
 autoRouting:
-  enable: true
-  defaultModel: "qwen-turbo"
-  rules:
-    - pattern: "(?i)(画|绘|生成图|图片|image|draw|paint)"
-      model: "qwen-vl-max"
-    - pattern: "(?i)(代码|编程|code|program|function|debug)"
-      model: "qwen-coder"
-    - pattern: "(?i)(翻译|translate|translation)"
-      model: "qwen-turbo"
-    - pattern: "(?i)(数学|计算|math|calculate)"
-      model: "qwen-math"
+    agentMode: true
+    defaultModel: gpt-5.6-sol
+    enable: true
+    rules:
+    - model: qwen-vl-max
+      pattern: (?i)(画|绘|生成图|图片|image|draw|paint)
+    - model: qwen-coder
+      pattern: (?i)(代码|编程|code|program|function|debug)
+    - model: qwen-turbo
+      pattern: (?i)(翻译|translate|translation)
+    - model: qwen-math
+      pattern: (?i)(数学|计算|math|calculate)
+    enable: true
+    modelKey: model
+    modelToHeader: x-higress-llm-model
+    redis:
+      database: 1
+      redis_key_prefix: 'chat_quota:'
+      service_name: redis.dns
+      service_port: 6379
+      timeout: 2000
 ```
 
 #### 工作原理
@@ -158,6 +178,8 @@ autoRouting:
 4. 匹配成功时，将对应的 model 值设置到 `x-higress-llm-model` 请求头
 5. 如果所有规则都未匹配，则使用 `defaultModel` 配置的默认模型
 6. 如果未配置 `defaultModel` 且无规则匹配，则不设置路由头（会记录警告日志）
+7. 针对agent loop做了优化，实现单一agent loop下可以路由到同一个模型，避免agent反复思考会被路由到不同模型，导致质量不一
+
 
 #### 使用示例
 

--- a/plugins/wasm-go/extensions/model-router/ai-client-context/codex.go
+++ b/plugins/wasm-go/extensions/model-router/ai-client-context/codex.go
@@ -1,0 +1,64 @@
+package aiclientcontext
+
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/higress-group/proxy-wasm-go-sdk/proxywasm"
+	"github.com/higress-group/wasm-go/pkg/log"
+)
+
+type CodexClient struct{}
+
+type codex_metadataType struct {
+	XCodexInstallationId string `json:"x-codex-installation-id,omitempty"`
+	TurnId               string `json:"turn_id,omitempty"`
+	XCodexTurnMetadata   string `json:"x-codex-turn-metadata,omitempty"`
+	ThreadId             string `json:"thread_id,omitempty"`
+	SessionId            string `json:"session_id,omitempty"`
+	XCodexWindowId       string `json:"x-codex-window-id,omitempty"`
+}
+
+type codexMetadata struct {
+	ClientMetadata codex_metadataType `json:"client_metadata,omitempty"`
+}
+
+func (c *CodexClient) Name() string {
+	return "codex"
+}
+
+func (c *CodexClient) Match() bool {
+	userAgent, err := proxywasm.GetHttpRequestHeader("User-Agent")
+	if err != nil {
+		originator, err := proxywasm.GetHttpRequestHeader("Originator")
+		if err != nil {
+			return false
+		}
+		strings.Contains(strings.ToLower(originator), "codex")
+	}
+
+	return strings.Contains(strings.ToLower(userAgent), "codex")
+}
+
+func (c *CodexClient) ExtractContext(body []byte) (*Context, bool) {
+	metadata, _ := proxywasm.GetHttpRequestHeader("X-Codex-Turn-Metadata")
+	var codexMetadataType codex_metadataType
+	if err := json.Unmarshal([]byte(metadata), &codexMetadataType); err != nil || codexMetadataType.TurnId == "" {
+		log.Warnf("Header X-Codex-Turn-Metadata parse failed, %s", err.Error())
+		var codexBodyMetadata codexMetadata
+		if err := json.Unmarshal(body, &codexBodyMetadata); err != nil || codexBodyMetadata.ClientMetadata.TurnId == "" {
+			return &Context{}, false
+		}
+		return &Context{
+			ClientType: "Codex",
+			LoopID:     codexBodyMetadata.ClientMetadata.TurnId,
+			LoopIDKey:  PrefixKey + codexBodyMetadata.ClientMetadata.TurnId,
+		}, true
+	}
+
+	return &Context{
+		ClientType: "Codex",
+		LoopID:     codexMetadataType.TurnId,
+		LoopIDKey:  PrefixKey + codexMetadataType.TurnId,
+	}, true
+}

--- a/plugins/wasm-go/extensions/model-router/ai-client-context/interface.go
+++ b/plugins/wasm-go/extensions/model-router/ai-client-context/interface.go
@@ -1,0 +1,33 @@
+package aiclientcontext
+
+const PrefixKey = "model-router:agentaffinity:"
+
+type ClientType string
+
+// 通过UserAgent Header来判断对应Agent框架
+const (
+	ClientUnknown    ClientType = "unknown"
+	ClientCodex      ClientType = "codex"
+	ClientClaudeCode ClientType = "claude-code"
+	ClientDSHarness  ClientType = "ds-harness"
+)
+
+// 最终归一化结构体
+type Context struct {
+	ClientType ClientType
+	LoopID     string
+	LoopIDKey  string
+}
+
+// 抽象接口
+type Client interface {
+	Name() string //Client名字
+	Match() bool
+	ExtractContext(body []byte) (*Context, bool) //判断的对应框架唯一的agent loop id 做单一loop的模型亲和
+}
+
+func NewClientList() []Client {
+	return []Client{
+		&CodexClient{},
+	}
+}

--- a/plugins/wasm-go/extensions/model-router/main.go
+++ b/plugins/wasm-go/extensions/model-router/main.go
@@ -3,9 +3,12 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"io"
 	"mime"
 	"mime/multipart"
+	aiclientcontext "model-router/ai-client-context"
 	"net/http"
 	"net/textproto"
 	"regexp"
@@ -16,6 +19,7 @@ import (
 	"github.com/higress-group/wasm-go/pkg/log"
 	"github.com/higress-group/wasm-go/pkg/wrapper"
 	"github.com/tidwall/gjson"
+	"github.com/tidwall/resp"
 	"github.com/tidwall/sjson"
 )
 
@@ -43,15 +47,28 @@ type AutoRoutingRule struct {
 }
 
 type ModelRouterConfig struct {
+	redisInfo             RedisInfo `yaml:"redis"`
+	RedisKeyPrefix        string    `yaml:"redis_key_prefix"`
 	modelKey              string
 	addProviderHeader     string
 	modelToHeader         string
 	enableOnPathSuffix    []string
 	keepOriginalModelName bool
 	// Auto routing configuration
-	enableAutoRouting bool
-	autoRoutingRules  []AutoRoutingRule
-	defaultModel      string
+	enableAutoRouting          bool
+	enableAutoRoutingAgentMode bool
+	autoRoutingRules           []AutoRoutingRule
+	defaultModel               string
+	redisClient                wrapper.RedisClient
+}
+
+type RedisInfo struct {
+	ServiceName string `required:"true" yaml:"service_name" json:"service_name"`
+	ServicePort int    `required:"false" yaml:"service_port" json:"service_port"`
+	Username    string `required:"false" yaml:"username" json:"username"`
+	Password    string `required:"false" yaml:"password" json:"password"`
+	Timeout     int    `required:"false" yaml:"timeout" json:"timeout"`
+	Database    int    `required:"false" yaml:"database" json:"database"`
 }
 
 func parseConfig(json gjson.Result, config *ModelRouterConfig) error {
@@ -90,6 +107,7 @@ func parseConfig(json gjson.Result, config *ModelRouterConfig) error {
 	if autoRouting.Exists() {
 		config.enableAutoRouting = autoRouting.Get("enable").Bool()
 		config.defaultModel = autoRouting.Get("defaultModel").String()
+		config.enableAutoRoutingAgentMode = autoRouting.Get("agentMode").Bool()
 
 		rules := autoRouting.Get("rules")
 		if rules.Exists() && rules.IsArray() {
@@ -111,6 +129,50 @@ func parseConfig(json gjson.Result, config *ModelRouterConfig) error {
 				})
 				log.Debugf("loaded auto routing rule: pattern=%s, model=%s", patternStr, model)
 			}
+		}
+
+		if config.enableAutoRoutingAgentMode {
+			// Redis
+			config.RedisKeyPrefix = json.Get("redis_key_prefix").String()
+			if config.RedisKeyPrefix == "" {
+				config.RedisKeyPrefix = "chat_quota:"
+			}
+			redisConfig := json.Get("redis")
+			if !redisConfig.Exists() {
+				return errors.New("missing redis in config")
+			}
+			serviceName := redisConfig.Get("service_name").String()
+			if serviceName == "" {
+				return errors.New("redis service name must not be empty")
+			}
+			servicePort := int(redisConfig.Get("service_port").Int())
+			if servicePort == 0 {
+				if strings.HasSuffix(serviceName, ".static") {
+					// use default logic port which is 80 for static service
+					servicePort = 80
+				} else {
+					servicePort = 6379
+				}
+			}
+			username := redisConfig.Get("username").String()
+			password := redisConfig.Get("password").String()
+			timeout := int(redisConfig.Get("timeout").Int())
+			if timeout == 0 {
+				timeout = 1000
+			}
+			database := int(redisConfig.Get("database").Int())
+			config.redisInfo.ServiceName = serviceName
+			config.redisInfo.ServicePort = servicePort
+			config.redisInfo.Username = username
+			config.redisInfo.Password = password
+			config.redisInfo.Timeout = timeout
+			config.redisInfo.Database = database
+			config.redisClient = wrapper.NewRedisClusterClient(wrapper.FQDNCluster{
+				FQDN: serviceName,
+				Port: int64(servicePort),
+			})
+
+			return config.redisClient.Init(username, password, int64(timeout), wrapper.WithDataBase(database))
 		}
 	}
 
@@ -166,27 +228,83 @@ func onHttpRequestBody(ctx wrapper.HttpContext, config ModelRouterConfig, body [
 
 // extractLastUserMessage extracts the content of the last message with role "user" from the messages array
 func extractLastUserMessage(body []byte) string {
+	// Chat Completions API
 	messages := gjson.GetBytes(body, "messages")
-	if !messages.Exists() || !messages.IsArray() {
+	if messages.Exists() && messages.IsArray() {
+		return extractLastUserFromMessages(messages)
+	}
+
+	// Responses API
+	input := gjson.GetBytes(body, "input")
+	if input.Exists() {
+		return extractLastUserFromInput(input)
+	}
+
+	return ""
+}
+
+func extractLastUserFromMessages(messages gjson.Result) string {
+	var lastUserContent string
+
+	for _, msg := range messages.Array() {
+		if msg.Get("role").String() != "user" {
+			continue
+		}
+
+		content := msg.Get("content")
+
+		if content.IsArray() {
+			for _, item := range content.Array() {
+				if item.Get("type").String() == "text" {
+					lastUserContent = item.Get("text").String()
+				}
+			}
+		} else if content.Type == gjson.String {
+			lastUserContent = content.String()
+		}
+	}
+
+	return lastUserContent
+}
+
+func extractLastUserFromInput(input gjson.Result) string {
+	// input: "hello"
+	if input.Type == gjson.String {
+		return input.String()
+	}
+
+	if !input.IsArray() {
 		return ""
 	}
 
 	var lastUserContent string
-	for _, msg := range messages.Array() {
-		if msg.Get("role").String() == "user" {
-			content := msg.Get("content")
-			if content.IsArray() {
-				// Handle array content (e.g., multimodal messages with text and images)
-				for _, item := range content.Array() {
-					if item.Get("type").String() == "text" {
-						lastUserContent = item.Get("text").String()
+
+	for _, item := range input.Array() {
+		if item.Get("role").String() != "user" {
+			continue
+		}
+
+		content := item.Get("content")
+
+		// content: "hello"
+		if content.Type == gjson.String {
+			lastUserContent = content.String()
+			continue
+		}
+
+		// content: [{type:"input_text", text:"hello"}]
+		if content.IsArray() {
+			for _, part := range content.Array() {
+				switch part.Get("type").String() {
+				case "input_text", "text":
+					if text := part.Get("text").String(); text != "" {
+						lastUserContent = text
 					}
 				}
-			} else {
-				lastUserContent = content.String()
 			}
 		}
 	}
+
 	return lastUserContent
 }
 
@@ -216,9 +334,57 @@ func handleJsonBody(ctx wrapper.HttpContext, config ModelRouterConfig, body []by
 		userMessage := extractLastUserMessage(body)
 		var targetModel string
 		if userMessage != "" {
-			if matchedModel, found := matchAutoRoutingRule(config, userMessage); found {
-				targetModel = matchedModel
-				log.Infof("auto routing: user message matched, routing to model: %s", matchedModel)
+			if config.enableAutoRoutingAgentMode {
+				var agentLoopID string
+				for _, client := range aiclientcontext.NewClientList() {
+					if !client.Match() {
+						continue
+					}
+					agentMetadata, ok := client.ExtractContext(body)
+					if !ok {
+						break
+					}
+					agentLoopID = agentMetadata.LoopID
+				}
+				err := getAgentLoopIdFromRedis(config.redisClient, agentLoopID, func(value string, err error) {
+					if err != nil || value == "" {
+						log.Errorf("get agent loop id  failed: %v", err)
+						if matchedModel, found := matchAutoRoutingRule(config, userMessage); found {
+							targetModel = matchedModel
+							log.Infof("auto routing: user message matched, routing to model: %s", matchedModel)
+						}
+						err = insertAgentLoopIdInRedis(config.redisClient, agentLoopID, targetModel, func(err error) {
+							if err != nil {
+								log.Errorf("insert redis failed: %v", err)
+								return
+							}
+
+							log.Infof("insert redis success")
+						})
+
+						if err != nil {
+							log.Errorf("dispatch redis call failed: %v", err)
+						}
+
+					} else {
+						log.Infof("get agent loop id success, value is %s", value)
+						targetModel = value
+					}
+
+					proxywasm.ResumeHttpRequest()
+
+				})
+				if err != nil {
+					log.Errorf("get agent loop id function failed: %v", err)
+					return types.ActionContinue
+				}
+
+				return types.ActionPause
+			} else {
+				if matchedModel, found := matchAutoRoutingRule(config, userMessage); found {
+					targetModel = matchedModel
+					log.Infof("auto routing: user message matched, routing to model: %s", matchedModel)
+				}
 			}
 		}
 		// No rule matched, use default model if configured
@@ -270,6 +436,76 @@ func handleJsonBody(ctx wrapper.HttpContext, config ModelRouterConfig, body []by
 	}
 
 	return types.ActionContinue
+}
+
+func insertAgentLoopIdInRedis(
+	client wrapper.RedisClient,
+	turnId string,
+	modelValue string,
+	onDone func(error),
+) error {
+
+	key := fmt.Sprintf(
+		"%s%s",
+		aiclientcontext.PrefixKey,
+		turnId,
+	)
+
+	err := client.Command(
+		[]interface{}{
+			"SET",
+			key,
+			modelValue,
+		},
+		func(response resp.Value) {
+			if response.Error() != nil {
+				onDone(response.Error())
+				return
+			}
+
+			onDone(nil)
+		},
+	)
+
+	return err
+}
+
+func getAgentLoopIdFromRedis(
+	client wrapper.RedisClient,
+	turnId string,
+	onDone func(string, error),
+) error {
+
+	key := fmt.Sprintf(
+		"%s%s",
+		aiclientcontext.PrefixKey,
+		turnId,
+	)
+
+	err := client.Command(
+		[]interface{}{
+			"GET",
+			key,
+		},
+		func(response resp.Value) {
+			if response.Error() != nil {
+				onDone("", response.Error())
+				return
+			}
+
+			// Redis key 不存在
+			if response.Type == nil {
+				onDone("", nil)
+				return
+			}
+
+			value := response.String()
+
+			onDone(value, nil)
+		},
+	)
+
+	return err
 }
 
 func handleMultipartBody(ctx wrapper.HttpContext, config ModelRouterConfig, body []byte, contentType string) types.Action {


### PR DESCRIPTION
为model-router插件增加了针对agent单一loop的模型亲和性优化，避免发生单一agent loop路由到不同模型的情况， 当前只支持了codex，后续会增加claude code、dsh-harness等等
<!--This is a translation content dividing line, the content below is generated by machine, please do not modify the content below-->
---
Added model affinity optimization for a single agent loop to the model-router plug-in to avoid the situation where a single agent loop is routed to different models. Currently, only codex is supported, and claude code, dsh-harness, etc. will be added in the future
