### PR TITLE
feat(ai-proxy): add support for DaoXE provider

### DIFF
--- a/plugins/wasm-go/extensions/ai-proxy/README.md
+++ b/plugins/wasm-go/extensions/ai-proxy/README.md
@@ -202,6 +202,10 @@ Fireworks AI 所对应的 `type` 为 `fireworks`。它并无特有的配置字�
 
 Galadriel 所对应的 `type` 为 `galadriel`。它并无特有的配置字段。
 
+#### DaoXE
+
+DaoXE 所对应的 `type` 为 `daoxe`。它并无特有的配置字段。
+
 #### 文心一言（Baidu）
 
 文心一言所对应的 `type` 为 `baidu`。它并无特有的配置字段。
@@ -1206,6 +1210,62 @@ provider:
   ],
   "created": 1728558433,
   "model": "neuralmagic/Meta-Llama-3.1-8B-Instruct-FP8",
+  "object": "chat.completion",
+  "service_tier": null,
+  "system_fingerprint": null
+}
+```
+
+### 使用 OpenAI 协议代理 DaoXE 服务
+
+**配置信息**
+
+```yaml
+provider:
+  type: daoxe
+  apiTokens:
+    - "YOUR_DAOXE_API_TOKEN"
+  modelMapping:
+    "gpt-4": "claude-sonnet-4"
+    "gpt-3.5-turbo": "gpt-4o-mini"
+    "*": "gpt-4o-mini"
+```
+
+**请求示例**
+
+```json
+{
+  "model": "gpt-4o-mini",
+  "messages": [
+    {
+      "role": "user",
+      "content": "你好，你是谁？"
+    }
+  ]
+}
+```
+
+**响应示例**
+
+```json
+{
+  "id": "chatcmpl-example",
+  "choices": [
+    {
+      "finish_reason": "stop",
+      "index": 0,
+      "logprobs": null,
+      "message": {
+        "content": "你好！我是一个AI助手。",
+        "refusal": null,
+        "role": "assistant",
+        "function_call": null,
+        "tool_calls": null
+      }
+    }
+  ],
+  "created": 1728558433,
+  "model": "gpt-4o-mini",
   "object": "chat.completion",
   "service_tier": null,
   "system_fingerprint": null

--- a/plugins/wasm-go/extensions/ai-proxy/README_EN.md
+++ b/plugins/wasm-go/extensions/ai-proxy/README_EN.md
@@ -186,6 +186,10 @@ For Fireworks AI, the corresponding `type` is `fireworks`. It has no unique conf
 
 For Galadriel, the corresponding `type` is `galadriel`. It has no unique configuration fields.
 
+#### DaoXE
+
+For DaoXE, the corresponding `type` is `daoxe`. It has no unique configuration fields.
+
 #### ERNIE Bot
 
 For ERNIE Bot, the corresponding `type` is `baidu`. It has no unique configuration fields.
@@ -1156,6 +1160,62 @@ provider:
   ],
   "created": 1728558433,
   "model": "neuralmagic/Meta-Llama-3.1-8B-Instruct-FP8",
