### PR TITLE
docs: update remaining alibaba/higress links to higress-group

### DIFF
--- a/.agents/skills/higress-daily-report/README.md
+++ b/.agents/skills/higress-daily-report/README.md
@@ -194,5 +194,5 @@ higress-daily-report/
 ## 相关链接
 
 - [Clawdbot 文档](https://docs.clawd.bot)
-- [Higress 项目](https://github.com/alibaba/higress)
+- [Higress 项目](https://github.com/higress-group/higress)
 - [GitHub CLI 文档](https://cli.github.com/manual/)

--- a/.agents/skills/higress-daily-report/SKILL.md
+++ b/.agents/skills/higress-daily-report/SKILL.md
@@ -28,10 +28,10 @@ description: 生成 Higress 项目每日报告，追踪 issue/PR 动态，沉淀
 
 ```bash
 # 获取昨日 issues
-gh search issues --repo alibaba/higress --created yesterday --json number,title,author,url,body,state,labels --limit 50
+gh search issues --repo higress-group/higress --created yesterday --json number,title,author,url,body,state,labels --limit 50
 
 # 获取昨日 PRs
-gh search prs --repo alibaba/higress --created yesterday --json number,title,author,url,body,state,additions,deletions,reviewDecision --limit 50
+gh search prs --repo higress-group/higress --created yesterday --json number,title,author,url,body,state,additions,deletions,reviewDecision --limit 50
 ```
 
 ### 2. Issue 追踪状态管理
@@ -235,19 +235,19 @@ Higress 插件执行阶段优先级：AUTHN (310) > AUTHZ (340) > STATS
 
 ```bash
 # 查看 issue 详情和评论
-gh issue view <number> --repo alibaba/higress --json number,title,state,comments,author,createdAt,labels,url
+gh issue view <number> --repo higress-group/higress --json number,title,state,comments,author,createdAt,labels,url
 
 # 查看 issue 评论
-gh issue view <number> --repo alibaba/higress --comments
+gh issue view <number> --repo higress-group/higress --comments
 
 # 发送 issue 评论
-gh issue comment <number> --repo alibaba/higress --body "评论内容"
+gh issue comment <number> --repo higress-group/higress --body "评论内容"
 
 # 关闭 issue
-gh issue close <number> --repo alibaba/higress --reason completed
+gh issue close <number> --repo higress-group/higress --reason completed
 
 # 添加标签
-gh issue edit <number> --repo alibaba/higress --add-label "bug"
+gh issue edit <number> --repo higress-group/higress --add-label "bug"
 ```
 
 ## Discord 输出

--- a/.agents/skills/nginx-to-higress-migration/README.md
+++ b/.agents/skills/nginx-to-higress-migration/README.md
@@ -414,7 +414,7 @@ EOF
 ### 1. Analyze Your Current Setup
 ```bash
 # Clone this skill
-git clone https://github.com/alibaba/higress.git
+git clone https://github.com/higress-group/higress.git
 cd higress/.claude/skills/nginx-to-higress-migration
 
 # Check for snippet usage (complex mode indicator)

--- a/.agents/skills/nginx-to-higress-migration/README_CN.md
+++ b/.agents/skills/nginx-to-higress-migration/README_CN.md
@@ -414,7 +414,7 @@ EOF
 ### 1. 分析当前设置
 ```bash
 # 克隆此技能
-git clone https://github.com/alibaba/higress.git
+git clone https://github.com/higress-group/higress.git
 cd higress/.claude/skills/nginx-to-higress-migration
 
 # 检查 snippet 使用情况（复杂模式指标）

--- a/plugins/wasm-go/mcp-servers/README.md
+++ b/plugins/wasm-go/mcp-servers/README.md
@@ -80,8 +80,8 @@ import (
     "net/http"
     
     "my-mcp-server/config"
-    "github.com/alibaba/higress/plugins/wasm-go/pkg/mcp/server"
-    "github.com/alibaba/higress/plugins/wasm-go/pkg/mcp/utils"
+    "github.com/higress-group/higress/plugins/wasm-go/pkg/mcp/server"
+    "github.com/higress-group/higress/plugins/wasm-go/pkg/mcp/utils"
 )
 
 // Define your tool structure with input parameters
@@ -145,8 +145,8 @@ For better organization, you can create a separate file to load all your tools:
 package tools
 
 import (
-    "github.com/alibaba/higress/plugins/wasm-go/pkg/mcp"
-    "github.com/alibaba/higress/plugins/wasm-go/pkg/mcp/server"
+    "github.com/higress-group/higress/plugins/wasm-go/pkg/mcp"
+    "github.com/higress-group/higress/plugins/wasm-go/pkg/mcp/server"
 )
 
 func LoadTools(server *mcp.MCPServer) server.Server {
@@ -170,7 +170,7 @@ import (
     amap "amap-tools/tools"
     quark "quark-search/tools"
     
-    "github.com/alibaba/higress/plugins/wasm-go/pkg/mcp"
+    "github.com/higress-group/higress/plugins/wasm-go/pkg/mcp"
 )
 
 func main() {}
@@ -188,7 +188,7 @@ The configuration for the all-in-one plugin follows the same pattern as individu
 
 ## REST-to-MCP Configuration
 
-Higress supports a special REST-to-MCP configuration that allows you to convert REST APIs to MCP tools without writing any code. This is useful for quickly integrating existing REST APIs with AI assistants. This capability is built into all MCP servers and can be used with the all-in-one plugin. The implementation is available at [rest_server.go](https://github.com/alibaba/higress/blob/wasm-go-1.24/plugins/wasm-go/pkg/mcp/server/rest_server.go).
+Higress supports a special REST-to-MCP configuration that allows you to convert REST APIs to MCP tools without writing any code. This is useful for quickly integrating existing REST APIs with AI assistants. This capability is built into all MCP servers and can be used with the all-in-one plugin. The implementation is available at [rest_server.go](https://github.com/higress-group/higress/blob/wasm-go-1.24/plugins/wasm-go/pkg/mcp/server/rest_server.go).
 
 ### Configuration Format
 
@@ -375,7 +375,7 @@ package main
 import (
     "my-mcp-server/tools"
     
-    "github.com/alibaba/higress/plugins/wasm-go/pkg/mcp"
+    "github.com/higress-group/higress/plugins/wasm-go/pkg/mcp"
 )
 
 func main() {}
@@ -412,7 +412,7 @@ Your MCP server must use a specific version of the wasm-go SDK that supports Go 
 
 ```bash
 # Add the required dependency
-go get github.com/alibaba/higress/plugins/wasm-go
+go get github.com/higress-group/higress/plugins/wasm-go
 ```
 
 Make sure your go.mod file specifies Go 1.24:
@@ -423,7 +423,7 @@ module my-mcp-server
 go 1.24
 
 require (
-    github.com/alibaba/higress/plugins/wasm-go v1.4.4-0.20250324133957-dab499f6ade6
+    github.com/higress-group/higress/plugins/wasm-go v1.4.4-0.20250324133957-dab499f6ade6
     // other dependencies
 )
 ```

--- a/plugins/wasm-go/mcp-servers/README_zh.md
+++ b/plugins/wasm-go/mcp-servers/README_zh.md
@@ -182,7 +182,7 @@ all-in-one 插件的配置方式与所有 MCP server 插件都是一样的，都
 
 ## REST-to-MCP 配置
 
-Higress 支持一种特殊的 REST-to-MCP 配置，允许您无需编写任何代码即可将 REST API 转换为 MCP 工具。这对于快速将现有 REST API 与 AI 助手集成非常有用。这个能力是所有 MCP 服务器内置的，可以基于 all-in-one 这个插件来使用。内置的逻辑实现在 [rest_server.go](https://github.com/alibaba/higress/blob/wasm-go-1.24/plugins/wasm-go/pkg/mcp/server/rest_server.go)。
+Higress 支持一种特殊的 REST-to-MCP 配置，允许您无需编写任何代码即可将 REST API 转换为 MCP 工具。这对于快速将现有 REST API 与 AI 助手集成非常有用。这个能力是所有 MCP 服务器内置的，可以基于 all-in-one 这个插件来使用。内置的逻辑实现在 [rest_server.go](https://github.com/higress-group/higress/blob/wasm-go-1.24/plugins/wasm-go/pkg/mcp/server/rest_server.go)。
 
 ### 配置格式
 
@@ -406,7 +406,7 @@ server:
 
 ```bash
 # 添加必需的依赖项
-go get github.com/alibaba/higress/plugins/wasm-go
+go get github.com/higress-group/higress/plugins/wasm-go
 ```
 
 确保您的 go.mod 文件指定 Go 1.24：
@@ -417,7 +417,7 @@ module my-mcp-server
 go 1.24
 
 require (
-    github.com/alibaba/higress/plugins/wasm-go v1.4.4-0.20250324133957-dab499f6ade6
+    github.com/higress-group/higress/plugins/wasm-go v1.4.4-0.20250324133957-dab499f6ade6
     // 其他依赖项
 )
 ```

--- a/plugins/wasm-go/mcp-servers/mcp-shebao-tools/README.md
+++ b/plugins/wasm-go/mcp-servers/mcp-shebao-tools/README.md
@@ -35,7 +35,7 @@ An implementation of the Model Context Protocol (MCP) server that integrates soc
 In the `mcp-server.yaml` file, set the `apikey` field to a valid API key.
 
 ### Knowledge Base
-1. Import [city_data.xls](https://github.com/alibaba/higress/raw/refs/heads/main/plugins/wasm-go/mcp-servers/mcp-shebao-tools/city_data.xls) into the knowledge base.
+1. Import [city_data.xls](https://github.com/higress-group/higress/raw/refs/heads/main/plugins/wasm-go/mcp-servers/mcp-shebao-tools/city_data.xls) into the knowledge base.
 
 ### Integrate into MCP Client
 

--- a/plugins/wasm-go/mcp-servers/mcp-shebao-tools/README_ZH.md
+++ b/plugins/wasm-go/mcp-servers/mcp-shebao-tools/README_ZH.md
@@ -36,7 +36,7 @@
 2. 发送邮件to: yuanpeng@junrunrenli.com   标题：MCP  内容：申请MCP社保计算工具服务，并提供你的账号。
 
 ### 知识库
-1. 导入[city_data.xls](https://github.com/alibaba/higress/raw/refs/heads/main/plugins/wasm-go/mcp-servers/mcp-shebao-tools/city_data.xls)到知识库中。
+1. 导入[city_data.xls](https://github.com/higress-group/higress/raw/refs/heads/main/plugins/wasm-go/mcp-servers/mcp-shebao-tools/city_data.xls)到知识库中。
 
 ### 配置 API Key
 


### PR DESCRIPTION
## Summary
- Update remaining `github.com/alibaba/higress` links in MCP server docs and agent skill docs to `github.com/higress-group/higress`.
- Docs-only; no code change.
- Follows the same mechanical org-link correction already started in #4681 for `CONTRIBUTING_*`.

## Verification
- Confirmed remaining `alibaba/higress` links only in:
  - `.agents/skills/higress-daily-report/README.md`
  - `plugins/wasm-go/mcp-servers/README.md`
  - `plugins/wasm-go/mcp-servers/README_zh.md`
  - `plugins/wasm-go/mcp-servers/mcp-shebao-tools/README.md`
  - `plugins/wasm-go/mcp-servers/mcp-shebao-tools/README_ZH.md`
- `github.com/alibaba/nacos` and `github.com/alibaba/Sentinel` were left unchanged.
- DCO `Signed-off-by` included.

## Agent participation / AI disclosure
AI-assisted mechanical docs fix; contributor reviewed the final diff. No proposal/design issue required because this is a pure mechanical link correction.