### PR TITLE
fix(model-router): honor modelToHeader in auto routing mode

### DIFF
--- a/plugins/wasm-go/extensions/model-router/main.go
+++ b/plugins/wasm-go/extensions/model-router/main.go
@@ -229,7 +229,11 @@ func handleJsonBody(ctx wrapper.HttpContext, config ModelRouterConfig, body []by
 
 		if targetModel != "" {
 			// Set the matched model to the header for routing
-			_ = proxywasm.ReplaceHttpRequestHeader("x-higress-llm-model", targetModel)
+			modelHeader := "x-higress-llm-model"
+			if config.modelToHeader != "" {
+				modelHeader = config.modelToHeader
+			}
+			_ = proxywasm.ReplaceHttpRequestHeader(modelHeader, targetModel)
 			// Update the model field in the request body
 			newBody, err := sjson.SetBytes(body, config.modelKey, targetModel)
 			if err != nil {

--- a/plugins/wasm-go/extensions/model-router/main_test.go
+++ b/plugins/wasm-go/extensions/model-router/main_test.go
@@ -663,8 +663,8 @@ func TestAutoRoutingIntegration(t *testing.T) {
 			require.Equal(t, types.ActionContinue, action)
 
 			headers := host.GetRequestHeaders()
-			modelHeader, found := getHeader(headers, "x-higress-llm-model")
-			require.True(t, found, "x-higress-llm-model header should be set")
+			modelHeader, found := getHeader(headers, "x-model")
+			require.True(t, found, "x-model header should be set")
 			require.Equal(t, "qwen-vl-max", modelHeader)
 		})
 
@@ -690,7 +690,7 @@ func TestAutoRoutingIntegration(t *testing.T) {
 			require.Equal(t, types.ActionContinue, action)
 
 			headers := host.GetRequestHeaders()
-			modelHeader, found := getHeader(headers, "x-higress-llm-model")
+			modelHeader, found := getHeader(headers, "x-model")
 			require.True(t, found)
 			require.Equal(t, "qwen-coder", modelHeader)
 		})
@@ -717,7 +717,7 @@ func TestAutoRoutingIntegration(t *testing.T) {
 			require.Equal(t, types.ActionContinue, action)
 
 			headers := host.GetRequestHeaders()
-			modelHeader, found := getHeader(headers, "x-higress-llm-model")
+			modelHeader, found := getHeader(headers, "x-model")
 			require.True(t, found)
 			require.Equal(t, "qwen-turbo", modelHeader)
 		})
@@ -744,8 +744,8 @@ func TestAutoRoutingIntegration(t *testing.T) {
 			require.Equal(t, types.ActionContinue, action)
 
 			headers := host.GetRequestHeaders()
-			_, found := getHeader(headers, "x-higress-llm-model")
-			require.False(t, found, "x-higress-llm-model should not be set when no rule matches and no default")
+			_, found := getHeader(headers, "x-model")
+			require.False(t, found, "x-model should not be set when no rule matches and no default")
 		})
 
 		t.Run("normal routing when model is not higress/auto", func(t *testing.T) {
@@ -804,7 +804,7 @@ func TestAutoRoutingIntegration(t *testing.T) {
 			require.Equal(t, types.ActionContinue, action)
 
 			headers := host.GetRequestHeaders()
-			modelHeader, found := getHeader(headers, "x-higress-llm-model")
+			modelHeader, found := getHeader(headers, "x-model")
 			require.True(t, found)
 			require.Equal(t, "qwen-turbo", modelHeader) // matches 翻译 rule
 		})


### PR DESCRIPTION
## What

Fix the model-router plugin ignoring the user-configured `modelToHeader` in automatic routing mode.

## Problem

In the auto-routing path, `handleJsonBody` always wrote the matched model into the hardcoded `x-higress-llm-model` header:

```go
_ = proxywasm.ReplaceHttpRequestHeader("x-higress-llm-model", targetModel)
```

A user who set `modelToHeader` to a custom name (e.g. `x-model`) found that name ignored in auto-routing mode, while the non-auto paths already honored `config.modelToHeader`.

## Fix

Use the configured header when present, falling back to the default `x-higress-llm-model` only when `modelToHeader` is empty. Updated the auto-routing integration tests to assert the configured header.

## Test plan

`go test ./...` in `plugins/wasm-go/extensions/model-router` — `ok`.

Fixes #4686