+  "object": "chat.completion",
+  "service_tier": null,
+  "system_fingerprint": null
+}
+```
+
+### Using OpenAI Protocol Proxy for DaoXE Service
+
+**Configuration Information**
+
+```yaml
+provider:
+  type: daoxe
+  apiTokens:
+    - "YOUR_DAOXE_API_TOKEN"
+  modelMapping:
+    "gpt-4": "claude-sonnet-4"
+    "gpt-3.5-turbo": "gpt-4o-mini"
+    "*": "gpt-4o-mini"
+```
+
+**Example Request**
+
+```json
+{
+  "model": "gpt-4o-mini",
+  "messages": [
+    {
+      "role": "user",
+      "content": "Hello, who are you?"
+    }
+  ]
+}
+```
+
+**Example Response**
+
+```json
+{
+  "id": "chatcmpl-example",
+  "choices": [
+    {
+      "finish_reason": "stop",
+      "index": 0,
+      "logprobs": null,
+      "message": {
+        "content": "Hello! I am an AI assistant.",
+        "refusal": null,
+        "role": "assistant",
+        "function_call": null,
+        "tool_calls": null
+      }
+    }
+  ],
+  "created": 1728558433,
+  "model": "gpt-4o-mini",
   "object": "chat.completion",
   "service_tier": null,
   "system_fingerprint": null

--- a/plugins/wasm-go/extensions/ai-proxy/main_test.go
+++ b/plugins/wasm-go/extensions/ai-proxy/main_test.go
@@ -329,6 +329,15 @@ func TestGaladriel(t *testing.T) {
 	test.RunGaladrielOnStreamingResponseBodyTests(t)
 }
 
+func TestDaoxe(t *testing.T) {
+	test.RunDaoxeParseConfigTests(t)
+	test.RunDaoxeOnHttpRequestHeadersTests(t)
+	test.RunDaoxeOnHttpRequestBodyTests(t)
+	test.RunDaoxeOnHttpResponseHeadersTests(t)
+	test.RunDaoxeOnHttpResponseBodyTests(t)
+	test.RunDaoxeOnStreamingResponseBodyTests(t)
+}
+
 func TestMinimax(t *testing.T) {
 	test.RunMinimaxBasePathHandlingTests(t)
 }

--- a/plugins/wasm-go/extensions/ai-proxy/provider/daoxe.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/daoxe.go
@@ -1,0 +1,93 @@
+package provider
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+
+	"github.com/alibaba/higress/plugins/wasm-go/extensions/ai-proxy/util"
+	"github.com/higress-group/proxy-wasm-go-sdk/proxywasm/types"
+	"github.com/higress-group/wasm-go/pkg/wrapper"
+)
+
+// daoxeProvider is the provider for the DaoXE service (https://daoxe.com),
+// an OpenAI-compatible multi-model LLM gateway.
+
+const (
+	daoxeDomain = "api.daoxe.com"
+)
+
+type daoxeProviderInitializer struct{}
+
+func (m *daoxeProviderInitializer) ValidateConfig(config *ProviderConfig) error {
+	if config.apiTokens == nil || len(config.apiTokens) == 0 {
+		return errors.New("no apiToken found in provider config")
+	}
+	return nil
+}
+
+func (m *daoxeProviderInitializer) DefaultCapabilities() map[string]string {
+	return map[string]string{
+		string(ApiNameChatCompletion): PathOpenAIChatCompletions,
+		string(ApiNameCompletion):     PathOpenAICompletions,
+		string(ApiNameModels):         PathOpenAIModels,
+	}
+}
+
+func (m *daoxeProviderInitializer) CreateProvider(config ProviderConfig) (Provider, error) {
+	config.setDefaultCapabilities(m.DefaultCapabilities())
+	return &daoxeProvider{
+		config:       config,
+		contextCache: createContextCache(&config),
+	}, nil
+}
+
+type daoxeProvider struct {
+	config       ProviderConfig
+	contextCache *contextCache
+}
+
+func (d *daoxeProvider) GetProviderType() string {
+	return providerTypeDaoxe
+}
+
+func (d *daoxeProvider) OnRequestHeaders(ctx wrapper.HttpContext, apiName ApiName) error {
+	d.config.handleRequestHeaders(d, ctx, apiName)
+	return nil
+}
+
+func (d *daoxeProvider) OnRequestBody(ctx wrapper.HttpContext, apiName ApiName, body []byte) (types.Action, error) {
+	if !d.config.isSupportedAPI(apiName) {
+		return types.ActionContinue, errUnsupportedApiName
+	}
+	return d.config.handleRequestBody(d, d.contextCache, ctx, apiName, body)
+}
+
+func (d *daoxeProvider) OnStreamingResponseBody(ctx wrapper.HttpContext, apiName ApiName, chunk []byte, isLastChunk bool) ([]byte, error) {
+	if len(chunk) == 0 {
+		return nil, nil
+	}
+	// DaoXE chat completion streams use the OpenAI-compatible SSE format,
+	// so no provider-specific conversion is required here.
+	return chunk, nil
+}
+
+func (d *daoxeProvider) TransformRequestHeaders(ctx wrapper.HttpContext, apiName ApiName, headers http.Header) {
+	util.OverwriteRequestPathHeaderByCapability(headers, string(apiName), d.config.capabilities)
+	util.OverwriteRequestHostHeader(headers, daoxeDomain)
+	util.OverwriteRequestAuthorizationHeader(headers, "Bearer "+d.config.GetApiTokenInUse(ctx))
+	headers.Del("Content-Length")
+}
+
+func (d *daoxeProvider) GetApiName(path string) ApiName {
+	if strings.Contains(path, PathOpenAIChatCompletions) {
+		return ApiNameChatCompletion
+	}
+	if strings.Contains(path, PathOpenAICompletions) {
+		return ApiNameCompletion
+	}
+	if strings.Contains(path, PathOpenAIModels) {
+		return ApiNameModels
+	}
+	return ""
+}

