### PR TITLE
docs(helm): clarify upstream idle timeout zero value

### DIFF
--- a/helm/core/values.yaml
+++ b/helm/core/values.yaml
@@ -737,7 +737,9 @@ downstream:
 
 # -- Upstream config settings
 upstream:
+  # -- Idle timeout in seconds for HTTP upstream connections in the connection pool. Defaults to 10. Set to 0 to disable the timeout; this does not use Envoy's one-hour default.
   idleTimeout: 10
+  # -- Per-upstream-connection buffer limit in bytes.
   connectionBufferLimits: 10485760
 
 # -- Gzip compression settings

--- a/helm/higress/README.md
+++ b/helm/higress/README.md
@@ -318,3 +318,5 @@ The command removes all the Kubernetes components associated with the chart and 
 | tracing.sampling | int | `100` |  |
 | tracing.timeout | int | `500` |  |
 | upstream | object | `{"connectionBufferLimits":10485760,"idleTimeout":10}` | Upstream config settings |
+| upstream.connectionBufferLimits | int | `10485760` | Per-upstream-connection buffer limit in bytes. |
+| upstream.idleTimeout | int | `10` | Idle timeout in seconds for HTTP upstream connections in the connection pool. Defaults to 10. Set to 0 to disable the timeout; this does not use Envoy's one-hour default. |


### PR DESCRIPTION
## Summary
- document the upstream HTTP connection-pool idle timeout in Helm values
- clarify that `upstream.idleTimeout: 0` disables the timeout rather than using Envoy's one-hour default
- regenerate the Helm chart README

## Validation
- `helm lint helm/higress --set upstream.idleTimeout=0`

The documentation matches the current implementation, which emits an explicit `0s` duration to Envoy.