### PR TITLE
docs: update CONTRIBUTING GitHub links from alibaba to higress-group

### DIFF
--- a/CONTRIBUTING_CN.md
+++ b/CONTRIBUTING_CN.md
@@ -27,7 +27,7 @@
 
 ## 报告一般问题
 
-老实说，我们把每一个 Higress 用户都视为非常善良的贡献者。在体验了 Higress 之后，您可能会对项目有一些反馈。然后随时通过 [NEW ISSUE](https://github.com/alibaba/higress/issues/new/choose)打开一个问题。
+老实说，我们把每一个 Higress 用户都视为非常善良的贡献者。在体验了 Higress 之后，您可能会对项目有一些反馈。然后随时通过 [NEW ISSUE](https://github.com/higress-group/higress/issues/new/choose)打开一个问题。
 
 因为我们在一个分布式的方式合作项目Higress，我们欣赏写得很好的，详细的，准确的问题报告。为了让沟通更高效，我们希望每个人都可以搜索您的问题是否在搜索列表中。如果您发现它存在，请在现有问题下的评论中添加您的详细信息，而不是打开一个全新的问题。
 
@@ -79,15 +79,15 @@
 
 为了提出 PR，我们假设你已经注册了一个 GitHub ID。然后您可以通过以下步骤完成准备工作：
 
-1. **FORK** Higress 到您的存储库。要完成这项工作，您只需单击 [alibaba/higress](https://github.com/alibaba/higress) 主页右侧的 Fork 按钮。然后你将在 
+1. **FORK** Higress 到您的存储库。要完成这项工作，您只需单击 [higress-group/higress](https://github.com/higress-group/higress) 主页右侧的 Fork 按钮。然后你将在 
    中得到你的存储库`https://github.com/<your-username>/higress`，其中your-username是你的 GitHub 用户名。
 
 2. **克隆** 您自己的存储库以在本地开发. 用于 `git clone git@github.com:<your-username>/higress.git` 将存储库克隆到本地计算机。 然后您可以创建新分支来完成您希望进行的更改。
 
-3. **设置远程** 将上游设置为 `git@github.com:alibaba/higress.git` 使用以下两个命令：
+3. **设置远程** 将上游设置为 `git@github.com:higress-group/higress.git` 使用以下两个命令：
 
 ```bash
-git remote add upstream git@github.com:alibaba/higress.git
+git remote add upstream git@github.com:higress-group/higress.git
 git remote set-url --push upstream no-pushing
 ```
 
@@ -97,7 +97,7 @@ git remote set-url --push upstream no-pushing
 $ git remote -v
 origin     git@github.com:<your-username>/higress.git (fetch)
 origin     git@github.com:<your-username>/higress.git (push)
-upstream   git@github.com:alibaba/higress.git (fetch)
+upstream   git@github.com:higress-group/higress.git (fetch)
 upstream   no-pushing (push)
 ```
 
@@ -105,7 +105,7 @@ upstream   no-pushing (push)
 
 ### 分支定义
 
-现在我们假设通过拉取请求的每个贡献都是针对 Higress 中的 [主分支](https://github.com/alibaba/higress/tree/main) 。在贡献之前，请注意分支定义会很有帮助。
+现在我们假设通过拉取请求的每个贡献都是针对 Higress 中的 [主分支](https://github.com/higress-group/higress/tree/main) 。在贡献之前，请注意分支定义会很有帮助。
 
 作为贡献者，请再次记住，通过拉取请求的每个贡献都是针对主分支的。而在Higress项目中，还有其他几个分支，我们一般称它们为release分支（如0.6.0、0.6.1）、feature分支、hotfix分支。
 

--- a/CONTRIBUTING_EN.md
+++ b/CONTRIBUTING_EN.md
@@ -28,7 +28,7 @@ Security issues are always treated seriously. As our usual principle, we discour
 ## Reporting general issues
 
 To be honest, we regard every user of Higress as a very kind contributor. After experiencing Higress, you may have 
-some feedback for the project. Then feel free to open an issue via [NEW ISSUE](https://github.com/alibaba/higress/issues/new/choose).
+some feedback for the project. Then feel free to open an issue via [NEW ISSUE](https://github.com/higress-group/higress/issues/new/choose).
 
 Since we collaborate project Higress in a distributed way, we appreciate **WELL-WRITTEN**, **DETAILED**, **EXPLICIT** issue reports. To make the communication more efficient, we wish everyone could search if your issue is an existing one in the searching list. If you find it existing, please add your details in comments under the existing issue instead of opening a brand new one.
 
@@ -79,15 +79,15 @@ Since you are ready to improve Higress with a PR, we suggest you could take a lo
 
 To put forward a PR, we assume you have registered a GitHub ID. Then you could finish the preparation in the following steps:
 
-1. **FORK** Higress to your repository. To make this work, you just need to click the button Fork in right-left of[alibaba/higress](https://github.com/alibaba/higress) main page. Then you will end up with your repository in 
+1. **FORK** Higress to your repository. To make this work, you just need to click the button Fork in right-left of[higress-group/higress](https://github.com/higress-group/higress) main page. Then you will end up with your repository in 
    `https://github.com/<your-username>/higress`, in which `your-username` is your GitHub username.
 
 1. **CLONE** your own repository to develop locally. Use `git clone git@github.com:<your-username>/higress.git` to clone repository to your local machine. Then you can create new branches to finish the change you wish to make.
 
-1. **Set Remote** upstream to be `git@github.com:alibaba/higress.git` using the following two commands:
+1. **Set Remote** upstream to be `git@github.com:higress-group/higress.git` using the following two commands:
 
 ```bash
-git remote add upstream git@github.com:alibaba/higress.git
+git remote add upstream git@github.com:higress-group/higress.git
 git remote set-url --push upstream no-pushing
 ```
 
@@ -97,7 +97,7 @@ With this remote setting, you can check your git remote configuration like this:
 $ git remote -v
 origin     git@github.com:<your-username>/higress.git (fetch)
 origin     git@github.com:<your-username>/higress.git (push)
-upstream   git@github.com:alibaba/higress.git (fetch)
+upstream   git@github.com:higress-group/higress.git (fetch)
 upstream   no-pushing (push)
 ```
 
@@ -105,7 +105,7 @@ Adding this, we can easily synchronize local branches with upstream branches.
 
 ### Branch Definition
 
-Right now we assume every contribution via pull request is for [branch main](https://github.com/alibaba/higress/tree/main) in Higress. Before contributing, be aware of branch definition would help a lot.
+Right now we assume every contribution via pull request is for [branch main](https://github.com/higress-group/higress/tree/main) in Higress. Before contributing, be aware of branch definition would help a lot.
 
 As a contributor, keep in mind again that every contribution via pull request is for branch main. While in project Higress, there are several other branches, we generally call them release branches (such as 0.6.0,0.6.1), feature branches, hotfix branches.
 

--- a/CONTRIBUTING_JP.md
+++ b/CONTRIBUTING_JP.md
@@ -27,7 +27,7 @@ Higress のハッキングに興味がある場合は、温かく歓迎します
 
 ## 一般的な問題の報告
 
-正直なところ、Higress のすべてのユーザーを非常に親切な貢献者と見なしています。Higress を体験した後、プロジェクトに対するフィードバックがあるかもしれません。その場合は、[NEW ISSUE](https://github.com/alibaba/higress/issues/new/choose) を通じて問題を開くことを自由に行ってください。
+正直なところ、Higress のすべてのユーザーを非常に親切な貢献者と見なしています。Higress を体験した後、プロジェクトに対するフィードバックがあるかもしれません。その場合は、[NEW ISSUE](https://github.com/higress-group/higress/issues/new/choose) を通じて問題を開くことを自由に行ってください。
 
 Higress プロジェクトを分散型で協力しているため、**よく書かれた**、**詳細な**、**明確な**問題報告を高く評価します。コミュニケーションをより効率的にするために、問題が検索リストに存在するかどうかを検索することを希望します。存在する場合は、新しい問題を開くのではなく、既存の問題のコメントに詳細を追加してください。
 
@@ -78,14 +78,14 @@ Higress を PR で改善する準備ができたら、ここで PR ルールを�
 
 PR を提出するために、GitHub ID に登録していることを前提とします。その後、以下の手順で準備を完了できます：
 
-1. Higress を自分のリポジトリに **FORK** します。この作業を行うには、[alibaba/higress](https://github.com/alibaba/higress) のメインページの右上にある Fork ボタンをクリックするだけです。その後、`https://github.com/<your-username>/higress` に自分のリポジトリが作成されます。ここで、`your-username` はあなたの GitHub ユーザー名です。
+1. Higress を自分のリポジトリに **FORK** します。この作業を行うには、[higress-group/higress](https://github.com/higress-group/higress) のメインページの右上にある Fork ボタンをクリックするだけです。その後、`https://github.com/<your-username>/higress` に自分のリポジトリが作成されます。ここで、`your-username` はあなたの GitHub ユーザー名です。
 
 2. 自分のリポジトリをローカルに **CLONE** します。`git clone git@github.com:<your-username>/higress.git` を使用してリポジトリをローカルマシンにクローンします。その後、新しいブランチを作成して、行いたい変更を完了できます。
 
-3. リモートを `git@github.com:alibaba/higress.git` に設定します。以下の2つのコマンドを使用します：
+3. リモートを `git@github.com:higress-group/higress.git` に設定します。以下の2つのコマンドを使用します：
 
 ```bash
-git remote add upstream git@github.com:alibaba/higress.git
+git remote add upstream git@github.com:higress-group/higress.git
 git remote set-url --push upstream no-pushing
 ```
 
@@ -95,7 +95,7 @@ git remote set-url --push upstream no-pushing
 $ git remote -v
 origin     git@github.com:<your-username>/higress.git (fetch)
 origin     git@github.com:<your-username>/higress.git (push)
-upstream   git@github.com:alibaba/higress.git (fetch)
+upstream   git@github.com:higress-group/higress.git (fetch)
 upstream   no-pushing (push)
 ```
 
@@ -103,7 +103,7 @@ upstream   no-pushing (push)
 
 ### ブランチの定義
 
-現在、プルリクエストを通じたすべての貢献は Higress の [main ブランチ](https://github.com/alibaba/higress/tree/main) に対するものであると仮定します。貢献する前に、ブランチの定義を理解することは非常に役立ちます。
+現在、プルリクエストを通じたすべての貢献は Higress の [main ブランチ](https://github.com/higress-group/higress/tree/main) に対するものであると仮定します。貢献する前に、ブランチの定義を理解することは非常に役立ちます。
 
 貢献者として、プルリクエストを通じたすべての貢献は main ブランチに対するものであることを再度覚えておいてください。Higress プロジェクトには、リリースブランチ（例：0.6.0、0.6.1）、機能ブランチ、ホットフィックスブランチなど、いくつかの他のブランチがあります。
 


### PR DESCRIPTION
## Summary

Higress is hosted under higress-group/higress, but the contributing guides still point new contributors at the old libaba/higress org for issue links, fork instructions, and upstream remote setup.

Updates all three locale guides:

- CONTRIBUTING_EN.md
- CONTRIBUTING_CN.md
- CONTRIBUTING_JP.md

Replacements are limited to GitHub org/URL references (github.com/alibaba/higress → github.com/higress-group/higress, git@github.com:alibaba/higress.git → git@github.com:higress-group/higress.git). Go module paths still using github.com/alibaba/higress are intentionally left unchanged.