--- a/plugins/wasm-go/extensions/ai-proxy/provider/provider.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/provider.go
@@ -162,6 +162,7 @@ const (
 	providerTypeLongcat    = "longcat"
 	providerTypeFireworks  = "fireworks"
 	providerTypeGaladriel  = "galadriel"
+	providerTypeDaoxe      = "daoxe"
 	providerTypeVllm       = "vllm"
 	providerTypeGeneric    = "generic"
 	providerTypeKling      = "kling"
@@ -269,6 +270,7 @@ var (
 		providerTypeLongcat:    &longcatProviderInitializer{},
 		providerTypeFireworks:  &fireworksProviderInitializer{},
 		providerTypeGaladriel:  &galadrielProviderInitializer{},
+		providerTypeDaoxe:      &daoxeProviderInitializer{},
 		providerTypeVllm:       &vllmProviderInitializer{},
 		providerTypeGeneric:    &genericProviderInitializer{},
 		providerTypeKling:      &klingProviderInitializer{},

--- a/plugins/wasm-go/extensions/ai-proxy/test/daoxe.go
+++ b/plugins/wasm-go/extensions/ai-proxy/test/daoxe.go
@@ -1,0 +1,435 @@
+package test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/higress-group/proxy-wasm-go-sdk/proxywasm/types"
+	"github.com/higress-group/wasm-go/pkg/test"
+	"github.com/stretchr/testify/require"
+)
+
+// 测试配置：基本 DaoXE 配置
+var basicDaoxeConfig = func() json.RawMessage {
+	data, _ := json.Marshal(map[string]interface{}{
+		"provider": map[string]interface{}{
+			"type":      "daoxe",
+			"apiTokens": []string{"sk-daoxe-test123456789"},
+			"modelMapping": map[string]string{
+				"*": "gpt-4o-mini",
+			},
+		},
+	})
+	return data
+}()
+
+// 测试配置：DaoXE 多模型配置
+var daoxeMultiModelConfig = func() json.RawMessage {
+	data, _ := json.Marshal(map[string]interface{}{
+		"provider": map[string]interface{}{
+			"type":      "daoxe",
+			"apiTokens": []string{"sk-daoxe-multi-model"},
+			"modelMapping": map[string]string{
+				"gpt-4":         "claude-sonnet-4",
+				"gpt-3.5-turbo": "gpt-4o-mini",
+			},
+		},
+	})
+	return data
+}()
+
+// 测试配置：无效 DaoXE 配置（缺少 apiToken）
+var invalidDaoxeConfig = func() json.RawMessage {
+	data, _ := json.Marshal(map[string]interface{}{
+		"provider": map[string]interface{}{
+			"type":         "daoxe",
+			"apiTokens":    []string{},
+			"modelMapping": map[string]string{},
+		},
+	})
+	return data
+}()
+
+// 测试配置：完整 DaoXE 配置
+var completeDaoxeConfig = func() json.RawMessage {
+	data, _ := json.Marshal(map[string]interface{}{
+		"provider": map[string]interface{}{
+			"type":      "daoxe",
+			"apiTokens": []string{"sk-daoxe-complete-test"},
+			"timeout":   30000,
+			"modelMapping": map[string]string{
+				"gpt-4":         "claude-sonnet-4",
+				"gpt-3.5-turbo": "gpt-4o-mini",
+				"*":             "gpt-4o-mini",
+			},
+		},
+	})
+	return data
+}()
+
+// RunDaoxeParseConfigTests 测试 DaoXE 配置解析
+func RunDaoxeParseConfigTests(t *testing.T) {
+	test.RunGoTest(t, func(t *testing.T) {
+		// 测试基本 DaoXE 配置解析
+		t.Run("basic daoxe config", func(t *testing.T) {
+			host, status := test.NewTestHost(basicDaoxeConfig)
+			defer host.Reset()
+			require.Equal(t, types.OnPluginStartStatusOK, status)
+
+			config, err := host.GetMatchConfig()
+			require.NoError(t, err)
+			require.NotNil(t, config)
+		})
+
+		// 测试 DaoXE 多模型配置解析
+		t.Run("daoxe multi model config", func(t *testing.T) {
+			host, status := test.NewTestHost(daoxeMultiModelConfig)
+			defer host.Reset()
+			require.Equal(t, types.OnPluginStartStatusOK, status)
+
+			config, err := host.GetMatchConfig()
+			require.NoError(t, err)
+			require.NotNil(t, config)
+		})
+
+		// 测试无效 DaoXE 配置（缺少 apiToken）
+		t.Run("invalid daoxe config - missing apiToken", func(t *testing.T) {
+			host, status := test.NewTestHost(invalidDaoxeConfig)
+			defer host.Reset()
+			require.Equal(t, types.OnPluginStartStatusFailed, status)
+		})
+
+		// 测试完整 DaoXE 配置解析
+		t.Run("daoxe complete config", func(t *testing.T) {
+			host, status := test.NewTestHost(completeDaoxeConfig)
+			defer host.Reset()
+			require.Equal(t, types.OnPluginStartStatusOK, status)
+
+			config, err := host.GetMatchConfig()
+			require.NoError(t, err)
+			require.NotNil(t, config)
+		})
+	})
+}
+
+// RunDaoxeOnHttpRequestHeadersTests 测试 DaoXE 请求头处理
+func RunDaoxeOnHttpRequestHeadersTests(t *testing.T) {
+	test.RunTest(t, func(t *testing.T) {
+		// 测试 DaoXE 聊天完成请求头处理
+		t.Run("daoxe chat completion request headers", func(t *testing.T) {
+			host, status := test.NewTestHost(basicDaoxeConfig)
+			defer host.Reset()
+			require.Equal(t, types.OnPluginStartStatusOK, status)
+
+			action := host.CallOnHttpRequestHeaders([][2]string{
+				{":authority", "example.com"},
+				{":path", "/v1/chat/completions"},
+				{":method", "POST"},
+				{"Content-Type", "application/json"},
+			})
+
+			// 应该返回 HeaderStopIteration，因为需要处理请求体
+			require.Equal(t, types.HeaderStopIteration, action)
+
+			requestHeaders := host.GetRequestHeaders()
+			require.NotNil(t, requestHeaders)
+
+			// 验证 Host 是否被改为 DaoXE 域名
+			hostValue, hasHost := test.GetHeaderValue(requestHeaders, ":authority")
+			require.True(t, hasHost, "Host header should exist")
+			require.Equal(t, "api.daoxe.com", hostValue, "Host should be changed to DaoXE domain")
+
+			// 验证 Authorization 是否被设置
+			authValue, hasAuth := test.GetHeaderValue(requestHeaders, "Authorization")
+			require.True(t, hasAuth, "Authorization header should exist")
+			require.Contains(t, authValue, "Bearer sk-daoxe-test123456789", "Authorization should contain DaoXE API token with Bearer prefix")
+
+			// 验证 Path 保持 OpenAI 兼容格式
+			pathValue, hasPath := test.GetHeaderValue(requestHeaders, ":path")
+			require.True(t, hasPath, "Path header should exist")
+			require.Equal(t, "/v1/chat/completions", pathValue, "Path should remain OpenAI compatible")
+		})
+
+		// 测试 DaoXE 文本完成请求头处理
+		t.Run("daoxe completion request headers", func(t *testing.T) {
+			host, status := test.NewTestHost(basicDaoxeConfig)
+			defer host.Reset()
+			require.Equal(t, types.OnPluginStartStatusOK, status)
+
+			action := host.CallOnHttpRequestHeaders([][2]string{
+				{":authority", "example.com"},
+				{":path", "/v1/completions"},
+				{":method", "POST"},
+				{"Content-Type", "application/json"},
+			})
+
+			require.Equal(t, types.HeaderStopIteration, action)
+
+			requestHeaders := host.GetRequestHeaders()
+			require.NotNil(t, requestHeaders)
+
+			hostValue, hasHost := test.GetHeaderValue(requestHeaders, ":authority")
+			require.True(t, hasHost)
+			require.Equal(t, "api.daoxe.com", hostValue)
+
+			pathValue, hasPath := test.GetHeaderValue(requestHeaders, ":path")
+			require.True(t, hasPath)
+			require.Equal(t, "/v1/completions", pathValue, "Path should remain OpenAI compatible for completions")
+
+			authValue, hasAuth := test.GetHeaderValue(requestHeaders, "Authorization")
+			require.True(t, hasAuth, "Authorization header should exist for completions")
+			require.Contains(t, authValue, "Bearer sk-daoxe-test123456789", "Authorization should contain DaoXE API token")
+		})
+
+		// 测试 DaoXE 模型列表请求头处理
+		t.Run("daoxe models request headers", func(t *testing.T) {
+			host, status := test.NewTestHost(basicDaoxeConfig)
+			defer host.Reset()
+			require.Equal(t, types.OnPluginStartStatusOK, status)
+
+			action := host.CallOnHttpRequestHeaders([][2]string{
+				{":authority", "example.com"},
+				{":path", "/v1/models"},
+				{":method", "GET"},
+			})
+
+			// TODO: Due to the limitations of the test framework, we just treat it as a request with body here.
+			require.Equal(t, types.HeaderStopIteration, action)
+
+			requestHeaders := host.GetRequestHeaders()
+			require.NotNil(t, requestHeaders)
+
+			hostValue, hasHost := test.GetHeaderValue(requestHeaders, ":authority")
+			require.True(t, hasHost)
+			require.Equal(t, "api.daoxe.com", hostValue)
+
+			pathValue, hasPath := test.GetHeaderValue(requestHeaders, ":path")
+			require.True(t, hasPath)
+			require.Equal(t, "/v1/models", pathValue, "Path should remain OpenAI compatible for models")
+
+			authValue, hasAuth := test.GetHeaderValue(requestHeaders, "Authorization")
+			require.True(t, hasAuth, "Authorization header should exist for models")
+			require.Contains(t, authValue, "Bearer sk-daoxe-test123456789", "Authorization should contain DaoXE API token")
+		})
+	})
+}
+
+// RunDaoxeOnHttpRequestBodyTests 测试 DaoXE 请求体处理
+func RunDaoxeOnHttpRequestBodyTests(t *testing.T) {
+	test.RunTest(t, func(t *testing.T) {
+		// 测试 DaoXE 聊天完成请求体处理
+		t.Run("daoxe chat completion request body", func(t *testing.T) {
+			host, status := test.NewTestHost(basicDaoxeConfig)
+			defer host.Reset()
+			require.Equal(t, types.OnPluginStartStatusOK, status)
+
+			host.CallOnHttpRequestHeaders([][2]string{
+				{":authority", "example.com"},
+				{":path", "/v1/chat/completions"},
+				{":method", "POST"},
+				{"Content-Type", "application/json"},
+			})
+
+			requestBody := `{
+				"model": "gpt-3.5-turbo",
+				"messages": [
+					{"role": "user", "content": "Hello, world!"}
+				],
+				"stream": false
+			}`
+
+			action := host.CallOnHttpRequestBody([]byte(requestBody))
+			require.Equal(t, types.ActionContinue, action)
+
+			actualRequestBody := host.GetRequestBody()
+			require.NotNil(t, actualRequestBody)
+
+			// 验证模型映射
+			require.Contains(t, string(actualRequestBody), "gpt-4o-mini",
+				"Model should be mapped via modelMapping")
+			require.Contains(t, string(actualRequestBody), "Hello, world!",
+				"Request content should be preserved")
+		})
+
+		// 测试 DaoXE 多模型映射
+		t.Run("daoxe multi model mapping", func(t *testing.T) {
+			host, status := test.NewTestHost(daoxeMultiModelConfig)
+			defer host.Reset()
+			require.Equal(t, types.OnPluginStartStatusOK, status)
+
+			host.CallOnHttpRequestHeaders([][2]string{
+				{":authority", "example.com"},
+				{":path", "/v1/chat/completions"},
+				{":method", "POST"},
+				{"Content-Type", "application/json"},
+			})
+
+			requestBody := `{
+				"model": "gpt-4",
+				"messages": [
+					{"role": "user", "content": "Write a poem about AI"}
+				],
+				"stream": true
+			}`
+
+			action := host.CallOnHttpRequestBody([]byte(requestBody))
+			require.Equal(t, types.ActionContinue, action)
+
+			actualRequestBody := host.GetRequestBody()
+			require.NotNil(t, actualRequestBody)
+
+			require.Contains(t, string(actualRequestBody), "claude-sonnet-4",
+				"GPT-4 should be mapped to the configured target model")
+			require.Contains(t, string(actualRequestBody), "Write a poem about AI",
+				"Request content should be preserved")
+			require.Contains(t, string(actualRequestBody), `"stream": true`,
+				"Stream flag should be preserved")
+		})
+
+		// 测试不支持的 API（覆盖 OnRequestBody 错误路径）
+		t.Run("daoxe unsupported api", func(t *testing.T) {
+			host, status := test.NewTestHost(basicDaoxeConfig)
+			defer host.Reset()
+			require.Equal(t, types.OnPluginStartStatusOK, status)
+
+			host.CallOnHttpRequestHeaders([][2]string{
+				{":authority", "example.com"},
+				{":path", "/v1/unknown/endpoint"},
+				{":method", "POST"},
+				{"Content-Type", "application/json"},
+			})
+
+			requestBody := `{"model": "gpt-3.5-turbo", "messages": [{"role": "user", "content": "test"}]}`
+
+			action := host.CallOnHttpRequestBody([]byte(requestBody))
+			// OnRequestBody 返回错误后由 main.go 的 ErrorHandler 处理
+			require.Equal(t, types.ActionContinue, action)
+		})
+	})
+}
+
+// RunDaoxeOnHttpResponseHeadersTests 测试 DaoXE 响应头处理
+func RunDaoxeOnHttpResponseHeadersTests(t *testing.T) {
+	test.RunTest(t, func(t *testing.T) {
+		t.Run("daoxe chat completion response headers", func(t *testing.T) {
+			host, status := test.NewTestHost(basicDaoxeConfig)
+			defer host.Reset()
+			require.Equal(t, types.OnPluginStartStatusOK, status)
+
+			host.CallOnHttpRequestHeaders([][2]string{
+				{":authority", "example.com"},
+				{":path", "/v1/chat/completions"},
+				{":method", "POST"},
+				{"Content-Type", "application/json"},
+			})
+
+			action := host.CallOnHttpResponseHeaders([][2]string{
+				{":status", "200"},
+				{"content-type", "application/json"},
+			})
+
+			require.Equal(t, types.ActionContinue, action)
+
+			responseHeaders := host.GetResponseHeaders()
+			require.NotNil(t, responseHeaders)
+
+			statusValue, hasStatus := test.GetHeaderValue(responseHeaders, ":status")
+			require.True(t, hasStatus, "Status header should exist")
+			require.Equal(t, "200", statusValue, "Status should be 200")
+
+			contentTypeValue, hasContentType := test.GetHeaderValue(responseHeaders, "content-type")
+			require.True(t, hasContentType, "Content-Type header should exist")
+			require.Equal(t, "application/json", contentTypeValue, "Content-Type should be application/json")
+		})
+	})
+}
+
+// RunDaoxeOnHttpResponseBodyTests 测试 DaoXE 响应体处理
+func RunDaoxeOnHttpResponseBodyTests(t *testing.T) {
+	test.RunTest(t, func(t *testing.T) {
+		t.Run("daoxe chat completion response body", func(t *testing.T) {
+			host, status := test.NewTestHost(basicDaoxeConfig)
+			defer host.Reset()
+			require.Equal(t, types.OnPluginStartStatusOK, status)
+
+			host.CallOnHttpRequestHeaders([][2]string{
+				{":authority", "example.com"},
+				{":path", "/v1/chat/completions"},
+				{":method", "POST"},
+				{"Content-Type", "application/json"},
+			})
+
+			responseBody := `{
+				"id": "chatcmpl-test",
+				"object": "chat.completion",
+				"created": 1728558433,
+				"model": "gpt-4o-mini",
+				"choices": [
+					{
+						"index": 0,
+						"message": {
+							"role": "assistant",
+							"content": "Hello! I am an AI assistant."
+						},
+						"finish_reason": "stop"
+					}
+				]
+			}`
+
+			action := host.CallOnHttpResponseBody([]byte(responseBody))
+			require.Equal(t, types.ActionContinue, action)
+
+			actualResponseBody := host.GetResponseBody()
+			require.NotNil(t, actualResponseBody)
+
+			bodyStr := string(actualResponseBody)
+			require.Contains(t, bodyStr, `"object": "chat.completion"`, "Response should contain chat.completion object")
+			require.Contains(t, bodyStr, `"Hello! I am an AI assistant."`, "Response should contain the assistant message")
+		})
+	})
+}
+
+// RunDaoxeOnStreamingResponseBodyTests 测试 DaoXE 流式响应体处理
+func RunDaoxeOnStreamingResponseBodyTests(t *testing.T) {
+	test.RunTest(t, func(t *testing.T) {
+		t.Run("daoxe streaming response body", func(t *testing.T) {
+			host, status := test.NewTestHost(basicDaoxeConfig)
+			defer host.Reset()
+			require.Equal(t, types.OnPluginStartStatusOK, status)
+
+			host.CallOnHttpRequestHeaders([][2]string{
+				{":authority", "example.com"},
+				{":path", "/v1/chat/completions"},
+				{":method", "POST"},
+				{"Content-Type", "application/json"},
+			})
+
+			requestBody := `{"model":"gpt-3.5-turbo","messages":[{"role":"user","content":"test"}],"stream":true}`
+			action := host.CallOnHttpRequestBody([]byte(requestBody))
+			require.Equal(t, types.ActionContinue, action)
+
+			host.CallOnHttpResponseHeaders([][2]string{
+				{":status", "200"},
+				{"content-type", "text/event-stream"},
+			})
+
+			// DaoXE 流式响应使用 OpenAI 兼容的 SSE 格式，原样透传
+			streamChunks := []string{
+				`data: {"id":"chatcmpl-test","object":"chat.completion.chunk","created":1699123456,"model":"gpt-4o-mini","choices":[{"index":0,"delta":{"role":"assistant","content":"Hello"},"finish_reason":null}]}`,
+				`data: {"id":"chatcmpl-test","object":"chat.completion.chunk","created":1699123456,"model":"gpt-4o-mini","choices":[{"index":0,"delta":{"content":" there!"},"finish_reason":null}]}`,
+				`data: {"id":"chatcmpl-test","object":"chat.completion.chunk","created":1699123456,"model":"gpt-4o-mini","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}`,
+				`data: [DONE]`,
+			}
+
+			for _, chunk := range streamChunks {
+				streamChunk := chunk + "\n\n"
+				action := host.CallOnHttpStreamingResponseBody([]byte(streamChunk), false)
+				require.Equal(t, types.ActionContinue, action)
+				require.Contains(t, string(host.GetResponseBody()), chunk)
+			}
+
+			action = host.CallOnHttpStreamingResponseBody([]byte{}, true)
+			require.Equal(t, types.ActionContinue, action)
+		})
+	})
+}


### PR DESCRIPTION
### Ⅰ. Describe what this PR did
Add a new `daoxe` provider type to the ai-proxy plugin. DaoXE (https://daoxe.com) is an OpenAI-compatible multi-model LLM gateway; the provider proxies chat completions, completions, and models-list requests to `api.daoxe.com` over the standard OpenAI wire format (Bearer API token, OpenAI-compatible SSE streaming passthrough, `modelMapping` support). It follows the same shape as other OpenAI-compatible providers (e.g. fireworks, galadriel).

### Ⅱ. Does this pull request fix one issue?
(none)

### Ⅲ. Why don't you add test cases?
Test cases are included: `test/daoxe.go` (config parsing, request headers, request body, response headers/body, streaming) wired up as `TestDaoxe` in `main_test.go`, mirroring the galadriel/fireworks test layout.

### Ⅳ. Describe how to verify it
`cd plugins/wasm-go/extensions/ai-proxy && go test -run TestDaoxe ./...` — or the full module suite `go test ./...`. Manual: configure `provider: { type: daoxe, apiTokens: ["..."] }` on a Higress route and call `/v1/chat/completions`; see the new README sections for full config/request/response examples.

### Ⅴ. Special notes for reviews
Disclosure: I am affiliated with DaoXE; this contribution adds it as a supported upstream provider alongside the existing ones.
